### PR TITLE
Implement FilePath.getCurrentWorkingDirectory()

### DIFF
--- a/Sources/System/FilePath/FilePath.swift
+++ b/Sources/System/FilePath/FilePath.swift
@@ -62,6 +62,16 @@ public struct FilePath {
 
 // @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 extension FilePath {
+  
+  /// Returns the current working directory of this process
+  public static func getCurrentWorkingDirectory() throws -> FilePath {
+    guard let cwd = system_getcwd(nil, 0) else {
+      throw Errno.current
+    }
+    defer { system_free(cwd) }
+    return FilePath(platformString: cwd)
+  }
+  
   /// The length of the file path, excluding the null terminator.
   public var length: Int { _storage.length }
 }

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -123,3 +123,24 @@ internal func system_pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
   return pipe(fds)
 }
 #endif
+
+#if !os(Windows)
+internal func system_getcwd(_ buf: UnsafeMutablePointer<CInterop.PlatformChar>?, _ size: size_t) -> UnsafeMutablePointer<CInterop.PlatformChar>? {
+#if ENABLE_MOCKING
+  if mockingEnabled {
+    /// I'm not really sure how to mock this since `buf` is passed in uninitialized and it needs to return something
+    fatalError()
+  }
+#endif
+  return getcwd(buf, size)
+}
+#endif
+
+#if !os(Windows)
+internal func system_free(_ ptr: UnsafeMutableRawPointer?) {
+#if ENABLE_MOCKING
+  if mockingEnabled { _ = _mock(ptr) }
+#endif
+  free(ptr)
+}
+#endif

--- a/Tests/SystemTests/FilePathTests/FilePathTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTest.swift
@@ -72,5 +72,11 @@ final class FilePathTest: XCTestCase {
       }
     }
   }
+  
+  func testCurrentWorkingDirectory() {
+    XCTAssertEqual(
+      try FilePath.getCurrentWorkingDirectory().string,
+      FileManager.default.currentDirectoryPath)
+  }
 }
 


### PR DESCRIPTION
I'm not sure how to mock `system_getcwd`, but otherwise this works. We may eventually want to have a stack-allocated buffer of PATH_MAX size so we don't do two allocations, but I don't think we can achieve this in present-day Swift.