### PR TITLE
Add support for dup/dup2

### DIFF
--- a/Sources/SystemInternals/Syscalls.swift
+++ b/Sources/SystemInternals/Syscalls.swift
@@ -19,9 +19,10 @@ import ucrt
 
 #if ENABLE_MOCKING
 // Strip the mock_system prefix and the arg list suffix
-private func originalSyscallName(_ s: String) -> String {
-  precondition(s.starts(with: "system_"))
-  return String(s.dropFirst("system_".count).prefix { $0.isLetter })
+private func originalSyscallName(_ function: String) -> String {
+  // `function` must be of format `system_<name>(<parameters>)`
+  precondition(function.starts(with: "system_"))
+  return String(function.dropFirst("system_".count).prefix { $0 != "(" })
 }
 
 private func mockImpl(
@@ -152,3 +153,16 @@ public func system_pwrite(
   return pwrite(fd, buf, nbyte, offset)
 }
 
+public func system_dup(_ fd: Int32) -> Int32 {
+  #if ENABLE_MOCKING
+  if mockingEnabled { return mock(fd) }
+  #endif
+  return dup(fd)
+}
+
+public func system_dup2(_ fd: Int32, _ fd2: Int32) -> Int32 {
+  #if ENABLE_MOCKING
+  if mockingEnabled { return mock(fd, fd2) }
+  #endif
+  return dup2(fd, fd2)
+}

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -68,6 +68,14 @@ final class FileOperationsTest: XCTestCase {
         _ = try fd.close()
       },
 
+      MockTestCase(name: "dup", rawFD, interruptable: true) { retryOnInterrupt in
+        _ = try fd.duplicate(retryOnInterrupt: retryOnInterrupt)
+      },
+
+      MockTestCase(name: "dup2", rawFD, 42, interruptable: true) { retryOnInterrupt in
+        _ = try fd.duplicate(as: FileDescriptor(rawValue: 42),
+                             retryOnInterrupt: retryOnInterrupt)
+      },
     ]
 
     for test in syscallTestCases { test.runAllTests() }


### PR DESCRIPTION
This adds support for duplicating file descriptors via a `FileDescriptor.duplicate` method:

```swift
extension FileDescriptor {
  public func duplicate(
      as target: FileDescriptor? = nil,
      retryOnInterrupt: Bool = true
    ) throws -> FileDescriptor
}
```

The method dispatches to either `dup` or `dup2` based on whether or not it has an explicit target.

Usually, a non-nil `target` will be one of the file descriptors conventionally reserved for the stdin/stdout/stderr role; these were previously assigned symbolic names in https://github.com/apple/swift-system/pull/21. To target other file descriptors, users will need to use the `.init(rawValue:)` initializer. (This will rarely be needed, but some like to pass additional communication channels down to child processes using some custom numbering convention beyond the universal 0/1/2.)

```swift
let controlFd = try fd.duplicate(as: FileDescriptor(rawValue: 3))
```
