### PR TITLE
update cmake setup so that the library can be used by SwiftPM cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 cmake_minimum_required(VERSION 3.16.0)
-project(swift-system
+project(SwiftSystem
   LANGUAGES C Swift)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
@@ -21,9 +21,4 @@ set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 include(SwiftSupport)
 
 add_subdirectory(Sources)
-
-get_property(SWIFT_SYSTEM_EXPORTS GLOBAL PROPERTY SWIFT_SYSTEM_EXPORTS)
-export(TARGETS ${SWIFT_SYSTEM_EXPORTS}
-  NAMESPACE SwiftSystem::
-  FILE swift-system-config.cmake
-  EXPORT_LINK_INTERFACE_LIBRARIES)
+add_subdirectory(cmake/modules)

--- a/Sources/System/CMakeLists.txt
+++ b/Sources/System/CMakeLists.txt
@@ -7,7 +7,7 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 See https://swift.org/LICENSE.txt for license information
 #]]
 
-add_library(System
+add_library(SystemPackage
   Errno.swift
   FileDescriptor.swift
   FileHelpers.swift
@@ -17,7 +17,9 @@ add_library(System
   SystemString.swift
   Util.swift
   UtilConsumers.swift)
-target_sources(System PRIVATE
+set_target_properties(SystemPackage PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_sources(SystemPackage PRIVATE
   FilePath/FilePath.swift
   FilePath/FilePathComponents.swift
   FilePath/FilePathComponentView.swift
@@ -25,16 +27,16 @@ target_sources(System PRIVATE
   FilePath/FilePathString.swift
   FilePath/FilePathSyntax.swift
   FilePath/FilePathWindows.swift)
-target_sources(System PRIVATE
+target_sources(SystemPackage PRIVATE
   Internals/CInterop.swift
   Internals/Constants.swift
   Internals/Exports.swift
   Internals/Mocking.swift
   Internals/Syscalls.swift
   Internals/WindowsSyscallAdapters.swift)
-target_link_libraries(System PRIVATE
+target_link_libraries(SystemPackage PRIVATE
   CSystem)
 
 
-_install_target(System)
-set_property(GLOBAL APPEND PROPERTY SWIFT_SYSTEM_EXPORTS System)
+_install_target(SystemPackage)
+set_property(GLOBAL APPEND PROPERTY SWIFT_SYSTEM_EXPORTS SystemPackage)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,19 @@
+#[[
+This source file is part of the Swift System open source Project
+
+Copyright (c) 2021 Apple Inc. and the Swift System project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+set(SWIFT_SYSTEM_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/SwiftSystemExports.cmake)
+
+configure_file(SwiftSystemConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/SwiftSystemConfig.cmake)
+
+get_property(SWIFT_SYSTEM_EXPORTS GLOBAL PROPERTY SWIFT_SYSTEM_EXPORTS)
+export(TARGETS ${SWIFT_SYSTEM_EXPORTS}
+  NAMESPACE SwiftSystem::
+  FILE ${SWIFT_SYSTEM_EXPORTS_FILE}
+  EXPORT_LINK_INTERFACE_LIBRARIES)

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,5 +1,5 @@
 #[[
-This source file is part of the Swift System open source project
+This source file is part of the Swift System open source Project
 
 Copyright (c) 2020 Apple Inc. and the Swift System project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
@@ -17,8 +17,12 @@ See https://swift.org/LICENSE.txt for license information
 function(get_swift_host_arch result_var_name)
   if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     set("${result_var_name}" "x86_64" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
-    set("${result_var_name}" "aarch64" PARENT_SCOPE)
+  elseif ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AArch64|aarch64|arm64")
+    if(CMAKE_SYSTEM_NAME MATCHES Darwin)
+      set("${result_var_name}" "arm64" PARENT_SCOPE)
+    else()
+      set("${result_var_name}" "aarch64" PARENT_SCOPE)
+    endif()
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
     set("${result_var_name}" "powerpc64" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
@@ -31,6 +35,8 @@ function(get_swift_host_arch result_var_name)
     set("${result_var_name}" "armv7" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
     set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "amd64")
+    set("${result_var_name}" "amd64" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
     set("${result_var_name}" "x86_64" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,5 +1,5 @@
 #[[
-This source file is part of the Swift System open source Project
+This source file is part of the Swift System open source project
 
 Copyright (c) 2020 Apple Inc. and the Swift System project authors
 Licensed under Apache License v2.0 with Runtime Library Exception

--- a/cmake/modules/SwiftSystemConfig.cmake.in
+++ b/cmake/modules/SwiftSystemConfig.cmake.in
@@ -1,0 +1,12 @@
+#[[
+This source file is part of the Swift System open source Project
+
+Copyright (c) 2021 Apple Inc. and the Swift System project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+if(NOT TARGET SwiftSystem)
+  include(@SWIFT_SYSTEM_EXPORTS_FILE@)
+endif()

--- a/cmake/modules/SwiftSystemConfig.cmake.in
+++ b/cmake/modules/SwiftSystemConfig.cmake.in
@@ -7,6 +7,6 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 See https://swift.org/LICENSE.txt for license information
 #]]
 
-if(NOT TARGET SwiftSystem)
+if(NOT TARGET SystemPackage)
   include(@SWIFT_SYSTEM_EXPORTS_FILE@)
 endif()


### PR DESCRIPTION
motivation: integrate with SwiftPM

changes:
* rename the top level project to SwiftSystem instead of swift-system to align with other projects
* rename System to SystemPackage to align with SwifPM setup
* update architectures to include arm64