### PR TITLE
Update package with changes from recent ABI stable releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 /.build
 /Packages
-/*.xcodeproj
+swift-system.xcodeproj
 xcuserdata/
 .*.sw?

--- a/Sources/System/CMakeLists.txt
+++ b/Sources/System/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(SystemPackage PRIVATE
   FilePath/FilePathSyntax.swift
   FilePath/FilePathWindows.swift)
 target_sources(SystemPackage PRIVATE
+  Internals/Backcompat.swift
   Internals/CInterop.swift
   Internals/Constants.swift
   Internals/Exports.swift

--- a/Sources/System/CMakeLists.txt
+++ b/Sources/System/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(SystemPackage
   PlatformString.swift
   SystemString.swift
   Util.swift
+  Util+StringArray.swift
   UtilConsumers.swift)
 set_target_properties(SystemPackage PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
@@ -32,6 +33,7 @@ target_sources(SystemPackage PRIVATE
   Internals/Constants.swift
   Internals/Exports.swift
   Internals/Mocking.swift
+  Internals/RawBuffer.swift
   Internals/Syscalls.swift
   Internals/WindowsSyscallAdapters.swift)
 target_link_libraries(SystemPackage PUBLIC

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -25,7 +25,8 @@ public struct FileDescriptor: RawRepresentable, Hashable, Codable {
   public init(rawValue: CInt) { self.rawValue = rawValue }
 }
 
-// Standard file descriptors
+// Standard file descriptors.
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FileDescriptor {
   /// The standard input file descriptor, with a numeric value of 0.
   @_alwaysEmitIntoClient

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -31,7 +31,7 @@ extension FileDescriptor {
     permissions: FilePermissions? = nil,
     retryOnInterrupt: Bool = true
   ) throws -> FileDescriptor {
-    try path.withPlatformString {
+    try path.withCString {
       try FileDescriptor.open(
         $0, mode, options: options, permissions: permissions, retryOnInterrupt: retryOnInterrupt)
     }
@@ -53,7 +53,7 @@ extension FileDescriptor {
   /// The corresponding C function is `open`.
   @_alwaysEmitIntoClient
   public static func open(
-    _ path: UnsafePointer<CInterop.PlatformChar>,
+    _ path: UnsafePointer<CChar>,
     _ mode: FileDescriptor.AccessMode,
     options: FileDescriptor.OpenOptions = FileDescriptor.OpenOptions(),
     permissions: FilePermissions? = nil,
@@ -66,7 +66,7 @@ extension FileDescriptor {
 
   @usableFromInline
   internal static func _open(
-    _ path: UnsafePointer<CInterop.PlatformChar>,
+    _ path: UnsafePointer<CChar>,
     _ mode: FileDescriptor.AccessMode,
     options: FileDescriptor.OpenOptions,
     permissions: FilePermissions?,
@@ -308,7 +308,10 @@ extension FileDescriptor {
       buffer,
       retryOnInterrupt: retryOnInterrupt)
   }
+}
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+extension FileDescriptor {
   /// Duplicate this file descriptor and return the newly created copy.
   ///
   /// - Parameters:
@@ -385,7 +388,7 @@ extension FileDescriptor {
   public static func pipe() throws -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
     try _pipe().get()
   }
-  
+
   /*System 1.1.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
   @usableFromInline
   internal static func _pipe() -> Result<(readEnd: FileDescriptor, writeEnd: FileDescriptor), Errno> {

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -32,12 +32,12 @@ extension FileDescriptor {
     retryOnInterrupt: Bool = true
   ) throws -> FileDescriptor {
     #if !os(Windows)
-    try path.withCString {
+    return try path.withCString {
       try FileDescriptor.open(
         $0, mode, options: options, permissions: permissions, retryOnInterrupt: retryOnInterrupt)
     }
     #else 
-    try path.withPlatformString {
+    return try path.withPlatformString {
       try FileDescriptor.open(
         $0, mode, options: options, permissions: permissions, retryOnInterrupt: retryOnInterrupt)
     }

--- a/Sources/System/FilePath/FilePathComponentView.swift
+++ b/Sources/System/FilePath/FilePathComponentView.swift
@@ -40,7 +40,7 @@ extension FilePath {
     }
   }
 
-  #if SYSTEM_PACKAGE
+  #if SYSTEM_PACKAGE // Workaround for a __consuming getter bug in Swift 5.3.3
   /// View the non-root components that make up this path.
   public var components: ComponentView {
     get { ComponentView(self) }
@@ -202,6 +202,7 @@ extension FilePath {
 
 // MARK: - Internals
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.ComponentView: _PathSlice {
   internal var _range: Range<SystemString.Index> {
     _start ..< _path._storage.endIndex
@@ -214,6 +215,7 @@ extension FilePath.ComponentView: _PathSlice {
 
 // MARK: - Invariants
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.ComponentView {
   internal func _invariantCheck() {
     #if DEBUG

--- a/Sources/System/FilePath/FilePathComponents.swift
+++ b/Sources/System/FilePath/FilePathComponents.swift
@@ -98,6 +98,7 @@ extension FilePath.Component {
   }
 }
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Root {
   // TODO: Windows analysis APIs
 }
@@ -183,15 +184,18 @@ extension _PathSlice {
   internal var _storage: SystemString { _path._storage }
 }
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Component: _PathSlice {
 }
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Root: _PathSlice {
   internal var _range: Range<SystemString.Index> {
     (..<_rootEnd).relative(to: _path._storage)
   }
 }
+
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath: _PlatformStringable {
-  @usableFromInline
   func _withPlatformString<Result>(_ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result) rethrows -> Result {
     try _storage.withPlatformString(body)
   }
@@ -202,6 +206,7 @@ extension FilePath: _PlatformStringable {
 
 }
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Component {
   // The index of the `.` denoting an extension
   internal func _extensionIndex() -> SystemString.Index? {
@@ -230,6 +235,7 @@ internal func _makeExtension(_ ext: String) -> SystemString {
   return result
 }
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Component {
   internal init?(_ str: SystemString) {
     // FIXME: explicit null root? Or something else?
@@ -242,6 +248,7 @@ extension FilePath.Component {
   }
 }
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Root {
   internal init?(_ str: SystemString) {
     // FIXME: explicit null root? Or something else?
@@ -256,6 +263,7 @@ extension FilePath.Root {
 
 // MARK: - Invariants
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Component {
   // TODO: ensure this all gets easily optimized away in release...
   internal func _invariantCheck() {
@@ -267,6 +275,8 @@ extension FilePath.Component {
     #endif // DEBUG
   }
 }
+
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Root {
   internal func _invariantCheck() {
     #if DEBUG

--- a/Sources/System/FilePath/FilePathParsing.swift
+++ b/Sources/System/FilePath/FilePathParsing.swift
@@ -111,6 +111,7 @@ extension SystemString {
   }
 }
 
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath {
   internal mutating func _removeTrailingSeparator() {
     _storage._removeTrailingSeparator()
@@ -191,6 +192,7 @@ extension SystemString {
   }
 }
 
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath {
   internal var _relativeStart: SystemString.Index {
     _storage._relativePathStart
@@ -202,6 +204,7 @@ extension FilePath {
 
 // Parse separators
 
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath {
   internal typealias _Index = SystemString.Index
 
@@ -265,6 +268,7 @@ extension FilePath {
   }
 }
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.ComponentView {
   // TODO: Store this...
   internal var _relativeStart: SystemString.Index {
@@ -289,6 +293,7 @@ extension SystemString {
   }
 }
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension FilePath.Root {
   // Asserting self is a root, returns whether this is an
   // absolute root.
@@ -313,6 +318,7 @@ extension FilePath.Root {
   }
 }
 
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath {
   internal var _portableDescription: String {
     guard _windowsPaths else { return description }
@@ -331,6 +337,7 @@ internal var _windowsPaths: Bool {
   #endif
 }
 
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath {
   // Whether we should add a separator when doing an append
   internal var _needsSeparatorForAppend: Bool {
@@ -358,6 +365,7 @@ extension FilePath {
 }
 
 // MARK: - Invariants
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath {
   internal func _invariantCheck() {
     #if DEBUG

--- a/Sources/System/FilePath/FilePathString.swift
+++ b/Sources/System/FilePath/FilePathString.swift
@@ -20,7 +20,13 @@ extension FilePath {
     self.init(_platformString: platformString)
   }
 
-#if !os(Windows) // Availability workaround
+  #if !os(Windows)
+  // Note: This function should have been opaque, but it shipped as 
+  // `@_alwaysEmitIntoClient` in macOS 12/iOS 15, and now it is stuck
+  // this way forever. (Or until the language provides a way for us
+  // to declare separate availability for a function's exported symbol
+  // and its inlinable body.)
+
   /// Calls the given closure with a pointer to the contents of the file path,
   /// represented as a null-terminated platform string.
   ///
@@ -37,7 +43,6 @@ extension FilePath {
   public func withPlatformString<Result>(
     _ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result
   ) rethrows -> Result {
-    // For backwards deployment, call withCString if available.
     return try withCString(body)
   }
 #else
@@ -56,7 +61,6 @@ extension FilePath {
   public func withPlatformString<Result>(
     _ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result
   ) rethrows -> Result {
-    // For backwards deployment, call withCString if available.
     return try _withPlatformString(body)
   }
 #endif

--- a/Sources/System/FilePermissions.swift
+++ b/Sources/System/FilePermissions.swift
@@ -21,14 +21,14 @@
 public struct FilePermissions: OptionSet, Hashable, Codable {
   /// The raw C file permissions.
   @_alwaysEmitIntoClient
-  public let rawValue: CInterop.Mode
+  public let rawValue: CModeT
 
   /// Create a strongly-typed file permission from a raw C value.
   @_alwaysEmitIntoClient
-  public init(rawValue: CInterop.Mode) { self.rawValue = rawValue }
+  public init(rawValue: CModeT) { self.rawValue = rawValue }
 
   @_alwaysEmitIntoClient
-  private init(_ raw: CInterop.Mode) { self.init(rawValue: raw) }
+  private init(_ raw: CModeT) { self.init(rawValue: raw) }
 
   /// Indicates that other users have read-only permission.
   @_alwaysEmitIntoClient

--- a/Sources/System/Internals/Backcompat.swift
+++ b/Sources/System/Internals/Backcompat.swift
@@ -1,0 +1,29 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+extension String {
+  internal init(
+    _unsafeUninitializedCapacity capacity: Int,
+    initializingUTF8With body: (UnsafeMutableBufferPointer<UInt8>) throws -> Int
+  ) rethrows {
+    if #available(macOS 11, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+      self = try String(
+        unsafeUninitializedCapacity: capacity,
+        initializingUTF8With: body)
+      return
+    }
+
+    let array = try Array<UInt8>(
+      unsafeUninitializedCapacity: capacity
+    ) { buffer, count in
+      count = try body(buffer)
+    }
+    self = String(decoding: array, as: UTF8.self)
+  }
+}

--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -1,18 +1,11 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
 */
-
-// MARK: - Public typealiases
-
-/// The C `mode_t` type.
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
-@available(*, deprecated, renamed: "CInterop.Mode")
-public typealias CModeT =  CInterop.Mode
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
@@ -24,6 +17,20 @@ import CSystem
 import ucrt
 #else
 #error("Unsupported Platform")
+#endif
+
+// MARK: - Public typealiases
+
+// FIXME: `CModeT` ought to be deprecated and replaced with `CInterop.Mode`
+//        if/when the compiler becomes less strict about availability checking
+//        of "namespaced" typealiases. (rdar://81722893)
+#if os(Windows)
+/// The C `mode_t` type.
+public typealias CModeT = CInt
+#else
+/// The C `mode_t` type.
+/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+public typealias CModeT = mode_t
 #endif
 
 /// A namespace for C and platform types

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -528,4 +528,3 @@ internal var _SEEK_HOLE: CInt { SEEK_HOLE }
 @_alwaysEmitIntoClient
 internal var _SEEK_DATA: CInt { SEEK_DATA }
 #endif
-

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -60,7 +60,10 @@ internal func system_strerror(_ __errnum: Int32) -> UnsafeMutablePointer<Int8>! 
   strerror(__errnum)
 }
 
-internal func system_strlen(_ s: UnsafePointer<Int8>) -> Int {
+internal func system_strlen(_ s: UnsafePointer<CChar>) -> Int {
+  strlen(s)
+}
+internal func system_strlen(_ s: UnsafeMutablePointer<CChar>) -> Int {
   strlen(s)
 }
 
@@ -76,6 +79,15 @@ internal func system_platform_strlen(_ s: UnsafePointer<CInterop.PlatformChar>) 
   #else
   return strlen(s)
   #endif
+}
+
+// memset for raw buffers
+// FIXME: Do we really not have something like this in the stdlib already?
+internal func system_memset(
+  _ buffer: UnsafeMutableRawBufferPointer,
+  to byte: UInt8
+) {
+  memset(buffer.baseAddress, CInt(byte), buffer.count)
 }
 
 // Interop between String and platfrom string

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -87,7 +87,8 @@ internal func system_memset(
   _ buffer: UnsafeMutableRawBufferPointer,
   to byte: UInt8
 ) {
-  memset(buffer.baseAddress, CInt(byte), buffer.count)
+  guard buffer.count > 0 else { return }
+  memset(buffer.baseAddress!, CInt(byte), buffer.count)
 }
 
 // Interop between String and platfrom string

--- a/Sources/System/Internals/Mocking.swift
+++ b/Sources/System/Internals/Mocking.swift
@@ -19,9 +19,10 @@
 
 #if ENABLE_MOCKING
 internal struct Trace {
-  internal struct Entry: Hashable {
-    private var name: String
-    private var arguments: [AnyHashable]
+  internal struct Entry {
+
+    internal var name: String
+    internal var arguments: [AnyHashable]
 
     internal init(name: String, _ arguments: [AnyHashable]) {
       self.name = name

--- a/Sources/System/Internals/RawBuffer.swift
+++ b/Sources/System/Internals/RawBuffer.swift
@@ -1,0 +1,102 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// A copy-on-write fixed-size buffer of raw memory.
+internal struct _RawBuffer {
+  internal var _storage: Storage?
+
+  internal init() {
+    self._storage = nil
+  }
+
+  internal init(minimumCapacity: Int) {
+    if minimumCapacity > 0 {
+      self._storage = Storage.create(minimumCapacity: minimumCapacity)
+    } else {
+      self._storage = nil
+    }
+  }
+}
+
+extension _RawBuffer {
+  internal var capacity: Int {
+    _storage?.header ?? 0 // Note: not capacity!
+  }
+
+  internal mutating func ensureUnique() {
+    guard _storage != nil else { return }
+    let unique = isKnownUniquelyReferenced(&_storage)
+    if !unique {
+      _storage = _copy(capacity: capacity)
+    }
+  }
+
+  internal func _grow(desired: Int) -> Int {
+    let next = Int(1.75 * Double(self.capacity))
+    return Swift.max(next, desired)
+  }
+
+  internal mutating func ensureUnique(capacity: Int) {
+    let unique = isKnownUniquelyReferenced(&_storage)
+    if !unique || self.capacity < capacity {
+      _storage = _copy(capacity: _grow(desired: capacity))
+    }
+  }
+
+  internal func withUnsafeBytes<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    guard let storage = _storage else {
+      return try body(UnsafeRawBufferPointer(start: nil, count: 0))
+    }
+    return try storage.withUnsafeMutablePointers { count, bytes in
+      let buffer = UnsafeRawBufferPointer(start: bytes, count: count.pointee)
+      return try body(buffer)
+    }
+  }
+
+  internal mutating func withUnsafeMutableBytes<R>(
+    _ body: (UnsafeMutableRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    guard _storage != nil else {
+      return try body(UnsafeMutableRawBufferPointer(start: nil, count: 0))
+    }
+    ensureUnique()
+    return try _storage!.withUnsafeMutablePointers { count, bytes in
+      let buffer = UnsafeMutableRawBufferPointer(start: bytes, count: count.pointee)
+      return try body(buffer)
+    }
+  }
+}
+
+extension _RawBuffer {
+  internal class Storage: ManagedBuffer<Int, UInt8> {
+    internal static func create(minimumCapacity: Int) -> Storage {
+      Storage.create(
+        minimumCapacity: minimumCapacity,
+        makingHeaderWith: { $0.capacity }
+      ) as! Storage
+    }
+  }
+
+  internal func _copy(capacity: Int) -> Storage {
+    let copy = Storage.create(minimumCapacity: capacity)
+    copy.withUnsafeMutablePointers { dstlen, dst in
+      self.withUnsafeBytes { src in
+        guard src.count > 0 else { return }
+        assert(src.count <= dstlen.pointee)
+        UnsafeMutableRawPointer(dst)
+          .copyMemory(
+            from: src.baseAddress!,
+            byteCount: Swift.min(src.count, dstlen.pointee))
+      }
+    }
+    return copy
+  }
+}

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -54,7 +54,7 @@ internal func system_close(_ fd: Int32) -> Int32 {
 
 // read
 internal func system_read(
-  _ fd: Int32, _ buf: UnsafeMutableRawPointer!, _ nbyte: Int
+  _ fd: Int32, _ buf: UnsafeMutableRawPointer?, _ nbyte: Int
 ) -> Int {
 #if ENABLE_MOCKING
   if mockingEnabled { return _mockInt(fd, buf, nbyte) }
@@ -64,7 +64,7 @@ internal func system_read(
 
 // pread
 internal func system_pread(
-  _ fd: Int32, _ buf: UnsafeMutableRawPointer!, _ nbyte: Int, _ offset: off_t
+  _ fd: Int32, _ buf: UnsafeMutableRawPointer?, _ nbyte: Int, _ offset: off_t
 ) -> Int {
 #if ENABLE_MOCKING
   if mockingEnabled { return _mockInt(fd, buf, nbyte, offset) }
@@ -84,7 +84,7 @@ internal func system_lseek(
 
 // write
 internal func system_write(
-  _ fd: Int32, _ buf: UnsafeRawPointer!, _ nbyte: Int
+  _ fd: Int32, _ buf: UnsafeRawPointer?, _ nbyte: Int
 ) -> Int {
 #if ENABLE_MOCKING
   if mockingEnabled { return _mockInt(fd, buf, nbyte) }
@@ -94,7 +94,7 @@ internal func system_write(
 
 // pwrite
 internal func system_pwrite(
-  _ fd: Int32, _ buf: UnsafeRawPointer!, _ nbyte: Int, _ offset: off_t
+  _ fd: Int32, _ buf: UnsafeRawPointer?, _ nbyte: Int, _ offset: off_t
 ) -> Int {
 #if ENABLE_MOCKING
   if mockingEnabled { return _mockInt(fd, buf, nbyte, offset) }

--- a/Sources/System/PlatformString.swift
+++ b/Sources/System/PlatformString.swift
@@ -58,6 +58,7 @@ extension String {
 
 }
 
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension CInterop.PlatformChar {
   internal var _platformCodeUnit: CInterop.PlatformUnicodeEncoding.CodeUnit {
     #if os(Windows)
@@ -67,6 +68,8 @@ extension CInterop.PlatformChar {
     #endif
   }
 }
+
+/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
 extension CInterop.PlatformUnicodeEncoding.CodeUnit {
   internal var _platformChar: CInterop.PlatformChar {
     #if os(Windows)

--- a/Sources/System/Util+StringArray.swift
+++ b/Sources/System/Util+StringArray.swift
@@ -1,0 +1,117 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+extension Array where Element == String {
+  internal typealias CStr = UnsafePointer<CChar>?
+
+  /// Call `body` with a buffer of `UnsafePointer<CChar>?` values,
+  /// suitable for passing to a C function that expects a C string array.
+  /// The buffer is guaranteed to be followed by an extra storage slot
+  /// containing a null pointer. (For C functions that expect an array
+  /// terminated with a null pointer.)
+  ///
+  /// This function is careful not to heap allocate memory unless there are
+  /// too many strings, or if it needs to copy too much character data.
+  internal func _withCStringArray<R>(
+    _ body: (UnsafeBufferPointer<UnsafePointer<CChar>?>) throws -> R
+  ) rethrows -> R {
+    if self.count == 0 {
+      // Fast path: empty array.
+      let p: CStr = nil
+      return try Swift.withUnsafePointer(to: p) { array in
+        try body(UnsafeBufferPointer(start: array, count: 0))
+      }
+    }
+    #if SYSTEM_OS_BUILD // String._guts isn't accessible from SwiftPM or CMake
+    if self.count == 1, self[0]._guts._isLargeZeroTerminatedContiguousUTF8 {
+      // Fast path: Single fast string.
+      let start = self[0]._guts._largeContiguousUTF8CodeUnits.baseAddress!
+      var p: (CStr, CStr) = (
+        UnsafeRawPointer(start).assumingMemoryBound(to: CChar.self),
+        nil
+      )
+      return try Swift.withUnsafeBytes(of: &p) { buffer in
+        let start = buffer.baseAddress!.assumingMemoryBound(to: CStr.self)
+        return try body(UnsafeBufferPointer(start: start, count: 1))
+      }
+    }
+    #endif
+    // We need to create a buffer for the C array.
+    return try _withStackBuffer(
+      capacity: (self.count + 1) * MemoryLayout<CStr>.stride
+    ) { array in
+      let array = array.bindMemory(to: CStr.self)
+      // Calculate number of bytes we need for character storage
+      let bytes = self.reduce(into: 0) { count, string in
+        #if SYSTEM_OS_BUILD
+        if string._guts._isLargeZeroTerminatedContiguousUTF8 { return }
+        #endif
+        count += string.utf8.count + 1 // Plus one for terminating NUL
+      }
+      #if SYSTEM_OS_BUILD
+      if bytes == 0 {
+        // Fast path: we only contain strings with stable null-terminated storage
+        for i in self.indices {
+          let string = self[i]
+          precondition(string._guts._isLargeZeroTerminatedContiguousUTF8)
+          let address = string._guts._largeContiguousUTF8CodeUnits.baseAddress!
+          array[i] = UnsafeRawPointer(address).assumingMemoryBound(to: CChar.self)
+        }
+        array[self.count] = nil
+        return try body(UnsafeBufferPointer(rebasing: array.dropLast()))
+      }
+      #endif
+      return try _withStackBuffer(capacity: bytes) { chars in
+        var chars = chars
+        for i in self.indices {
+          let (cstr, scratchUsed) = self[i]._getCStr(with: chars)
+          array[i] = cstr.assumingMemoryBound(to: CChar.self)
+          chars = .init(rebasing: chars[scratchUsed...])
+        }
+        array[self.count] = nil
+        return try body(UnsafeBufferPointer(rebasing: array.dropLast()))
+      }
+    }
+  }
+}
+
+extension String {
+  fileprivate func _getCStr(
+    with scratch: UnsafeMutableRawBufferPointer
+  ) -> (cstr: UnsafeRawPointer, scratchUsed: Int) {
+    #if SYSTEM_OS_BUILD
+    if _guts._isLargeZeroTerminatedContiguousUTF8 {
+      // This is a wonderful string, we can just use its storage address.
+      let address = _guts._largeContiguousUTF8CodeUnits.baseAddress!
+      return (UnsafeRawPointer(address), 0)
+    }
+    #endif
+    let r: (UnsafeRawPointer, Int)? = self.utf8.withContiguousStorageIfAvailable { source in
+      // This is a somewhat okay string -- we need to use memcpy.
+      precondition(source.count <= scratch.count)
+      let start = scratch.baseAddress!
+      start.copyMemory(from: source.baseAddress!, byteCount: source.count)
+      start.storeBytes(of: 0, toByteOffset: source.count, as: UInt8.self)
+      return (UnsafeRawPointer(start), source.count + 1)
+    }
+    if let r = r { return r }
+
+    // What a horrible string; we need to copy individual bytes.
+    precondition(self.utf8.count <= scratch.count)
+    var c = 0
+    for byte in self.utf8 {
+      scratch[c] = byte
+      c += 1
+    }
+    scratch[c] = 0
+    c += 1
+    return (UnsafeRawPointer(scratch.baseAddress!), c)
+  }
+}
+

--- a/Tests/SystemTests/UtilTests.swift
+++ b/Tests/SystemTests/UtilTests.swift
@@ -1,0 +1,89 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import XCTest
+
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+class UtilTests: XCTestCase {
+  func testStackBuffer() {
+    // Exercises _withStackBuffer a bit, in hopes any bugs will
+    // show up as ASan failures.
+    for size in stride(from: 0, to: 1000, by: 5) {
+      var called = false
+      _withStackBuffer(capacity: size) { buffer in
+        XCTAssertFalse(called)
+        called = true
+
+        buffer.initializeMemory(as: UInt8.self, repeating: 42)
+      }
+      XCTAssertTrue(called)
+    }
+  }
+
+  func testCStringArray() {
+    func check(
+      _ array: [String],
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+      array._withCStringArray { carray in
+        let actual = carray.map { $0.map { String(cString: $0) } ?? "<NULL>" }
+        XCTAssertEqual(actual, array, file: file, line: line)
+        // Verify that there is a null pointer following the last item in
+        // carray. (Note: this is intentionally addressing beyond the
+        // end of the buffer, as the function promises that is going to be okay.)
+        XCTAssertNil((carray.baseAddress! + carray.count).pointee)
+      }
+    }
+
+    check([])
+    check([""])
+    check(["", ""])
+    check(["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""])
+    // String literals of various sizes and counts
+    check(["hello"])
+    check(["hello", "world"])
+    check(["This is a rather large string literal"])
+    check([
+      "This is a rather large string literal",
+      "This is small",
+      "This one is not that small -- it's even longer than the first",
+    ])
+    check([
+      "This is a rather large string literal",
+      "This one is not that small -- it's even longer than the first",
+      "And this is the largest of them all. I wonder if it even fits on a line"
+    ])
+    check(Array(repeating: "", count: 100))
+    check(Array(repeating: "Hiii", count: 100))
+    check(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m"])
+    check(["", "b", "", "d", "", "f", "", "h", "", "j", "", "👨‍👨‍👧‍👦👩‍❤️‍💋‍👨", "m"])
+
+    var girls = ["Dörothy", "Róse", "Blánche", "Sőphia"]
+    check(girls) // Small strings
+    for i in girls.indices {
+      // Convert to native
+      girls[i] = "\(girls[i]) \(girls[i]) \(girls[i])"
+    }
+    check(girls) // Native large strings
+    for i in girls.indices {
+      let data = girls[i].data(using: .utf16)!
+      girls[i] = NSString(
+        data: data,
+        encoding: String.Encoding.utf16.rawValue
+      )! as String
+    }
+    check(girls) // UTF-16 Cocoa strings
+  }
+}


### PR DESCRIPTION
This brings the contents of this package up to date with versions of the ABI stable `System` module that shipped in recent iOS/macOS releases.

Most changes only touch internal implementation details, but some ABI-related fixes also affect the public API. There are no source-incompatible changes.

- ABI stability fixes (un-deprecate `CModeT`, don't use `PlatformChar` in inlinable contexts that need to deploy to iOS 14)
- New utilities: `_RawBuffer`, `Array<String>._withCStringArray`, `_withOptionalUnsafePointerOrNull`, `_withStackBuffer`, `system_memset`
- Prefer using explicit optionals to implicitly-unwrapped ones
- Add support for wildcard matching in mocking tests
- A bunch of new availability annotations. (I expect there will be more of these coming in future PRs.)