### PR TITLE
FilePath: enable building on Windows

### DIFF
--- a/Sources/System/FilePath/FilePathComponents.swift
+++ b/Sources/System/FilePath/FilePathComponents.swift
@@ -190,6 +190,7 @@ extension FilePath.Root: _PathSlice {
   }
 }
 extension FilePath: _PlatformStringable {
+  @usableFromInline
   func _withPlatformString<Result>(_ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result) rethrows -> Result {
     try _storage.withPlatformString(body)
   }


### PR DESCRIPTION
When building on Windows, we rely on the `withPlatformString` to convert
the strings to the native platform encoding (UTF-16).  The public
`FilePath.withPlatformString` is marked as `@_alwaysEmitIntoClient` and
references the `_withPlatformString` which is marked as `internal`.
Annotate the function as `@usableFromInline` to enable the inlined
method to reference this function.