### PR TITLE
Rebind byte types safely

### DIFF
--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -391,10 +391,12 @@ extension FileDescriptor {
   internal static func _pipe() -> Result<(readEnd: FileDescriptor, writeEnd: FileDescriptor), Errno> {
     var fds: (Int32, Int32) = (-1, -1)
     return withUnsafeMutablePointer(to: &fds) { pointer in
-      valueOrErrno(retryOnInterrupt: false) {
-        system_pipe(UnsafeMutableRawPointer(pointer).assumingMemoryBound(to: Int32.self))
+      pointer.withMemoryRebound(to: Int32.self, capacity: 2) { fds in
+        valueOrErrno(retryOnInterrupt: false) {
+          system_pipe(fds)
+        }.map { _ in (.init(rawValue: fds[0]), .init(rawValue: fds[1])) }
       }
-    }.map { _ in (.init(rawValue: fds.0), .init(rawValue: fds.1)) }
+    }
   }
 }
 #endif

--- a/Tests/SystemTests/FilePathTests/FilePathTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTest.swift
@@ -22,7 +22,9 @@ func filePathFromUnterminatedBytes<S: Sequence>(_ bytes: S) -> FilePath where S.
   array += [0]
 
   return array.withUnsafeBufferPointer {
-    FilePath(platformString: $0.baseAddress!._asCChar)
+    $0.withMemoryRebound(to: CChar.self) {
+      FilePath(platformString: $0.baseAddress!)
+    }
   }
 }
 let invalidBytes: [UInt8] = [0x2F, 0x61, 0x2F, 0x62, 0x2F, 0x83]

--- a/Tests/SystemTests/SystemStringTests.swift
+++ b/Tests/SystemTests/SystemStringTests.swift
@@ -10,29 +10,6 @@
 // Tests for PlatformString, SystemString, and FilePath's forwarding APIs
 
 // TODO: Adapt test to Windows
-extension UnsafePointer where Pointee == UInt8 {
-  internal var _asCChar: UnsafePointer<CChar> {
-    UnsafeRawPointer(self).assumingMemoryBound(to: CChar.self)
-  }
-}
-extension UnsafePointer where Pointee == CChar {
-  internal var _asUInt8: UnsafePointer<UInt8> {
-    UnsafeRawPointer(self).assumingMemoryBound(to: UInt8.self)
-  }
-}
-extension UnsafeBufferPointer where Element == UInt8 {
-  internal var _asCChar: UnsafeBufferPointer<CChar> {
-    let base = baseAddress?._asCChar
-    return UnsafeBufferPointer<CChar>(start: base, count: self.count)
-  }
-}
-extension UnsafeBufferPointer where Element == CChar {
-  internal var _asUInt8: UnsafeBufferPointer<UInt8> {
-    let base = baseAddress?._asUInt8
-    return UnsafeBufferPointer<UInt8>(start: base, count: self.count)
-  }
-}
-
 
 import XCTest
 
@@ -46,7 +23,7 @@ private func makeRaw(
   _ str: String
 ) -> [CInterop.PlatformChar] {
   var str = str
-  var array = str.withUTF8 { Array($0._asCChar) }
+  var array = str.withUTF8 { $0.withMemoryRebound(to: CChar.self, Array.init) }
   array.append(0)
   return array
 }


### PR DESCRIPTION
Eliminates all uses of `assumingMemoryBound` in favor of temporary rebinding, using memory binding API for Swift <5.7. The end result is more memory-safe.