### PR TITLE
Unify availability annotations & introduce a script to manage them

### DIFF
--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -10,7 +10,7 @@
 /// An error number used by system calls to communicate what kind of error
 /// occurred.
 @frozen
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 public struct Errno: RawRepresentable, Error, Hashable, Codable {
   /// The raw C error number.
   @_alwaysEmitIntoClient
@@ -1376,7 +1376,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
 }
 
 // Constants defined in header but not man page
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension Errno {
 
   /// Operation would block.
@@ -1470,7 +1470,7 @@ extension Errno {
 #endif
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension Errno {
   // TODO: We want to provide safe access to `errno`, but we need a
   // release-barrier to do so.
@@ -1485,14 +1485,14 @@ extension Errno {
 }
 
 // Use "hidden" entry points for `NSError` bridging
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension Errno {
   public var _code: Int { Int(rawValue) }
 
   public var _domain: String { "NSPOSIXErrorDomain" }
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension Errno: CustomStringConvertible, CustomDebugStringConvertible {
   ///  A textual representation of the most recent error
   ///  returned by a system call.
@@ -1512,7 +1512,7 @@ extension Errno: CustomStringConvertible, CustomDebugStringConvertible {
   public var debugDescription: String { self.description }
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension Errno {
   @_alwaysEmitIntoClient
   public static func ~=(_ lhs: Errno, _ rhs: Error) -> Bool {

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -14,7 +14,7 @@
 /// of `FileDescriptor` values,
 /// in the same way as you manage a raw C file handle.
 @frozen
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 public struct FileDescriptor: RawRepresentable, Hashable, Codable {
   /// The raw C file handle.
   @_alwaysEmitIntoClient
@@ -40,7 +40,7 @@ extension FileDescriptor {
   public static var standardError: FileDescriptor { .init(rawValue: 2) }
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FileDescriptor {
   /// The desired read and write access for a newly opened file.
   @frozen
@@ -385,7 +385,7 @@ extension FileDescriptor {
   }
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FileDescriptor.AccessMode
   : CustomStringConvertible, CustomDebugStringConvertible
 {
@@ -404,7 +404,7 @@ extension FileDescriptor.AccessMode
   public var debugDescription: String { self.description }
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FileDescriptor.SeekOrigin
   : CustomStringConvertible, CustomDebugStringConvertible
 {
@@ -427,7 +427,7 @@ extension FileDescriptor.SeekOrigin
   public var debugDescription: String { self.description }
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FileDescriptor.OpenOptions
   : CustomStringConvertible, CustomDebugStringConvertible
 {

--- a/Sources/System/FileHelpers.swift
+++ b/Sources/System/FileHelpers.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FileDescriptor {
   /// Runs a closure and then closes the file descriptor, even if an error occurs.
   ///

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FileDescriptor {
   /// Opens or creates a file for reading or writing.
   ///
@@ -337,7 +337,7 @@ extension FileDescriptor {
   ///
   /// The corresponding C functions are `dup` and `dup2`.
   @_alwaysEmitIntoClient
-  // @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  /*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
   public func duplicate(
     as target: FileDescriptor? = nil,
     retryOnInterrupt: Bool = true
@@ -345,7 +345,7 @@ extension FileDescriptor {
     try _duplicate(as: target, retryOnInterrupt: retryOnInterrupt).get()
   }
 
-  // @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  /*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
   @usableFromInline
   internal func _duplicate(
     as target: FileDescriptor?,
@@ -370,7 +370,10 @@ extension FileDescriptor {
   public func dup2() throws -> FileDescriptor {
     fatalError("Not implemented")
   }
-  
+}
+
+/*System 1.1.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
+extension FileDescriptor {
   #if !os(Windows)
   /// Create a pipe, a unidirectional data channel which can be used for interprocess communication.
   ///
@@ -378,11 +381,12 @@ extension FileDescriptor {
   ///
   /// The corresponding C function is `pipe`.
   @_alwaysEmitIntoClient
-  // @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  /*System 1.1.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
   public static func pipe() throws -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
     try _pipe().get()
   }
   
+  /*System 1.1.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
   @usableFromInline
   internal static func _pipe() -> Result<(readEnd: FileDescriptor, writeEnd: FileDescriptor), Errno> {
     var fds: (Int32, Int32) = (-1, -1)

--- a/Sources/System/FilePath/FilePath.swift
+++ b/Sources/System/FilePath/FilePath.swift
@@ -40,7 +40,7 @@
 ///
 // TODO(docs): Section on all the new syntactic operations, lexical normalization, decomposition,
 // components, etc.
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 public struct FilePath {
   internal var _storage: SystemString
 
@@ -60,12 +60,12 @@ public struct FilePath {
   }
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath {
   /// The length of the file path, excluding the null terminator.
   public var length: Int { _storage.length }
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath: Hashable, Codable {}
 

--- a/Sources/System/FilePath/FilePathComponentView.swift
+++ b/Sources/System/FilePath/FilePathComponentView.swift
@@ -9,7 +9,7 @@
 
 // MARK: - API
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// A bidirectional, range replaceable collection of the non-root components
   /// that make up a file path.
@@ -89,7 +89,7 @@ extension FilePath {
   #endif
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.ComponentView: BidirectionalCollection {
   public typealias Element = FilePath.Component
   public struct Index: Comparable, Hashable {
@@ -123,7 +123,7 @@ extension FilePath.ComponentView: BidirectionalCollection {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.ComponentView: RangeReplaceableCollection {
   public init() {
     self.init(FilePath())
@@ -173,7 +173,7 @@ extension FilePath.ComponentView: RangeReplaceableCollection {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// Create a file path from a root and a collection of components.
   public init<C: Collection>(

--- a/Sources/System/FilePath/FilePathComponents.swift
+++ b/Sources/System/FilePath/FilePathComponents.swift
@@ -9,7 +9,7 @@
 
 // MARK: - API
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// Represents a root of a file path.
   ///
@@ -73,7 +73,7 @@ extension FilePath {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Component {
 
   /// Whether a component is a regular file or directory name, or a special

--- a/Sources/System/FilePath/FilePathString.swift
+++ b/Sources/System/FilePath/FilePathString.swift
@@ -9,7 +9,7 @@
 
 // MARK: - Platform string
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// Creates a file path by copying bytes from a null-terminated platform
   /// string.
@@ -45,7 +45,7 @@ extension FilePath {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Component {
   /// Creates a file path component by copying bytes from a null-terminated
   /// platform string.
@@ -82,7 +82,7 @@ extension FilePath.Component {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Root {
   /// Creates a file path root by copying bytes from a null-terminated platform
   /// string.
@@ -120,7 +120,7 @@ extension FilePath.Root {
 
 // MARK: - String literals
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath: ExpressibleByStringLiteral {
   /// Creates a file path from a string literal.
   ///
@@ -139,7 +139,7 @@ extension FilePath: ExpressibleByStringLiteral {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Component: ExpressibleByStringLiteral {
   /// Create a file path component from a string literal.
   ///
@@ -164,7 +164,7 @@ extension FilePath.Component: ExpressibleByStringLiteral {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Root: ExpressibleByStringLiteral {
   /// Create a file path root from a string literal.
   ///
@@ -189,7 +189,7 @@ extension FilePath.Root: ExpressibleByStringLiteral {
 
 // MARK: - Printing and dumping
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the file path.
   ///
@@ -205,7 +205,7 @@ extension FilePath: CustomStringConvertible, CustomDebugStringConvertible {
   public var debugDescription: String { description.debugDescription }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Component: CustomStringConvertible, CustomDebugStringConvertible {
 
   /// A textual representation of the path component.
@@ -222,7 +222,7 @@ extension FilePath.Component: CustomStringConvertible, CustomDebugStringConverti
   public var debugDescription: String { description.debugDescription }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Root: CustomStringConvertible, CustomDebugStringConvertible {
 
   /// A textual representation of the path root.
@@ -242,7 +242,7 @@ extension FilePath.Root: CustomStringConvertible, CustomDebugStringConvertible {
 // MARK: - Convenience helpers
 
 // Convenience helpers
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// Creates a string by interpreting the path’s content as UTF-8 on Unix
   /// and UTF-16 on Windows.
@@ -253,7 +253,7 @@ extension FilePath {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Component {
   /// Creates a string by interpreting the component’s content as UTF-8 on Unix
   /// and UTF-16 on Windows.
@@ -264,7 +264,7 @@ extension FilePath.Component {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Root {
   /// On Unix, this returns `"/"`.
   ///
@@ -278,7 +278,7 @@ extension FilePath.Root {
 
 // MARK: - Decoding and validating
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension String {
   /// Creates a string by interpreting the file path's content as UTF-8 on Unix
   /// and UTF-16 on Windows.
@@ -308,7 +308,7 @@ extension String {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension String {
   /// Creates a string by interpreting the path component's content as UTF-8 on
   /// Unix and UTF-16 on Windows.
@@ -338,7 +338,7 @@ extension String {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension String {
   /// On Unix, creates the string `"/"`
   ///
@@ -391,7 +391,7 @@ extension String {
 
 // MARK: - Deprecations
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension String {
   @available(*, deprecated, renamed: "init(decoding:)")
   public init(_ path: FilePath) { self.init(decoding: path) }
@@ -401,7 +401,7 @@ extension String {
 }
 
 #if !os(Windows)
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath {
   /// For backwards compatibility only. This initializer is equivalent to
   /// the preferred `FilePath(platformString:)`.

--- a/Sources/System/FilePath/FilePathSyntax.swift
+++ b/Sources/System/FilePath/FilePathSyntax.swift
@@ -9,7 +9,7 @@
 
 // MARK: - Query API
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// Returns true if this path uniquely identifies the location of
   /// a file without reference to an additional starting location.
@@ -101,7 +101,7 @@ extension FilePath {
 }
 
 // MARK: - Decompose a path
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// Returns the root of a path if there is one, otherwise `nil`.
   ///
@@ -186,7 +186,7 @@ extension FilePath {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// Returns the final component of the path.
   /// Returns `nil` if the path is empty or only contains a root.
@@ -258,7 +258,7 @@ extension FilePath {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Component {
   /// The extension of this file or directory component.
   ///
@@ -291,7 +291,7 @@ extension FilePath.Component {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
 
   /// The extension of the file or directory last component.
@@ -358,7 +358,7 @@ extension FilePath {
 
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// Whether the path is in lexical-normal form, that is `.` and `..`
   /// components have been collapsed lexically (i.e. without following
@@ -439,7 +439,7 @@ extension FilePath {
 }
 
 // Modification and concatenation API
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// If `prefix` is a prefix of `self`, removes it and returns `true`.
   /// Otherwise returns `false`.
@@ -601,7 +601,7 @@ extension FilePath {
 }
 
 // MARK - Renamed
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   @available(*, unavailable, renamed: "removingLastComponent()")
   public var dirname: FilePath { removingLastComponent() }

--- a/Sources/System/FilePermissions.swift
+++ b/Sources/System/FilePermissions.swift
@@ -17,7 +17,7 @@
 ///     let perms = FilePermissions(rawValue: 0o644)
 ///     perms == [.ownerReadWrite, .groupRead, .otherRead] // true
 @frozen
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 public struct FilePermissions: OptionSet, Hashable, Codable {
   /// The raw C file permissions.
   @_alwaysEmitIntoClient
@@ -135,7 +135,7 @@ public struct FilePermissions: OptionSet, Hashable, Codable {
   public static var saveText: FilePermissions { FilePermissions(0o1000) }
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePermissions
   : CustomStringConvertible, CustomDebugStringConvertible
 {

--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -10,7 +10,7 @@
 // MARK: - Public typealiases
 
 /// The C `mode_t` type.
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 @available(*, deprecated, renamed: "CInterop.Mode")
 public typealias CModeT =  CInterop.Mode
 
@@ -27,7 +27,7 @@ import ucrt
 #endif
 
 /// A namespace for C and platform types
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 public enum CInterop {
 #if os(Windows)
   public typealias Mode = CInt

--- a/Sources/System/PlatformString.swift
+++ b/Sources/System/PlatformString.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension String {
   /// Creates a string by interpreting the null-terminated platform string as
   /// UTF-8 on Unix and UTF-16 on Windows.

--- a/Sources/System/Util.swift
+++ b/Sources/System/Util.swift
@@ -8,21 +8,21 @@
 */
 
 // Results in errno if i == -1
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 private func valueOrErrno<I: FixedWidthInteger>(
   _ i: I
 ) -> Result<I, Errno> {
   i == -1 ? .failure(Errno.current) : .success(i)
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 private func nothingOrErrno<I: FixedWidthInteger>(
   _ i: I
 ) -> Result<(), Errno> {
   valueOrErrno(i).map { _ in () }
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 internal func valueOrErrno<I: FixedWidthInteger>(
   retryOnInterrupt: Bool, _ f: () -> I
 ) -> Result<I, Errno> {
@@ -36,7 +36,7 @@ internal func valueOrErrno<I: FixedWidthInteger>(
   } while true
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 internal func nothingOrErrno<I: FixedWidthInteger>(
   retryOnInterrupt: Bool, _ f: () -> I
 ) -> Result<(), Errno> {

--- a/Tests/SystemTests/ErrnoTest.swift
+++ b/Tests/SystemTests/ErrnoTest.swift
@@ -15,7 +15,7 @@ import SystemPackage
 import System
 #endif
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 final class ErrnoTest: XCTestCase {
   func testConstants() {
     XCTAssert(EPERM == Errno.notPermitted.rawValue)

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -15,7 +15,7 @@ import SystemPackage
 import System
 #endif
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 final class FileOperationsTest: XCTestCase {
   func testSyscalls() {
     let fd = FileDescriptor(rawValue: 1)

--- a/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
@@ -15,7 +15,7 @@ import XCTest
 @testable import System
 #endif
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 struct TestPathComponents: TestCase {
   var path: FilePath
   var expectedRoot: FilePath.Root?
@@ -100,7 +100,7 @@ struct TestPathComponents: TestCase {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 final class FilePathComponentsTest: XCTestCase {
   func testAdHocRRC() {
     var path: FilePath = "/usr/local/bin"

--- a/Tests/SystemTests/FilePathTests/FilePathExtras.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathExtras.swift
@@ -6,7 +6,7 @@
 #endif
 
 // Why can't I write this extension on `FilePath.ComponentView.SubSequence`?
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension Slice where Base == FilePath.ComponentView {
   internal var _storageSlice: SystemString.SubSequence {
     base._path._storage[self.startIndex._storage ..< self.endIndex._storage]
@@ -15,7 +15,7 @@ extension Slice where Base == FilePath.ComponentView {
 
 
 // Proposed API that didn't make the cut, but we stil want to keep our testing for
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath {
   /// Returns `self` relative to `base`.
   /// This does not cosult the file system or resolve symlinks.

--- a/Tests/SystemTests/FilePathTests/FilePathParsingTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathParsingTest.swift
@@ -68,7 +68,7 @@ extension ParsingTestCase {
 @testable import System
 #endif
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 final class FilePathParsingTest: XCTestCase {
   func testNormalization() {
     let unixPaths: Array<ParsingTestCase> = [

--- a/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
@@ -146,7 +146,7 @@ extension SyntaxTestCase {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension SyntaxTestCase {
   func testComponents(_ path: FilePath, expected: [String]) {
     let expectedComponents = expected.map { FilePath.Component($0)! }
@@ -342,7 +342,7 @@ private struct WindowsRootTestCase: TestCase {
   var line: UInt
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension WindowsRootTestCase {
   func runAllTests() {
     withWindowsPaths(enabled: true) {
@@ -357,7 +357,7 @@ extension WindowsRootTestCase {
   }
 }
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 final class FilePathSyntaxTest: XCTestCase {
   func testPathSyntax() {
     let unixPaths: Array<SyntaxTestCase> = [

--- a/Tests/SystemTests/FilePathTests/FilePathTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTest.swift
@@ -15,7 +15,7 @@ import SystemPackage
 import System
 #endif
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 func filePathFromUnterminatedBytes<S: Sequence>(_ bytes: S) -> FilePath where S.Element == UInt8 {
   var array = Array(bytes)
   assert(array.last != 0, "already null terminated")
@@ -27,7 +27,7 @@ func filePathFromUnterminatedBytes<S: Sequence>(_ bytes: S) -> FilePath where S.
 }
 let invalidBytes: [UInt8] = [0x2F, 0x61, 0x2F, 0x62, 0x2F, 0x83]
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 final class FilePathTest: XCTestCase {
   struct TestPath {
     let filePath: FilePath

--- a/Tests/SystemTests/FileTypesTest.swift
+++ b/Tests/SystemTests/FileTypesTest.swift
@@ -15,7 +15,7 @@ import SystemPackage
 import System
 #endif
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 final class FileDescriptorTest: XCTestCase {
   func testStandardDescriptors() {
     XCTAssertEqual(FileDescriptor.standardInput.rawValue, 0)
@@ -60,7 +60,7 @@ final class FileDescriptorTest: XCTestCase {
 
 }
 
-// @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 final class FilePermissionsTest: XCTestCase {
 
   func testPermissions() {

--- a/Tests/SystemTests/MockingTest.swift
+++ b/Tests/SystemTests/MockingTest.swift
@@ -15,7 +15,7 @@ import XCTest
 @testable import System
 #endif
 
-// @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 final class MockingTest: XCTestCase {
   func testMocking() {
     XCTAssertFalse(mockingEnabled)

--- a/Utilities/expand-availability.py
+++ b/Utilities/expand-availability.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
-# This script uses the file `availability-macros.def` to automatically
-# add/remove `@available` attributes to declarations in Swift sources
-# in this package.
+# This script can be used to automatically add/remove `@available` attributes to
+# declarations in Swift sources in this package.
 #
 # In order for this to work, ABI-impacting declarations need to be annotated
 # with special comments in the following format:
@@ -34,9 +33,8 @@
 #       "Hello"
 #     }
 #
-# The script recognizes these attributes and updates/removes them on each run,
-# so you can run the script to enable/disable attributes without worrying about
-# duplicate attributes.
+# The script recognizes all three forms of these annotations and updates them on
+# every run, so we can run the script to enable/disable attributes as needed.
 
 import os
 import os.path

--- a/Utilities/expand-availability.py
+++ b/Utilities/expand-availability.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# This script uses the file `availability-macros.def` to automatically
+# add/remove `@available` attributes to declarations in Swift sources
+# in this package.
+#
+# In order for this to work, ABI-impacting declarations need to be annotated
+# with special comments in the following format:
+#
+#     /*System 0.0.2*/
+#     public func greeting() -> String {
+#       "Hello"
+#     }
+#
+# The script adds full availability incantations to these comments. It can run
+# in one of two modes:
+#
+# By default, `expand-availability.py` expands availability macros within the
+# comments. This is useful during package development to cross-reference
+# availability across `SystemPackage` and the ABI-stable `System` module that
+# ships in Apple's OS releases:
+#
+#     /*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+#     public func greeting() -> String {
+#       "Hello"
+#     }
+#
+# `expand-availability.py --attributes` adds actual availability attributes.
+# This is used by maintainers to build ABI stable releases of System on Apple's
+# platforms:
+#
+#     /*System 0.0.2*/@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+#     public func greeting() -> String {
+#       "Hello"
+#     }
+#
+# The script recognizes these attributes and updates/removes them on each run,
+# so you can run the script to enable/disable attributes without worrying about
+# duplicate attributes.
+
+import os
+import os.path
+import fileinput
+import re
+import sys
+import argparse
+
+versions = {
+    "System 0.0.1": "macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0",
+    "System 0.0.2": "macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0",
+    "System 1.1.0": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
+}
+
+parser = argparse.ArgumentParser(description="Expand availability macros.")
+parser.add_argument("--attributes", help="Add @available attributes",
+                    action="store_true")
+args = parser.parse_args()
+
+def swift_sources_in(path):
+    result = []
+    for (dir, _, files) in os.walk(path):
+        for file in files:
+            extension = os.path.splitext(file)[1]
+            if extension == ".swift":
+                result.append(os.path.join(dir, file))
+    return result
+
+macro_pattern = re.compile(
+    r"/\*(System [^ *]+)(, @available\([^)]*\))?\*/(@available\([^)]*\))?")
+
+sources = swift_sources_in("Sources") + swift_sources_in("Tests")
+for line in fileinput.input(files=sources, inplace=True):
+    match = re.search(macro_pattern, line)
+    if match:
+        system_version = match.group(1)
+        expansion = versions[system_version]
+        if expansion is None:
+            raise ValueError("{0}:{1}: error: Unknown System version '{0}'"
+                             .format(fileinput.filename(), fileinput.lineno(),
+                                     system_version))
+        if args.attributes:
+            replacement = "/*{0}*/@available({1}, *)".format(system_version, expansion)
+        else:
+            replacement = "/*{0}, @available({1}, *)*/".format(system_version, expansion)
+        line = line[:match.start()] + replacement + line[match.end():]
+    print(line, end="")


### PR DESCRIPTION
Instead of spelling out availability incantations, contributors can now specify availability annotations using special comments that mention the swift-system version that will introduce the entry point:

```swift
/*System 0.0.2*/
public func greeting() -> String {
  "Hello"
}
```

The new script `Utilities/expand-availability.py` can then be used to augment these comments with the ABI-stable OS versions that introduced these:

```swift
/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
public func greeting() -> String {
  "Hello"
}
```

(The script updates these expansions every time it runs.)

When the script is run with the option `--attributes`, it instead adds the availability incantation as an actual availability attribute:

```swift
/*System 0.0.2*/@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
public func greeting() -> String {
  "Hello"
}
```

This can be used by package maintainers to generate the ABI stable variant of swift-system that ships in Apple's OS distributions.

The script recognizes all three forms of these annotations and updates them on every run, so we can run the script to enable/disable attributes as needed.
