### PR TITLE
Emit withPlatformString as an availability workaround for open

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let targets: [PackageDescription.Target] = [
     dependencies: ["CSystem"],
     path: "Sources/System",
     swiftSettings: [
+      .define("SYSTEM_PACKAGE"),
       .define("ENABLE_MOCKING", .when(configuration: .debug))
     ]),
   .target(

--- a/Sources/System/FilePath/FilePathString.swift
+++ b/Sources/System/FilePath/FilePathString.swift
@@ -32,10 +32,15 @@ extension FilePath {
   /// The pointer passed as an argument to `body` is valid
   /// only during the execution of this method.
   /// Don't try to store the pointer for later use.
+  @_alwaysEmitIntoClient
   public func withPlatformString<Result>(
     _ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result
   ) rethrows -> Result {
-    try _withPlatformString(body)
+    #if !os(Windows)
+    return try withCString(body)
+    #else
+    return try _withPlatformString(body)
+    #endif
   }
 }
 
@@ -412,7 +417,7 @@ extension FilePath {
     #if os(Windows)
     fatalError("FilePath.withCString() unsupported on Windows ")
     #else
-    return try withPlatformString(body)
+    return try _withPlatformString(body)
     #endif
   }
 }

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -26,7 +26,7 @@ internal func system_open(
 ) -> CInt {
 #if ENABLE_MOCKING
   if mockingEnabled {
-    return _mock(String(_errorCorrectingPlatformString: path), oflag)
+    return _mock(path: path, oflag)
   }
 #endif
   return open(path, oflag)
@@ -38,7 +38,7 @@ internal func system_open(
 ) -> CInt {
 #if ENABLE_MOCKING
   if mockingEnabled {
-    return _mock(String(_errorCorrectingPlatformString: path), oflag, mode)
+    return _mock(path: path, oflag, mode)
   }
 #endif
   return open(path, oflag, mode)

--- a/Tests/SystemTests/XCTestManifests.swift
+++ b/Tests/SystemTests/XCTestManifests.swift
@@ -17,6 +17,7 @@ extension FileDescriptorTest {
     // to regenerate.
     static let __allTests__FileDescriptorTest = [
         ("testConstants", testConstants),
+        ("testStandardDescriptors", testStandardDescriptors),
     ]
 }
 
@@ -26,6 +27,7 @@ extension FileOperationsTest {
     // to regenerate.
     static let __allTests__FileOperationsTest = [
         ("testAdHocOpen", testAdHocOpen),
+        ("testGithubIssues", testGithubIssues),
         ("testHelpers", testHelpers),
         ("testSyscalls", testSyscalls),
     ]
@@ -38,7 +40,6 @@ extension FilePathComponentsTest {
     static let __allTests__FilePathComponentsTest = [
         ("testAdHocRRC", testAdHocRRC),
         ("testCases", testCases),
-        ("testConcatenation", testConcatenation),
         ("testSeparatorNormalization", testSeparatorNormalization),
     ]
 }


### PR DESCRIPTION
Unfortunately introduces a warning until the compiler can give us a way to call deprecated methods.