### PR TITLE
Internals: replace `CModeT` with `CInterop.Mode`

### DIFF
--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -23,7 +23,8 @@ internal func open(
 
 @inline(__always)
 internal func open(
-  _ path: UnsafePointer<CInterop.PlatformChar>, _ oflag: Int32, _ mode: CModeT
+  _ path: UnsafePointer<CInterop.PlatformChar>, _ oflag: Int32,
+  _ mode: CInterop.Mode
 ) -> CInt {
   // TODO(compnerd): Apply read/write permissions
   var fh: CInt = -1


### PR DESCRIPTION
The typealias was renamed but the reference to it was not fully removed.
This updates the instance enabling building System on Windows.