### PR TITLE
[SKETCH] Add in fcntl raw, and higher-level support.

### DIFF
--- a/Sources/System/FileControl.swift
+++ b/Sources/System/FileControl.swift
@@ -1,0 +1,216 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// Strongly typed, Swifty interfaces to the most common and useful `fcntl`
+// commands.
+
+extension FileDescriptor {
+  /// Get the flags associated with this file descriptor
+  ///
+  /// The corresponding C function is `fcntl` with the `F_GETFD` command.
+  @_alwaysEmitIntoClient
+  public func getFlags() throws -> Flags {
+    try Flags(rawValue: fcntl(.getFlags))
+  }
+
+  /// Set the file descriptor flags.
+  ///
+  /// The corresponding C function is `fcntl` with the `F_SETFD` command.
+  @_alwaysEmitIntoClient
+  public func setFlags(_ value: Flags) throws {
+    _ = try fcntl(.setFlags, value.rawValue)
+  }
+
+  /// Get descriptor status flags.
+  ///
+  /// The corresponding C function is `fcntl` with the `F_GETFL` command.
+  @_alwaysEmitIntoClient
+  public func getStatusFlags() throws -> StatusFlags {
+    try StatusFlags(rawValue: fcntl(.getStatusFlags))
+  }
+
+  /// Set descriptor status flags.
+  ///
+  /// The corresponding C function is `fcntl` with the `F_SETFL` command.
+  @_alwaysEmitIntoClient
+  public func setStatusFlags(_ flags: StatusFlags) throws {
+    _ = try fcntl(.setStatusFlags, flags.rawValue)
+  }
+}
+
+// FIXME: We want a better approach for this one.
+extension FileDescriptor {
+  /// TODO: Flesh out PID work and see if there's a better, common formulation
+  /// of the process-or-group id concept.
+  @frozen
+  public struct PIDOrPGID: RawRepresentable {
+    @_alwaysEmitIntoClient
+    public let rawValue: CInt
+
+    @_alwaysEmitIntoClient
+    public init(rawValue: CInt) { self.rawValue = rawValue }
+
+    /// TODO: PID type
+    @_alwaysEmitIntoClient
+    public var asPID: CInt? { rawValue >= 0 ? rawValue : nil }
+
+    /// TODO: PGID type
+    @_alwaysEmitIntoClient
+    public var asPositiveGroupID: CInt? {
+      rawValue >= 0 ? nil : -rawValue
+    }
+
+    /// TODO: PID type
+    @_alwaysEmitIntoClient
+    public init(pid id: CInt) {
+      precondition(id >= 0)
+      self.init(rawValue: id)
+    }
+
+    /// TODO: PGID type
+    @_alwaysEmitIntoClient
+    public init(positiveGroupID id: CInt) {
+      precondition(id >= 0)
+      self.init(rawValue: -id)
+    }
+  }
+
+  /// Get the process ID or process group currently receiv-
+  /// ing SIGIO and SIGURG signals.
+  ///
+  /// The corresponding C function is `fcntl` with the `F_GETOWN` command.
+  @_alwaysEmitIntoClient
+  public func getOwner() throws -> PIDOrPGID {
+    try PIDOrPGID(rawValue: fcntl(.getOwner))
+  }
+
+  /// Set the process or process group to receive SIGIO and
+  /// SIGURG signals.
+  ///
+  /// The corresponding C function is `fcntl` with the `F_SETOWN` command.
+  @_alwaysEmitIntoClient
+  public func setOwner(_ id: PIDOrPGID) throws {
+    _ = try fcntl(.setOwner, id.rawValue)
+  }
+}
+
+extension FileDescriptor {
+  /// Duplicate this file descriptor and return the newly created copy.
+  ///
+  /// - Parameters:
+  ///   - `minRawValue`: A lower bound on the new file descriptor's raw value.
+  ///   - `closeOnExec`: Whether the new descriptor's `closeOnExec` flag is set.
+  /// - Returns: The lowest numbered available descriptor whose raw value is
+  ///     greater than or equal to `minRawValue`.
+  ///
+  /// File descriptors are merely references to some underlying system resource.
+  /// The system does not distinguish between the original and the new file
+  /// descriptor in any way. For example, read, write and seek operations on
+  /// one of them also affect the logical file position in the other, and
+  /// append mode, non-blocking I/O and asynchronous I/O options are shared
+  /// between the references. If a separate pointer into the file is desired,
+  /// a different object reference to the file must be obtained by issuing an
+  /// additional call to `open`.
+  ///
+  /// However, each file descriptor maintains its own close-on-exec flag.
+  ///
+  /// The corresponding C functions are `fcntl` with `F_DUPFD` and
+  /// `F_DUPFD_CLOEXEC`.
+  @_alwaysEmitIntoClient
+  public func duplicate(
+    minRawValue: CInt, closeOnExec: Bool
+  ) throws -> FileDescriptor {
+    let cmd: Command = closeOnExec ? .duplicateCloseOnExec : .duplicate
+    return try FileDescriptor(rawValue: fcntl(cmd, minRawValue))
+  }
+
+  // TODO: What is the firmlink thing about?
+
+  /// Get the path of the file descriptor
+  ///
+  /// - Parameters:
+  ///   - `noFirmLink`: Get the non firmlinked path of the file descriptor.
+  ///
+  /// The corresponding C functions are `fcntl` with `F_GETPATH` and
+  /// `F_GETPATH_NOFIRMLINK`.
+  public func getPath(noFirmLink: Bool = false) throws -> FilePath {
+    let cmd: Command = noFirmLink ? .getPathNoFirmLink : .getPath
+    // TODO: have a uninitialized init on FilePath / SystemString...
+    let bytes = try Array<SystemChar>(unsafeUninitializedCapacity: _maxPathLen) {
+      (bufPtr, count: inout Int) in
+      _ = try fcntl(cmd, UnsafeMutableRawPointer(bufPtr.baseAddress!))
+      // TODO: Does fcntl return the length?
+      // TODO: The below is probably the wrong formulation...
+      count = system_strlen(
+        UnsafeRawPointer(bufPtr.baseAddress!).assumingMemoryBound(to: Int8.self))
+    }
+    return FilePath(SystemString(nullTerminated: bytes))
+  }
+}
+
+// Record locking
+extension FileDescriptor {
+  /// Get record locking information.
+  ///
+  /// Get the first lock that blocks the lock description described by `lock`.
+  /// If no lock is found that would prevent this lock from being created, the
+  /// structure is left unchanged by this function call except for the lock type
+  /// which is set to F_UNLCK.
+  ///
+  /// The corresponding C function is `fcntl` with `F_GETLK`.
+  @_alwaysEmitIntoClient
+  public func getLock(blocking lock: FileLock) throws -> FileLock {
+    var copy = lock
+    try _fcntlLock(.getLock, &copy, retryOnInterrupt: false).get()
+    return copy
+  }
+
+  /// Set record locking information.
+  ///
+  /// Set or clear a file segment lock according to the lock description
+  /// `lock`.`setLock` is used to establish shared/read locks (`FileLock.read`)
+  /// or exclusive/write locks, (`FileLock.write`), as well as remove either
+  /// type of lock (`FileLock.unlock`).  If a shared or exclusive lock cannot be
+  /// set, this throws `Errno.resourceTemporarilyUnavailable`.
+  ///
+  /// If `waitIfBlocked` is set and a shared or exclusive lock is blocked by
+  /// other locks, the process waits until the request can be satisfied.  If a
+  /// signal that is to be caught is received while this calls is waiting for a
+  /// region, the it will be interrupted if the signal handler has not
+  /// specified the SA_RESTART (see sigaction(2)).
+  ///
+  /// The corresponding C function is `fcntl` with `F_SETLK`.
+  @_alwaysEmitIntoClient
+  public func setLock(
+    to lock: FileLock,
+    waitIfBlocked: Bool = false,
+    retryOnInterrupt: Bool = true
+  ) throws {
+    let cmd: Command = waitIfBlocked ? .setLockWait : .setLock
+    var copy = lock
+    try _fcntlLock(cmd, &copy, retryOnInterrupt: retryOnInterrupt).get()
+    // TODO: Does `fcntl` update `copy`? Should we return it?
+  }
+
+
+}
+
+// TODO: Should we do special interfaces for any of the following?
+//   - preallocate
+//   - punchhole
+//   - setsize
+//   - rdadvise, rdahead, nocache, log2phys
+//   - no sigpipe
+//   - read/write bootstrap?
+
+// TODO: More fsync functionality using `F_BARRIERFSYNC` and `F_FULLFSYNC`,
+// coinciding with the sketch for fsync.
+
+
+

--- a/Sources/System/FileControlRaw.swift
+++ b/Sources/System/FileControlRaw.swift
@@ -1,0 +1,726 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ */
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import CSystem
+import Glibc
+#elseif os(Windows)
+import CSystem
+import ucrt
+#else
+#error("Unsupported Platform")
+#endif
+
+// RawRepresentable wrappers
+extension FileDescriptor {
+  /// File descriptor flags.
+  @frozen
+  public struct Flags: OptionSet {
+    @_alwaysEmitIntoClient
+    public let rawValue: CInt
+
+    @_alwaysEmitIntoClient
+    public init(rawValue: CInt) { self.rawValue = rawValue }
+
+    /// The given file descriptor will be automatically closed in the
+    /// successor process image when one of the execv(2) or posix_spawn(2)
+    /// family of system calls is invoked.
+    ///
+    /// The corresponding C global is `FD_CLOEXEC`.
+    @_alwaysEmitIntoClient
+    public static var closeOnExec: Flags { Flags(rawValue: FD_CLOEXEC) }
+  }
+
+  /// File status flags.
+  @frozen
+  public struct StatusFlags: OptionSet {
+    @_alwaysEmitIntoClient
+    public let rawValue: CInt
+
+    @_alwaysEmitIntoClient
+    public init(rawValue: CInt) { self.rawValue = rawValue }
+
+    @_alwaysEmitIntoClient
+    fileprivate init(_ raw: CInt) { self.init(rawValue: raw) }
+
+    /// Non-blocking I/O; if no data is available to a read
+    /// call, or if a write operation would block, the read or
+    /// write call throws `Errno.resourceTemporarilyUnavailable`.
+    ///
+    /// The corresponding C constant is `O_NONBLOCK`.
+    @_alwaysEmitIntoClient
+    public static var nonblocking: StatusFlags { StatusFlags(O_NONBLOCK) }
+
+    /// Force each write to append at the end of file; corre-
+    /// sponds to `OpenOptions.append`.
+    ///
+    /// The corresponding C constant is `O_APPEND`.
+    @_alwaysEmitIntoClient
+    public static var append: StatusFlags { StatusFlags(O_APPEND) }
+
+    /// Enable the SIGIO signal to be sent to the process
+    /// group when I/O is possible, e.g., upon availability of
+    /// data to be read.
+    ///
+    /// The corresponding C constant is `O_ASYNC`.
+    @_alwaysEmitIntoClient
+    public static var async: StatusFlags { StatusFlags(O_ASYNC) }
+  }
+
+  /// Advisory record locks.
+  ///
+  /// The corresponding C type is `flock`.
+  @frozen
+  public struct FileLock: RawRepresentable {
+    @_alwaysEmitIntoClient
+    public var rawValue: CInterop.FileLock
+
+    @_alwaysEmitIntoClient
+    public init(rawValue: CInterop.FileLock) { self.rawValue = rawValue }
+
+    /// The type of the lock.
+    @frozen
+    public struct LockType: RawRepresentable, Hashable {
+      @_alwaysEmitIntoClient
+      public var rawValue: Int16
+
+      @_alwaysEmitIntoClient
+      public init(rawValue: Int16) { self.rawValue = rawValue }
+
+      @_alwaysEmitIntoClient
+      private init(_ cmd: FileDescriptor.Command) {
+        self.init(rawValue: Int16(cmd.rawValue))
+      }
+
+      /// Shared or read lock.
+      ///
+      /// The corresponding C constant is `F_RDLCK`.
+      @_alwaysEmitIntoClient
+      public static var readLock: LockType { LockType(.readLock) }
+
+      /// Unlock.
+      ///
+      /// The corresponding C constant is `F_UNLCK`.
+      @_alwaysEmitIntoClient
+      public static var unlock: LockType { LockType(.unlock) }
+
+      /// Exclusive or write lock.
+      ///
+      /// The corresponding C constant is `F_WRLCK`.
+      @_alwaysEmitIntoClient
+      public static var writeLock: LockType { LockType(.writeLock) }
+    }
+
+    // TOOO: convenience initializers / static constructors
+
+    /// The type of the locking operation.
+    ///
+    /// The corresponding C field is `l_type`.
+    @_alwaysEmitIntoClient
+    public var type: LockType {
+      get { LockType(rawValue: rawValue.l_type) }
+      set { rawValue.l_type = newValue.rawValue }
+    }
+
+    /// The origin of the locked region.
+    ///
+    /// The corresponding C field is `l_whence`.
+    @_alwaysEmitIntoClient
+    public var origin: SeekOrigin {
+      get { SeekOrigin(rawValue: CInt(rawValue.l_whence)) }
+      set { rawValue.l_whence = Int16(newValue.rawValue) }
+    }
+
+    /// The start offset (from the origin) of the locked region.
+    ///
+    /// The corresponding C field is `l_start`.
+    @_alwaysEmitIntoClient
+    public var start: Int64 {
+      get { Int64(rawValue.l_start) }
+      set { rawValue.l_start = CInterop.Offset(newValue) }
+    }
+
+    /// The number of consecutive bytes to lock.
+    ///
+    /// The corresponding C field is `l_len`.
+    @_alwaysEmitIntoClient
+    public var length: Int64 {
+      get { Int64(rawValue.l_len) }
+      set { rawValue.l_len = CInterop.Offset(newValue) }
+    }
+
+    /// The process ID of the lock holder, filled in by`FileDescriptor.getLock()`.
+    ///
+    /// TODO: Actual ProcessID type
+    ///
+    /// The corresponding C field is `l_pid`
+    @_alwaysEmitIntoClient
+    public var pid: CInterop.PID {
+      get { rawValue.l_pid }
+      set { rawValue.l_pid = newValue }
+    }
+  }
+
+}
+
+// Raw escape hatch
+extension FileDescriptor {
+  @usableFromInline
+  internal func _fcntl(_ cmd: Command) -> Result<CInt, Errno> {
+    valueOrErrno(retryOnInterrupt: false) {
+      system_fcntl(self.rawValue, cmd.rawValue)
+    }
+  }
+  @usableFromInline
+  internal func _fcntl(
+    _ cmd: Command, _ arg: CInt
+  ) -> Result<CInt, Errno> {
+    valueOrErrno(retryOnInterrupt: false) {
+      system_fcntl(self.rawValue, cmd.rawValue, arg)
+    }
+  }
+  @usableFromInline
+  internal func _fcntl(
+    _ cmd: Command, _ ptr: UnsafeMutableRawPointer
+  ) -> Result<CInt, Errno> {
+    valueOrErrno(retryOnInterrupt: false) {
+      system_fcntl(self.rawValue, cmd.rawValue, ptr)
+    }
+  }
+  @usableFromInline
+  internal func _fcntlLock(
+    _ cmd: Command, _ lock: inout FileLock,
+    retryOnInterrupt: Bool
+  ) -> Result<(), Errno> {
+    nothingOrErrno(retryOnInterrupt: retryOnInterrupt) {
+      withUnsafeMutablePointer(to: &lock) {
+        system_fcntl(self.rawValue, cmd.rawValue, $0)
+      }
+    }
+  }
+
+  /// Commands (and various constants) to pass to `fcntl`.
+  @frozen
+  public struct Command: RawRepresentable, Hashable {
+    @_alwaysEmitIntoClient
+    public let rawValue: CInt
+
+    @_alwaysEmitIntoClient
+    public init(rawValue: CInt) { self.rawValue = rawValue }
+
+    @_alwaysEmitIntoClient
+    private init(_ raw: CInt) { self.init(rawValue: raw) }
+
+    /// Duplicate file descriptor.
+    ///
+    /// Note: A Swiftier wrapper is
+    /// `FileDescriptor.duplicate(minRawValue:closeOnExec:)`.
+    ///
+    /// The corresponding C constant is `F_DUPFD`.
+    @_alwaysEmitIntoClient
+    public static var duplicate: Command { Command(F_DUPFD) }
+
+    /// Get file descriptor flags.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.getFlags()`.
+    ///
+    /// The corresponding C constant is `F_GETFD`.
+    @_alwaysEmitIntoClient
+    public static var getFlags: Command { Command(F_GETFD) }
+
+    /// Set file descriptor flags.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.setFlags(_:)`.
+    ///
+    /// The corresponding C constant is `F_SETFD`.
+    @_alwaysEmitIntoClient
+    public static var setFlags: Command { Command(F_SETFD) }
+
+    /// Get file status flags.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.getStatusFlags()`.
+    ///
+    /// The corresponding C constant is `F_GETFL`.
+    @_alwaysEmitIntoClient
+    public static var getStatusFlags: Command {
+      Command(F_GETFL)
+    }
+
+    /// Set file status flags.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.setStatusFlags(_:)`.
+    ///
+    /// The corresponding C constant is `F_SETFL`.
+    @_alwaysEmitIntoClient
+    public static var setStatusFlags: Command {
+      Command(F_SETFL)
+    }
+
+    /// Get SIGIO/SIGURG proc/pgrp.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.getOwner()`.
+    ///
+    /// The corresponding C constant is `F_GETOWN`.
+    @_alwaysEmitIntoClient
+    public static var getOwner: Command { Command(F_GETOWN) }
+
+    /// Set SIGIO/SIGURG proc/pgrp.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.setOwner(_:)`.
+    ///
+    /// The corresponding C constant is `F_SETOWN`.
+    @_alwaysEmitIntoClient
+    public static var setOwner: Command { Command(F_SETOWN) }
+
+    /// Get record locking information.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.getLock(_:_:)`.
+    ///
+    /// The corresponding C constant is `F_GETLK`.
+    @_alwaysEmitIntoClient
+    public static var getLock: Command { Command(F_GETLK) }
+
+    /// Set record locking information.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.setLock(_:_:)`.
+    ///
+    /// The corresponding C constant is `F_SETLK`.
+    @_alwaysEmitIntoClient
+    public static var setLock: Command { Command(F_SETLK) }
+
+    /// Wait if blocked.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.setLock(_:_:)`.
+    ///
+    /// The corresponding C constant is `F_SETLKW`.
+    @_alwaysEmitIntoClient
+    public static var setLockWait: Command { Command(F_SETLKW) }
+
+    /// Wait if blocked, return on timeout.
+    ///
+    /// TODO: A Swiftier wrapper
+    ///
+    /// The corresponding C constant is `F_SETLKWTIMEOUT`.
+    @_alwaysEmitIntoClient
+    public static var setLockWaitTimout: Command {
+      Command(F_SETLKWTIMEOUT)
+    }
+
+    /// ??? TODO: Where is this documented?
+    ///
+    /// The corresponding C constant is `F_FLUSH_DATA`.
+    @_alwaysEmitIntoClient
+    public static var flushData: Command {
+      Command(F_FLUSH_DATA)
+    }
+
+    /// Used for regression test.
+    ///
+    /// The corresponding C constant is `F_CHKCLEAN`.
+    @_alwaysEmitIntoClient
+    public static var checkClean: Command { Command(F_CHKCLEAN) }
+
+    /// Preallocate storage.
+    ///
+    /// The corresponding C constant is `F_PREALLOCATE`.
+    @_alwaysEmitIntoClient
+    public static var preallocate: Command {
+      Command(F_PREALLOCATE)
+    }
+
+    /// Truncate a file. Equivalent to calling truncate(2).
+    ///
+    /// The corresponding C constant is `F_SETSIZE`.
+    @_alwaysEmitIntoClient
+    public static var setSize: Command { Command(F_SETSIZE) }
+
+    /// Issue an advisory read async with no copy to user.
+    ///
+    /// The corresponding C constant is `F_RDADVISE`.
+    @_alwaysEmitIntoClient
+    public static var readAdvise: Command { Command(F_RDADVISE) }
+
+    /// Turn read ahead off/on for this fd.
+    ///
+    /// The corresponding C constant is `F_RDAHEAD`.
+    @_alwaysEmitIntoClient
+    public static var readAhead: Command { Command(F_RDAHEAD) }
+
+    ///
+    /// Header says: 46,47 used to be F_READBOOTSTRAP and F_WRITEBOOTSTRAP
+    /// FIXME: What do we do here?
+    ///
+
+    /// Turn data caching off/on for this fd.
+    ///
+    /// The corresponding C constant is `F_NOCACHE`.
+    @_alwaysEmitIntoClient
+    public static var noCache: Command { Command(F_NOCACHE) }
+
+    /// File offset to device offset.
+    ///
+    /// The corresponding C constant is `F_LOG2PHYS`.
+    @_alwaysEmitIntoClient
+    public static var log2phys: Command { Command(F_LOG2PHYS) }
+
+    /// Return the full path of the fd.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.getPath(_:)`.
+    ///
+    /// The corresponding C constant is `F_GETPATH`.
+    @_alwaysEmitIntoClient
+    public static var getPath: Command { Command(F_GETPATH) }
+
+    /// Fsync + ask the drive to flush to the media.
+    ///
+    /// The corresponding C constant is `F_FULLFSYNC`.
+    @_alwaysEmitIntoClient
+    public static var fullFsync: Command { Command(F_FULLFSYNC) }
+
+    /// Find which component (if any) is a package.
+    ///
+    /// The corresponding C constant is `F_PATHPKG_CHECK`.
+    @_alwaysEmitIntoClient
+    public static var pathPackageCheck: Command {
+      Command(F_PATHPKG_CHECK)
+    }
+
+    /// "Freeze" all fs operations.
+    ///
+    /// The corresponding C constant is `F_FREEZE_FS`.
+    @_alwaysEmitIntoClient
+    public static var freezeFS: Command { Command(F_FREEZE_FS) }
+
+    /// "Thaw" all fs operations.
+    ///
+    /// The corresponding C constant is `F_THAW_FS`.
+    @_alwaysEmitIntoClient
+    public static var thawFS: Command { Command(F_THAW_FS) }
+
+    /// Turn data caching off/on (globally) for this file.
+    ///
+    /// The corresponding C constant is `F_GLOBAL_NOCACHE`.
+    @_alwaysEmitIntoClient
+    public static var globalNoCache: Command {
+      Command(F_GLOBAL_NOCACHE)
+    }
+
+    /// Add detached signatures.
+    ///
+    /// The corresponding C constant is `F_ADDSIGS`.
+    @_alwaysEmitIntoClient
+    public static var addSignatures: Command {
+      Command(F_ADDSIGS)
+    }
+
+    /// Add signature from same file (used by dyld for shared libs).
+    ///
+    /// The corresponding C constant is `F_ADDFILESIGS`.
+    @_alwaysEmitIntoClient
+    public static var addFileSignatures: Command {
+      Command(F_ADDFILESIGS)
+    }
+
+    /// Used in conjunction with F_NOCACHE to indicate that DIRECT,
+    /// synchonous writes should not be used (i.e. its ok to temporaily create
+    /// cached pages).
+    ///
+    /// The corresponding C constant is `F_NODIRECT`.
+    @_alwaysEmitIntoClient
+    public static var noDirect: Command { Command(F_NODIRECT) }
+
+    /// Get the protection class of a file from the EA, returns int.
+    ///
+    /// The corresponding C constant is `F_GETPROTECTIONCLASS`.
+    @_alwaysEmitIntoClient
+    public static var getProtectionClass: Command {
+      Command(F_GETPROTECTIONCLASS)
+    }
+
+    /// Set the protection class of a file for the EA, requires int.
+    ///
+    /// The corresponding C constant is `F_SETPROTECTIONCLASS`.
+    @_alwaysEmitIntoClient
+    public static var setProtectionClass: Command {
+      Command(F_SETPROTECTIONCLASS)
+    }
+
+    /// File offset to device offset, extended.
+    ///
+    /// The corresponding C constant is `F_LOG2PHYS_EXT`.
+    @_alwaysEmitIntoClient
+    public static var log2physExtended: Command {
+      Command(F_LOG2PHYS_EXT)
+    }
+
+    /// Get record locking information, per-process.
+    ///
+    /// The corresponding C constant is `F_GETLKPID`.
+    @_alwaysEmitIntoClient
+    public static var getLockPID: Command { Command(F_GETLKPID) }
+
+    /// Mark the dup with FD_CLOEXEC.
+    ///
+    /// The corresponding C constant is `F_DUPFD_CLOEXEC`
+    @_alwaysEmitIntoClient
+    public static var duplicateCloseOnExec: Command {
+      Command(F_DUPFD_CLOEXEC)
+    }
+
+    /// Mark the file as being the backing store for another filesystem.
+    ///
+    /// The corresponding C constant is `F_SETBACKINGSTORE`.
+    @_alwaysEmitIntoClient
+    public static var setBackingStore: Command {
+      Command(F_SETBACKINGSTORE)
+    }
+
+    /// Return the full path of the FD, but error in specific mtmd
+    /// circumstances.
+    ///
+    /// The corresponding C constant is `F_GETPATH_MTMINFO`.
+    @_alwaysEmitIntoClient
+    public static var getPathMTMDInfo: Command {
+      Command(F_GETPATH_MTMINFO)
+    }
+
+    /// Returns the code directory, with associated hashes, to the caller.
+    ///
+    /// The corresponding C constant is `F_GETCODEDIR`.
+    @_alwaysEmitIntoClient
+    public static var getCodeDirectory: Command {
+      Command(F_GETCODEDIR)
+    }
+
+    /// No SIGPIPE generated on EPIPE.
+    ///
+    /// The corresponding C constant is `F_SETNOSIGPIPE`.
+    @_alwaysEmitIntoClient
+    public static var setNoSigPipe: Command {
+      Command(F_SETNOSIGPIPE)
+    }
+
+    /// Status of SIGPIPE for this fd.
+    ///
+    /// The corresponding C constant is `F_GETNOSIGPIPE`.
+    @_alwaysEmitIntoClient
+    public static var getNoSigPipe: Command {
+      Command(F_GETNOSIGPIPE)
+    }
+
+    /// For some cases, we need to rewrap the key for AKS/MKB.
+    ///
+    /// The corresponding C constant is `F_TRANSCODEKEY`.
+    @_alwaysEmitIntoClient
+    public static var transcodeKey: Command {
+      Command(F_TRANSCODEKEY)
+    }
+
+    /// File being written to a by single writer... if throttling enabled,
+    /// writes may be broken into smaller chunks with throttling in between.
+    ///
+    /// The corresponding C constant is `F_SINGLE_WRITER`.
+    @_alwaysEmitIntoClient
+    public static var singleWriter: Command {
+      Command(F_SINGLE_WRITER)
+    }
+
+
+    /// Get the protection version number for this filesystem.
+    ///
+    /// The corresponding C constant is `F_GETPROTECTIONLEVEL`.
+    @_alwaysEmitIntoClient
+    public static var getProtectionLevel: Command {
+      Command(F_GETPROTECTIONLEVEL)
+    }
+
+
+    /// Add detached code signatures (used by dyld for shared libs).
+    ///
+    /// The corresponding C constant is `F_FINDSIGS`.
+    @_alwaysEmitIntoClient
+    public static var findSignatures: Command {
+      Command(F_FINDSIGS)
+    }
+
+    /// Add signature from same file, only if it is signed by Apple (used by
+    /// dyld for simulator).
+    ///
+    /// The corresponding C constant is `F_ADDFILESIGS_FOR_DYLD_SIM`.
+    @_alwaysEmitIntoClient
+    public static var addFileSignaturesForDYLDSim: Command {
+      Command(F_ADDFILESIGS_FOR_DYLD_SIM)
+    }
+
+    /// Fsync + issue barrier to drive.
+    ///
+    /// The corresponding C constant is `F_BARRIERFSYNC`.
+    @_alwaysEmitIntoClient
+    public static var barrierFsync: Command {
+      Command(F_BARRIERFSYNC)
+    }
+
+    /// Add signature from same file, return end offset in structure on success.
+    ///
+    /// The corresponding C constant is `F_ADDFILESIGS_RETURN`.
+    @_alwaysEmitIntoClient
+    public static var addFileSignaturesReturn: Command {
+      Command(F_ADDFILESIGS_RETURN)
+    }
+
+    /// Check if Library Validation allows this Mach-O file to be mapped into
+    /// the calling process.
+    ///
+    /// The corresponding C constant is `F_CHECK_LV`.
+    @_alwaysEmitIntoClient
+    public static var checkLibraryValidation: Command {
+      Command(F_CHECK_LV)
+    }
+
+    /// Deallocate a range of the file.
+    ///
+    /// The corresponding C constant is `F_PUNCHHOLE`.
+    @_alwaysEmitIntoClient
+    public static var punchhole: Command { Command(F_PUNCHHOLE) }
+
+    /// Trim an active file.
+    ///
+    /// The corresponding C constant is `F_TRIM_ACTIVE_FILE`.
+    @_alwaysEmitIntoClient
+    public static var trimActiveFile: Command {
+      Command(F_TRIM_ACTIVE_FILE)
+    }
+
+    /// Synchronous advisory read fcntl for regular and compressed file.
+    ///
+    /// The corresponding C constant is `F_SPECULATIVE_READ`.
+    @_alwaysEmitIntoClient
+    public static var speculativeRead: Command {
+      Command(F_SPECULATIVE_READ)
+    }
+
+    /// Return the full path without firmlinks of the fd.
+    ///
+    /// Note: A Swiftier wrapper is `FileDescriptor.getPath(_:)`.
+    ///
+    /// The corresponding C constant is `F_GETPATH_NOFIRMLINK`.
+    @_alwaysEmitIntoClient
+    public static var getPathNoFirmLink: Command {
+      Command(F_GETPATH_NOFIRMLINK)
+    }
+
+    /// Add signature from same file, return information.
+    ///
+    /// The corresponding C constant is `F_ADDFILESIGS_INFO`.
+    @_alwaysEmitIntoClient
+    public static var addFileSignatureInfo: Command {
+      Command(F_ADDFILESIGS_INFO)
+    }
+
+    /// Add supplemental signature from same file with fd reference to original.
+    ///
+    /// The corresponding C constant is `F_ADDFILESUPPL`.
+    @_alwaysEmitIntoClient
+    public static var addFileSupplementalSignature: Command {
+      Command(F_ADDFILESUPPL)
+    }
+
+    /// Look up code signature information attached to a file or slice.
+    ///
+    /// The corresponding C constant is `F_GETSIGSINFO`.
+    @_alwaysEmitIntoClient
+    public static var getSignatureInfo: Command {
+      Command(F_GETSIGSINFO)
+    }
+
+    /// Shared or read lock.
+    ///
+    /// The corresponding C constant is `F_RDLCK`.
+    @_alwaysEmitIntoClient
+    public static var readLock: Command { Command(F_RDLCK) }
+
+    /// Unlock.
+    ///
+    /// The corresponding C constant is `F_UNLCK`.
+    @_alwaysEmitIntoClient
+    public static var unlock: Command { Command(F_UNLCK) }
+
+    /// Exclusive or write lock.
+    ///
+    /// The corresponding C constant is `F_WRLCK`.
+    @_alwaysEmitIntoClient
+    public static var writeLock: Command { Command(F_WRLCK) }
+
+    /// Allocate contigious space.
+    ///
+    /// TODO: This is actually a flag for the PREALLOCATE struct...
+    ///
+    /// The corresponding C constant is `F_ALLOCATECONTIG`.
+    @_alwaysEmitIntoClient
+    public static var allocateContiguous: Command {
+      Command(F_ALLOCATECONTIG)
+    }
+
+    /// Allocate all requested space or no space at all.
+    ///
+    /// TODO: This is actually a flag for the PREALLOCATE struct...
+    ///
+    /// The corresponding C constant is `F_ALLOCATEALL`.
+    @_alwaysEmitIntoClient
+    public static var allocateAll: Command {
+      Command(F_ALLOCATEALL)
+    }
+
+    /// Make it past all of the SEEK pos modes so that.
+    ///
+    /// TODO: The above is a direct quote from the header, figure out what it
+    /// means
+    ///
+    /// The corresponding C constant is `F_PEOFPOSMODE`.
+    @_alwaysEmitIntoClient
+    public static var endOfFile: Command {
+      Command(F_PEOFPOSMODE)
+    }
+
+    /// Specify volume starting postion.
+    ///
+    /// The corresponding C constant is `F_VOLPOSMODE`.
+    @_alwaysEmitIntoClient
+    public static var startOfVolume: Command {
+      Command(F_VOLPOSMODE)
+    }
+  }
+
+  /// Raw interface to C's `fcntl`. Note, most common operations have Swiftier
+  /// alternatives directly on `FileDescriptor`.
+  @_alwaysEmitIntoClient
+  public func fcntl(_ cmd: Command) throws -> CInt {
+    try _fcntl(cmd).get()
+  }
+
+  /// Raw interface to C's `fcntl`. Note, most common operations have Swiftier
+  /// alternatives directly on `FileDescriptor`.
+  @_alwaysEmitIntoClient
+  public func fcntl(_ cmd: Command, _ arg: CInt) throws -> CInt {
+    try _fcntl(cmd, arg).get()
+  }
+
+  /// Raw interface to C's `fcntl`. Note, most common operations have Swiftier
+  /// alternatives directly on `FileDescriptor`.
+  @_alwaysEmitIntoClient
+  public func fcntl(
+    _ cmd: Command, _ ptr: UnsafeMutableRawPointer
+  ) throws -> CInt {
+    try _fcntl(cmd, ptr).get()
+  }
+}
+
+internal var _maxPathLen: Int { Int(MAXPATHLEN) }

--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -63,4 +63,18 @@ public enum CInterop {
   /// on API.
   public typealias PlatformUnicodeEncoding = UTF8
   #endif
+
+  /// The C `flock` type
+  public typealias FileLock = flock
+
+  /// The C `pid_t` type
+  public typealias PID = pid_t
+
+  /// The C `off_t` type.
+  ///
+  /// Note that in System, we generally standardize on `Int64` where `off_t`
+  /// might otherwise appear. This typealias allows conversion code to be
+  /// emitted into client.
+  public typealias Offset = off_t
+
 }

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -115,3 +115,26 @@ internal func system_dup2(_ fd: Int32, _ fd2: Int32) -> Int32 {
   #endif
   return dup2(fd, fd2)
 }
+
+internal func system_fcntl(_ fd: Int32, _ cmd: Int32) -> Int32 {
+  #if ENABLE_MOCKING
+  if mockingEnabled { return _mock(fd, cmd) }
+  #endif
+  return fcntl(fd, cmd)
+}
+
+internal func system_fcntl(_ fd: Int32, _ cmd: Int32, _ arg: Int32) -> Int32 {
+  #if ENABLE_MOCKING
+  if mockingEnabled { return _mock(fd, cmd, arg) }
+  #endif
+  return fcntl(fd, cmd, arg)
+}
+
+internal func system_fcntl(
+  _ fd: Int32, _ cmd: Int32, _ arg: UnsafeMutableRawPointer
+) -> Int32 {
+  #if ENABLE_MOCKING
+  if mockingEnabled { return _mock(fd, cmd, arg) }
+  #endif
+  return fcntl(fd, cmd, arg)
+}


### PR DESCRIPTION
Add in support for fcntl and all the raw commands and flags it supports. Add in Swiftier representations of common and important invocations. 

### System Sketch

New design patterns:
  - We provide rawer, but complete, `FileDescriptor.fcntl()` and `FileDescriptor.Command` interfaces and wrappers.
  - We provide Swiftier type-safe interfaces for a common and important subset.
  - `FileDescriptor.FileLock` is our first RR wrapper of a real C struct.

Externals:
  - PID, and PIDOrGPID.
  - `flock` to coordinate design with `get/setLock()`.
  - `fsync` to coordinate design with `F_FULLFSYNC` etc.

Unknowns:
  - Headers have even more locking commands/variants, should we promote these to the Swifty APIs?
  - Is `Errno.resourceTemporarilyUnavailable` too removed from `EAGAIN`? Should we introduce `Errno.again` alias?
  - Are there other Swiftier interfaces we should provide?

Testing needs:
  - Normal mocking tests
  - Sample code, especially for provided Swiftier interfaces