### PR TITLE
[Pitch] Add non-throwing FileDescriptor.currentOffset helper

### DIFF
--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -116,6 +116,12 @@ extension FileDescriptor {
     try _seek(offset: offset, from: whence).get()
   }
 
+  /// Return the current offset for the given file descriptor.
+  @_alwaysEmitIntoClient
+  public var currentOffset: Int64 {
+    try! _seek(offset: 0, from: .current).get()
+  }
+
   @usableFromInline
   internal func _seek(
     offset: Int64, from whence: FileDescriptor.SeekOrigin

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -90,6 +90,17 @@ final class FileOperationsTest: XCTestCase {
     // TODO: Test writeAll, writeAll(toAbsoluteOffset), closeAfter
   }
 
+  func testCurrentOffset() throws {
+    let fd = try FileDescriptor.open("/tmp/a.txt", .readWrite, options: [.create, .truncate], permissions: .ownerReadWrite)
+    XCTAssertEqual(fd.currentOffset, 0)
+
+    try fd.writeAll("abc".utf8)
+    XCTAssertEqual(fd.currentOffset, 3)
+
+    try fd.seek(offset: -1, from: .current)
+    XCTAssertEqual(fd.currentOffset, 2)
+  }
+
   func testAdHocOpen() {
     // Ad-hoc test touching a file system.
     do {


### PR DESCRIPTION
Provided the file descriptor is still valid, accessing the current offset shouldn't fail.

---

It took me a bit of hunting around to figure out how to access the current offset in a file. I could see this being too trivial to add a helper for, however, after reading the man page for `lseek(2)`, it seemed like the operation shouldn't be able to fail for valid file descriptors, and so there's value in providing a non-throwing way to achieve this.

Would love to hear your feedback. Thanks!