### PR TITLE
build: install CSystem into the system

### DIFF
--- a/Sources/CSystem/CMakeLists.txt
+++ b/Sources/CSystem/CMakeLists.txt
@@ -12,4 +12,9 @@ target_include_directories(CSystem INTERFACE
   include)
 
 
+install(FILES
+  include/CSystemLinux.h
+  include/CSystemWindows.h
+  include/module.modulemap
+  DESTINATION include/CSystem)
 set_property(GLOBAL APPEND PROPERTY SWIFT_SYSTEM_EXPORTS CSystem)

--- a/Sources/System/CMakeLists.txt
+++ b/Sources/System/CMakeLists.txt
@@ -34,7 +34,7 @@ target_sources(SystemPackage PRIVATE
   Internals/Mocking.swift
   Internals/Syscalls.swift
   Internals/WindowsSyscallAdapters.swift)
-target_link_libraries(SystemPackage PRIVATE
+target_link_libraries(SystemPackage PUBLIC
   CSystem)
 
 


### PR DESCRIPTION
CSystem is a leaky library dependency from System and must be
distributed.  Install the files and make the dependency public so that
it is emitted into the clients.