### PR TITLE
Implement `FileDescriptor.memoryMap`, `FileDescriptor.memoryUnmap`, and `FileDescriptor.memorySync`

### DIFF
--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -441,6 +441,26 @@ internal var _ELAST: CInt { ELAST }
 
 // MARK: File Operations
 
+#if !os(Windows)
+@_alwaysEmitIntoClient
+internal var _MAP_SHARED: CInt { MAP_SHARED }
+
+@_alwaysEmitIntoClient
+internal var _MAP_PRIVATE: CInt { MAP_PRIVATE }
+
+@_alwaysEmitIntoClient
+internal var _MAP_FAILED: UnsafeMutableRawPointer { MAP_FAILED }
+
+@_alwaysEmitIntoClient
+internal var _MS_ASYNC: CInt { MS_ASYNC }
+
+@_alwaysEmitIntoClient
+internal var _MS_SYNC: CInt { MS_SYNC }
+
+@_alwaysEmitIntoClient
+internal var _MS_INVALIDATE: CInt { MS_INVALIDATE }
+#endif
+
 @_alwaysEmitIntoClient
 internal var _O_RDONLY: CInt { O_RDONLY }
 
@@ -510,6 +530,21 @@ internal var _O_SYMLINK: CInt { O_SYMLINK }
 #if !os(Windows)
 @_alwaysEmitIntoClient
 internal var _O_CLOEXEC: CInt { O_CLOEXEC }
+#endif
+
+// MARK: Mmap Protection
+#if !os(Windows)
+@_alwaysEmitIntoClient
+internal var _PROT_EXEC: CInt { PROT_EXEC }
+
+@_alwaysEmitIntoClient
+internal var _PROT_READ: CInt { PROT_READ }
+
+@_alwaysEmitIntoClient
+internal var _PROT_WRITE: CInt { PROT_WRITE }
+
+@_alwaysEmitIntoClient
+internal var _PROT_NONE: CInt { PROT_NONE }
 #endif
 
 @_alwaysEmitIntoClient

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -81,6 +81,42 @@ final class FileOperationsTest: XCTestCase {
         _ = try fd.duplicate(as: FileDescriptor(rawValue: 42),
                              retryOnInterrupt: retryOnInterrupt)
       },
+
+      MockTestCase(name: "mmap", .noInterrupt, rawFD, 1, PROT_NONE, MAP_SHARED, 0) { _ in
+        _ = try fd.memoryMap(length: 1, pageOffset: 0, kind: .shared, protection: [.none])
+      },
+
+      MockTestCase(name: "mmap", .noInterrupt, rawFD, 2, PROT_READ, MAP_PRIVATE, 1) { _ in
+        _ = try fd.memoryMap(length: 2, pageOffset: 1, kind: .private, protection: [.read])
+      },
+
+      MockTestCase(name: "mmap", .noInterrupt, rawFD, 2, PROT_READ | PROT_WRITE, MAP_PRIVATE, 1) { _ in
+        _ = try fd.memoryMap(length: 2, pageOffset: 1, kind: .private, protection: [.read, .write])
+      },
+
+      MockTestCase(name: "mmap", .noInterrupt, rawFD, 0, PROT_WRITE, MAP_PRIVATE, 1) { _ in
+        _ = try fd.memoryMap(length: 0, pageOffset: 1, kind: .private, protection: [.write])
+      },
+
+      MockTestCase(name: "munmap", .noInterrupt, rawBuf.baseAddress!, 42) { _ in
+        _ = try fd.memoryUnmap(memoryMap: rawBuf.baseAddress!, length: 42)
+      },
+
+      MockTestCase(name: "msync", .noInterrupt, rawBuf.baseAddress!, 42, MS_SYNC) { _ in
+        _ = try fd.memorySync(memoryMap: rawBuf.baseAddress!, length: 42, kind: .synchronous)
+      },
+
+      MockTestCase(name: "msync", .noInterrupt, rawBuf.baseAddress!, 42, MS_ASYNC) { _ in
+        _ = try fd.memorySync(memoryMap: rawBuf.baseAddress!, length: 42, kind: .asynchronous)
+      },
+
+      MockTestCase(name: "msync", .noInterrupt, rawBuf.baseAddress!, 42, MS_ASYNC & MS_INVALIDATE) { _ in
+        _ = try fd.memorySync(memoryMap: rawBuf.baseAddress!, length: 42, kind: .asynchronous, invalidateOtherMappings: true)
+      },
+
+      MockTestCase(name: "msync", .noInterrupt, rawBuf.baseAddress!, 42, MS_SYNC & MS_INVALIDATE) { _ in
+        _ = try fd.memorySync(memoryMap: rawBuf.baseAddress!, length: 42, kind: .synchronous, invalidateOtherMappings: true)
+      },
     ]
 
     for test in syscallTestCases { test.runAllTests() }
@@ -159,6 +195,80 @@ final class FileOperationsTest: XCTestCase {
     }
     issue26.runAllTests()
 
+  }
+
+  func testAdHocMmap() throws {
+    // Ad-hoc test for memory mapping a file.
+    let header = "swift"
+    let footer = "system"
+    do {
+      let fd = try FileDescriptor.open("/tmp/c.txt",
+                                       .readWrite,
+                                       options: [.create, .truncate],
+                                       permissions: .ownerReadWrite)
+
+      try fd.closeAfter {
+        // Write two pages of nil bytes to the file
+        try fd.writeAll(Data(count: sysconf(_SC_PAGESIZE) * 2))
+
+        // Map the first page with write protections
+        let ptr1page1 = try fd.memoryMap(length: header.count, pageOffset: 0, kind: .shared, protection: [.write])
+        let page1 = ptr1page1.assumingMemoryBound(to: String.self)
+        page1.pointee = header
+
+        // Create another map to page1
+        let ptr2page1 = try fd.memoryMap(length: header.count, pageOffset: 0, kind: .shared, protection: [.write])
+        XCTAssertEqual(ptr2page1.assumingMemoryBound(to: String.self).pointee, header)
+
+        // Map the second page with write protections
+        let ptr1page2 = try fd.memoryMap(length: footer.count, pageOffset: 1, kind: .shared, protection: [.write])
+        let page2 = ptr1page2.assumingMemoryBound(to: String.self)
+        page2.pointee = footer
+
+        // Create another map to page 2, asserting the data has been shared across the map
+        let ptr2page2 = try fd.memoryMap(length: footer.count, pageOffset: 1, kind: .shared, protection: [.write])
+        XCTAssertEqual(ptr2page2.assumingMemoryBound(to: String.self).pointee, footer)
+
+        // Create a *private* mapping to page 2
+        let ptr2page2private = try fd.memoryMap(length: footer.count,
+                                                pageOffset: 1,
+                                                kind: .private,
+                                                protection: [.write])
+        // Write to the private mapping so that the header is in place of the footer
+        let page2private = ptr2page2private.assumingMemoryBound(to: String.self)
+        page2private.pointee = header
+
+        // Assert that the shared mappings are still correct and unaffected by the private mapping
+        XCTAssertEqual(ptr2page1.assumingMemoryBound(to: String.self).pointee, header)
+        XCTAssertEqual(ptr2page2.assumingMemoryBound(to: String.self).pointee, footer)
+
+        // Flush changes to the filesystem
+        try fd.memorySync(memoryMap: ptr1page1, length: header.count, kind: .synchronous)
+        try fd.memorySync(memoryMap: ptr1page2, length: footer.count, kind: .synchronous)
+
+        // Seek to the start of the file, as writing to it will have moved our offset
+        try fd.seek(offset: 0, from: .start)
+        let readBytes = try Array<CChar>(unsafeUninitializedCapacity: sysconf(_SC_PAGESIZE) * 2) { (buf, count) in
+          count = try fd.read(into: UnsafeMutableRawBufferPointer(buf))
+        }
+        // Assert the header and footer are correctly in place
+        XCTAssertEqual(String(validatingPlatformString: readBytes), header)
+        let readFooter = [CChar](readBytes[sysconf(_SC_PAGESIZE)..<sysconf(_SC_PAGESIZE) + footer.count + 1])
+        XCTAssertEqual(String(validatingPlatformString: readFooter), footer)
+
+        try fd.memoryUnmap(memoryMap: ptr1page1, length: sysconf(_SC_PAGESIZE))
+        try fd.memoryUnmap(memoryMap: ptr2page1, length: sysconf(_SC_PAGESIZE))
+        try fd.memoryUnmap(memoryMap: ptr1page2, length: sysconf(_SC_PAGESIZE))
+        try fd.memoryUnmap(memoryMap: ptr2page2, length: sysconf(_SC_PAGESIZE))
+        try fd.memoryUnmap(memoryMap: page2private, length: sysconf(_SC_PAGESIZE))
+        // Nothing to check here. accessing the underlying memory will result in a SIGSEGV
+      }
+    } catch let err as Errno {
+      print("caught \(err))")
+      XCTAssert(false)
+    } catch {
+      fatalError("FATAL: `testAdHocMmap`")
+    }
   }
 }
 


### PR DESCRIPTION
Add Swift implementations for [`mmap`](https://man7.org/linux/man-pages/man2/mmap.2.html), [`munmap`](https://man7.org/linux/man-pages/man2/mmap.2.html), and [`msync`](https://man7.org/linux/man-pages/man2/msync.2.html):
```swift
let swiftString = "swift"
let map = try fd.memoryMap(length: swiftString.count, pageOffset: 0, kind: .shared, protection: [.write])
let ptr = map.assumingMemoryBound(to: String.self)
// Update the mapping
ptr.pointee = swiftString
// Flush changes to the file system
try fd.memorySync(memoryMap: map, length: swiftString.count, kind: .synchronous)
// Delete the mapping
try fd.memoryUnmap(memoryMap: map, length: swiftString.count)

// Read in the file and validate the string was written correctly
let readBytes = try Array<CChar>(unsafeUninitializedCapacity: swiftString.count + 1) { (buf, count) in
    count = try fd.read(into: UnsafeMutableRawBufferPointer(buf))
}
XCTAssertEqual(String(validatingPlatformString: readBytes), swiftString)
```
This PR adds all three methods because the ability to sync and delete mappings are sensible requirements of being able to create them.

Add `FileDescriptor.MemoryProtection` to describe the desired memory protection of a mapping. The `memoryMap` method accepts these values as an array to be bitwise OR'd by the implementation. 

Add `shared` and `private` for `FileDescriptor.MemoryMapKind`. There are more C flags available, but this seemed like the simplest starting point.

Add `synchronous` and `asynchronous` `FileDescriptor.MemorySyncKind`. The `memorySync` method accepts either one of these values and an `invalidateOtherMappings` boolean that is bitwise AND'd in the implementation to represent the appropriate C flag.

Add internal constants for flags/values related to `mmap`, `munmap`, and `msync`.

Add additional methods for more generic mocking and error handling. This seemed like a good addition for system calls that do not return `CInt`.

This PR does not include a Windows implementation.