### PR TITLE
Add symbolic names for standard file descriptors

### DIFF
--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -23,6 +23,21 @@ public struct FileDescriptor: RawRepresentable, Hashable, Codable {
   /// Creates a strongly-typed file handle from a raw C file handle.
   @_alwaysEmitIntoClient
   public init(rawValue: CInt) { self.rawValue = rawValue }
+}
+
+// Standard file descriptors
+extension FileDescriptor {
+  /// The standard input file descriptor, with a numeric value of 0.
+  @_alwaysEmitIntoClient
+  public static var standardInput: FileDescriptor { .init(rawValue: 0) }
+
+  /// The standard output file descriptor, with a numeric value of 1.
+  @_alwaysEmitIntoClient
+  public static var standardOutput: FileDescriptor { .init(rawValue: 1) }
+
+  /// The standard error file descriptor, with a numeric value of 2.
+  @_alwaysEmitIntoClient
+  public static var standardError: FileDescriptor { .init(rawValue: 2) }
 }
 
 // @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)

--- a/Tests/SystemTests/FileTypesTest.swift
+++ b/Tests/SystemTests/FileTypesTest.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,6 +12,12 @@ import SystemPackage
 
 // @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 final class FileDescriptorTest: XCTestCase {
+  func testStandardDescriptors() {
+    XCTAssertEqual(FileDescriptor.standardInput.rawValue, 0)
+    XCTAssertEqual(FileDescriptor.standardOutput.rawValue, 1)
+    XCTAssertEqual(FileDescriptor.standardError.rawValue, 2)
+  }
+
   // Test the constants match the C header values. For various reasons,
   func testConstants() {
     XCTAssertEqual(O_RDONLY, FileDescriptor.AccessMode.readOnly.rawValue)


### PR DESCRIPTION
These let us easily read/write data to/from stdin/stdout/stderr without resorting to `FileDescriptor(rawValue: 1)`.

```swift
var greeting = "Hello, world!\n"
try greeting.withUTF8 { buffer in
  _ = try FileDescriptor.standardOutput.writeAll(buffer)
}
```