### PR TITLE
Added `ioctl` support

### DIFF
--- a/Sources/CSystem/include/CSystemLinux.h
+++ b/Sources/CSystem/include/CSystemLinux.h
@@ -14,6 +14,7 @@
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/sysinfo.h>
+#include <sys/ioctl.h>
 #include <sys/timerfd.h>
 #include <sys/types.h>
 #include <errno.h>

--- a/Sources/System/InputOutput/IOControl.swift
+++ b/Sources/System/InputOutput/IOControl.swift
@@ -1,0 +1,47 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+/// Input / Output Request identifier for manipulating underlying device parameters of special files.
+public protocol IOControlID: RawRepresentable {
+    
+    /// Create a strongly-typed I/O request from a raw C IO request.
+    init?(rawValue: CUnsignedLong)
+    
+    /// The raw C IO request ID.
+    var rawValue: CUnsignedLong { get }
+}
+
+#if os(Linux)
+public extension IOControlID {
+    
+    @_alwaysEmitIntoClient
+    init(type: IOType, direction: IODirection, code: CInt, size: CInt) {
+        self.init(rawValue: _IOC(direction, type, nr, size))
+    }
+}
+#endif
+
+public protocol IOControlInteger {
+    
+    associatedtype ID: IOControlID
+    
+    static var id: ID { get }
+    
+    var intValue: Int32 { get }
+}
+
+public protocol IOControlValue {
+    
+    associatedtype ID: IOControlID
+    
+    static var id: ID { get }
+    
+    mutating func withUnsafeMutablePointer<Result>(_ body: (UnsafeMutableRawPointer) throws -> (Result)) rethrows -> Result
+}
+

--- a/Sources/System/InputOutput/IODirection.swift
+++ b/Sources/System/InputOutput/IODirection.swift
@@ -1,0 +1,40 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+#if os(Linux)
+
+/// `ioctl` Data Direction
+@frozen
+public struct IODirection: OptionSet, Hashable, Codable {
+    
+    /// The raw C file permissions.
+    @_alwaysEmitIntoClient
+    public let rawValue: CInt
+    
+    /// Create a strongly-typed file permission from a raw C value.
+    @_alwaysEmitIntoClient
+    public init(rawValue: CInt) { self.rawValue = rawValue }
+    
+    @_alwaysEmitIntoClient
+    private init(_ raw: CInt) { self.init(rawValue: raw) }
+}
+
+public extension IODirection {
+    
+    @_alwaysEmitIntoClient
+    static var none: IODirection { IODirection(0x00) }
+    
+    @_alwaysEmitIntoClient
+    static var read: IODirection { IODirection(0x01) }
+    
+    @_alwaysEmitIntoClient
+    static var write: IODirection { IODirection(0x02) }
+}
+
+#endif

--- a/Sources/System/InputOutput/IOOperations.swift
+++ b/Sources/System/InputOutput/IOOperations.swift
@@ -1,0 +1,73 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+extension FileDescriptor {
+    
+    /// Manipulates the underlying device parameters of special files.
+    @_alwaysEmitIntoClient
+    public func inputOutput<T: IOControlID>(
+        _ request: T,
+        retryOnInterrupt: Bool = true
+    ) throws {
+        try _inputOutput(request, retryOnInterrupt: true).get()
+    }
+    
+    /// Manipulates the underlying device parameters of special files.
+    @usableFromInline
+    internal func _inputOutput<T: IOControlID>(
+        _ request: T,
+        retryOnInterrupt: Bool
+    ) -> Result<(), Errno> {
+        nothingOrErrno(retryOnInterrupt: retryOnInterrupt) {
+            system_ioctl(self.rawValue, request.rawValue)
+        }
+    }
+    
+    /// Manipulates the underlying device parameters of special files.
+    @_alwaysEmitIntoClient
+    public func inputOutput<T: IOControlInteger>(
+        _ request: T,
+        retryOnInterrupt: Bool = true
+    ) throws {
+        try _inputOutput(request, retryOnInterrupt: retryOnInterrupt).get()
+    }
+    
+    /// Manipulates the underlying device parameters of special files.
+    @usableFromInline
+    internal func _inputOutput<T: IOControlInteger>(
+        _ request: T,
+        retryOnInterrupt: Bool
+    ) -> Result<(), Errno> {
+        nothingOrErrno(retryOnInterrupt: retryOnInterrupt) {
+            system_ioctl(self.rawValue, T.id.rawValue, request.intValue)
+        }
+    }
+    
+    /// Manipulates the underlying device parameters of special files.
+    @_alwaysEmitIntoClient
+    public func inputOutput<T: IOControlValue>(
+        _ request: inout T,
+        retryOnInterrupt: Bool = true
+    ) throws {
+        try _inputOutput(&request, retryOnInterrupt: retryOnInterrupt).get()
+    }
+    
+    /// Manipulates the underlying device parameters of special files.
+    @usableFromInline
+    internal func _inputOutput<T: IOControlValue>(
+        _ request: inout T,
+        retryOnInterrupt: Bool
+    ) -> Result<(), Errno> {
+        nothingOrErrno(retryOnInterrupt: retryOnInterrupt) {
+            request.withUnsafeMutablePointer { pointer in
+                system_ioctl(self.rawValue, T.id.rawValue, pointer)
+            }
+        }
+    }
+}

--- a/Sources/System/InputOutput/IOType.swift
+++ b/Sources/System/InputOutput/IOType.swift
@@ -1,0 +1,91 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+#if os(Linux)
+
+/// `ioctl` Device driver identifier code
+@frozen
+public struct IOType: RawRepresentable, Equatable, Hashable {
+    
+    @_alwaysEmitIntoClient
+    public let rawValue: CInt
+    
+    @_alwaysEmitIntoClient
+    public init(rawValue: CInt) {
+        self.rawValue = rawValue
+    }
+}
+
+// MARK: - ExpressibleByUnicodeScalarLiteral
+
+extension IOType: ExpressibleByUnicodeScalarLiteral {
+    
+    @_alwaysEmitIntoClient
+    public init(unicodeScalarLiteral character: Unicode.Scalar) {
+        self.init(rawValue: CInt(character.value))
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension IOType: ExpressibleByIntegerLiteral {
+    
+    @_alwaysEmitIntoClient
+    public init(integerLiteral value: Int32) {
+        self.init(rawValue: value)
+    }
+}
+
+// MARK: - Definitions
+
+// https://01.org/linuxgraphics/gfx-docs/drm/ioctl/ioctl-number.html
+public extension IOType {
+    
+    /// Floppy Disk
+    @_alwaysEmitIntoClient
+    static var floppyDisk: IOType { 0x02 } // linux/fd.h
+    
+    /// InfiniBand Subsystem
+    @_alwaysEmitIntoClient
+    static var infiniBand: IOType { 0x1b }
+    
+    /// IEEE 1394 Subsystem Block for the entire subsystem
+    @_alwaysEmitIntoClient
+    static var ieee1394: IOType { "#" }
+    
+    /// Performance counter
+    @_alwaysEmitIntoClient
+    static var performance: IOType { "$" } // linux/perf_counter.h, linux/perf_event.h
+    
+    /// System Trace Module subsystem
+    @_alwaysEmitIntoClient
+    static var systemTrace: IOType { "%" } // include/uapi/linux/stm.h
+    
+    /// Kernel-based Virtual Machine
+    @_alwaysEmitIntoClient
+    static var kvm: IOType { 0xAF }  // linux/kvm.h
+    
+    /// Freescale hypervisor
+    @_alwaysEmitIntoClient
+    static var freescaleHypervisor: IOType { 0xAF }  // linux/fsl_hypervisor.h
+    
+    /// GPIO
+    @_alwaysEmitIntoClient
+    static var gpio: IOType { 0xB4 }  // linux/gpio.h
+    
+    /// Linux FUSE
+    @_alwaysEmitIntoClient
+    static var fuse: IOType { 0xE5 }  // linux/fuse.h
+    
+    /// ChromeOS EC driver
+    @_alwaysEmitIntoClient
+    static var chromeEC: IOType { 0xEC } // drivers/platform/chrome/cros_ec_dev.h
+}
+
+#endif

--- a/Sources/System/InputOutput/TerminalIO.swift
+++ b/Sources/System/InputOutput/TerminalIO.swift
@@ -1,0 +1,105 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+#if os(macOS) || os(Linux) || os(FreeBSD) || os(Android)
+/// Terminal `ioctl` definitions
+@frozen
+public struct TerminalIO: IOControlID, Equatable, Hashable {
+    
+    public let rawValue: CUnsignedLong
+    
+    public init(rawValue: CUnsignedLong) {
+        self.rawValue = rawValue
+    }
+    
+    @_alwaysEmitIntoClient
+    private init(_ rawValue: CUnsignedLong) {
+        self.init(rawValue: rawValue)
+    }
+}
+
+public extension TerminalIO {
+    
+    /// Turn break on, that is, start sending zero bits.
+    @_alwaysEmitIntoClient
+    static var setBreakBit: TerminalIO { TerminalIO(_TIOCSBRK) }
+    
+    /// Turn break off, that is, stop sending zero bits.
+    @_alwaysEmitIntoClient
+    static var clearBreakBit: TerminalIO { TerminalIO(_TIOCCBRK) }
+    
+    /// Put the terminal into exclusive mode.
+    @_alwaysEmitIntoClient
+    static var setExclusiveMode: TerminalIO { TerminalIO(_TIOCEXCL) }
+    
+    /// Reset exclusive use of tty.
+    @_alwaysEmitIntoClient
+    static var resetExclusiveMode: TerminalIO { TerminalIO(_TIOCNXCL) }
+    
+    /// Get the line discipline of the terminal.
+    @_alwaysEmitIntoClient
+    static var getLineDiscipline: TerminalIO { TerminalIO(_TIOCGETD) }
+    
+    /// Set the line discipline of the terminal.
+    @_alwaysEmitIntoClient
+    static var setLineDiscipline: TerminalIO { TerminalIO(_TIOCSETD) }
+}
+
+public extension TerminalIO {
+    
+    /// Get the line discipline of the terminal.
+    @frozen
+    struct GetLineDiscipline: Equatable, Hashable, IOControlValue {
+        
+        @_alwaysEmitIntoClient
+        public static var id: TerminalIO { .getLineDiscipline }
+        
+        public private(set) var lineDiscipline: Int
+        
+        public init() {
+            self.lineDiscipline = 0
+        }
+        
+        public mutating func withUnsafeMutablePointer<Result>(_ body: (UnsafeMutableRawPointer) throws -> (Result)) rethrows -> Result {
+            // Argument: int *argp
+            var value: CInt = numericCast(self.lineDiscipline)
+            let result = try Swift.withUnsafeMutableBytes(of: &value) { buffer in
+                try body(buffer.baseAddress!)
+            }
+            self.lineDiscipline = numericCast(value)
+            return result
+        }
+    }
+    
+    /// Set the line discipline of the terminal.
+    @frozen
+    struct SetLineDiscipline: Equatable, Hashable, IOControlValue {
+        
+        @_alwaysEmitIntoClient
+        public static var id: TerminalIO { .setLineDiscipline }
+        
+        public let lineDiscipline: Int
+        
+        public init(lineDiscipline: Int) {
+            self.lineDiscipline = lineDiscipline
+        }
+        
+        public mutating func withUnsafeMutablePointer<Result>(_ body: (UnsafeMutableRawPointer) throws -> (Result)) rethrows -> Result {
+            // Argument: const int *argp
+            var value: CInt = numericCast(self.lineDiscipline)
+            let result = try Swift.withUnsafeMutableBytes(of: &value) { buffer in
+                try body(buffer.baseAddress!)
+            }
+            assert(numericCast(value) == self.lineDiscipline, "Value changed")
+            return result
+        }
+    }
+}
+
+#endif

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -529,3 +529,42 @@ internal var _SEEK_HOLE: CInt { SEEK_HOLE }
 internal var _SEEK_DATA: CInt { SEEK_DATA }
 #endif
 
+
+#if os(macOS)
+@_alwaysEmitIntoClient
+internal var _TIOCFLUSH: CUnsignedLong { TIOCFLUSH }
+
+@_alwaysEmitIntoClient
+internal var _TIOCSDTR: CUnsignedLong { TIOCSDTR }
+
+@_alwaysEmitIntoClient
+internal var _TIOCCDTR: CUnsignedLong { TIOCCDTR }
+#endif
+
+#if os(Linux)
+@_alwaysEmitIntoClient
+internal var _TCGETS: CUnsignedLong { TCGETS }
+
+@_alwaysEmitIntoClient
+internal var _TIOCGEXCL: CUnsignedLong { TIOCGEXCL }
+#endif
+
+@_alwaysEmitIntoClient
+internal var _TIOCSBRK: CUnsignedLong { TIOCSBRK }
+
+@_alwaysEmitIntoClient
+internal var _TIOCCBRK: CUnsignedLong { TIOCCBRK }
+
+@_alwaysEmitIntoClient
+internal var _TIOCEXCL: CUnsignedLong { TIOCEXCL }
+
+@_alwaysEmitIntoClient
+internal var _TIOCNXCL: CUnsignedLong { TIOCNXCL }
+
+@_alwaysEmitIntoClient
+internal var _TIOCGETD: CUnsignedLong { TIOCGETD }
+
+@_alwaysEmitIntoClient
+internal var _TIOCSETD: CUnsignedLong { TIOCSETD }
+
+

--- a/Sources/System/Internals/IOCTL.swift
+++ b/Sources/System/Internals/IOCTL.swift
@@ -1,0 +1,69 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+#if os(Linux)
+
+/// #define _IOC(dir,type,nr,size) \
+/// (((dir)  << _IOC_DIRSHIFT) | \
+/// ((type) << _IOC_TYPESHIFT) | \
+/// ((nr)   << _IOC_NRSHIFT) | \
+/// ((size) << _IOC_SIZESHIFT))
+@usableFromInline
+internal func _IOC(
+    _ direction: IODirection,
+    _ type: IOType,
+    _ nr: CInt,
+    _ size: CInt
+) -> CUnsignedLong {
+    
+    let dir = CInt(direction.rawValue)
+    let dirValue = dir << _DIRSHIFT
+    let typeValue = type.rawValue << _TYPESHIFT
+    let nrValue = nr << _NRSHIFT
+    let sizeValue = size << _SIZESHIFT
+    let value = CLong(dirValue | typeValue | nrValue | sizeValue)
+    return CUnsignedLong(bitPattern: value)
+}
+
+@_alwaysEmitIntoClient
+internal var _NRBITS: CInt       { CInt(8) }
+
+@_alwaysEmitIntoClient
+internal var _TYPEBITS: CInt     { CInt(8) }
+
+@_alwaysEmitIntoClient
+internal var _SIZEBITS: CInt     { CInt(14) }
+
+@_alwaysEmitIntoClient
+internal var _DIRBITS: CInt      { CInt(2) }
+
+@_alwaysEmitIntoClient
+internal var _NRMASK: CInt       { CInt((1 << _NRBITS)-1) }
+
+@_alwaysEmitIntoClient
+internal var _TYPEMASK: CInt     { CInt((1 << _TYPEBITS)-1) }
+
+@_alwaysEmitIntoClient
+internal var _SIZEMASK: CInt     { CInt((1 << _SIZEBITS)-1) }
+
+@_alwaysEmitIntoClient
+internal var _DIRMASK: CInt      { CInt((1 << _DIRBITS)-1) }
+
+@_alwaysEmitIntoClient
+internal var _NRSHIFT: CInt      { CInt(0) }
+
+@_alwaysEmitIntoClient
+internal var _TYPESHIFT: CInt    { CInt(_NRSHIFT+_NRBITS) }
+
+@_alwaysEmitIntoClient
+internal var _SIZESHIFT: CInt    { CInt(_TYPESHIFT+_TYPEBITS) }
+
+@_alwaysEmitIntoClient
+internal var _DIRSHIFT: CInt     { CInt(_SIZESHIFT+_SIZEBITS) }
+#endif

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -115,6 +115,42 @@ internal func system_dup2(_ fd: Int32, _ fd2: Int32) -> Int32 {
   #endif
   return dup2(fd, fd2)
 }
+
+// ioctl
+internal func system_ioctl(
+  _ fd: Int32,
+  _ request: CUnsignedLong
+) -> CInt {
+#if ENABLE_MOCKING
+  if mockingEnabled { return _mock(fd, request) }
+#endif
+  return ioctl(fd, request)
+}
+
+// ioctl
+internal func system_ioctl(
+  _ fd: Int32,
+  _ request: CUnsignedLong,
+  _ value: CInt
+) -> CInt {
+#if ENABLE_MOCKING
+  if mockingEnabled { return _mock(fd, request, value) }
+#endif
+  return ioctl(fd, request, value)
+}
+
+// ioctl
+internal func system_ioctl(
+  _ fd: Int32,
+  _ request: CUnsignedLong,
+  _ pointer: UnsafeMutableRawPointer
+) -> CInt {
+#if ENABLE_MOCKING
+  if mockingEnabled { return _mock(fd, request, pointer) }
+#endif
+  return ioctl(fd, request, pointer)
+}
+
 #if !os(Windows)
 internal func system_pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
 #if ENABLE_MOCKING


### PR DESCRIPTION
Added wrappers for interacting with `ioctl` on macOS and Linux.