### PR TITLE
Mitigate misuse of Swift's pointer conversion feature

### DIFF
--- a/Sources/System/FilePath/FilePathString.swift
+++ b/Sources/System/FilePath/FilePathString.swift
@@ -20,6 +20,49 @@ extension FilePath {
     self.init(_platformString: platformString)
   }
 
+  /// Creates a file path by copying bytes from a null-terminated platform
+  /// string.
+  ///
+  /// - Note It is a precondition that `platformString` must be null-terminated.
+  /// The absence of a null byte will trigger a runtime error.
+  ///
+  /// - Parameter platformString: A null-terminated platform string.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init(platformString: [CInterop.PlatformChar]) {
+    guard let _ = platformString.firstIndex(of: 0) else {
+      fatalError(
+        "input of FilePath.init(platformString:) must be null-terminated"
+      )
+    }
+    self = platformString.withUnsafeBufferPointer {
+      FilePath(platformString: $0.baseAddress!)
+    }
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Use FilePath(_: String) to create a path from a String.")
+  public init(platformString: inout CInterop.PlatformChar) {
+    guard platformString == 0 else {
+      fatalError(
+        "input of FilePath.init(platformString:) must be null-terminated"
+      )
+    }
+    self = FilePath()
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Use FilePath(_: String) to create a path from a String.")
+  public init(platformString: String) {
+    if let nullLoc = platformString.firstIndex(of: "\0") {
+      self = FilePath(String(platformString[..<nullLoc]))
+    } else {
+      self = FilePath(platformString)
+    }
+  }
+
   /// Calls the given closure with a pointer to the contents of the file path,
   /// represented as a null-terminated platform string.
   ///
@@ -60,6 +103,59 @@ extension FilePath.Component {
     self.init(_platformString: platformString)
   }
 
+  /// Creates a file path component by copying bytes from a null-terminated
+  /// platform string. It is a precondition that a null byte indicates the end of
+  /// the string. The absence of a null byte will trigger a runtime error.
+  ///
+  /// Returns `nil` if `platformString` is empty, is a root, or has more than
+  /// one component in it.
+  ///
+  /// - Note It is a precondition that `platformString` must be null-terminated.
+  /// The absence of a null byte will trigger a runtime error.
+  ///
+  /// - Parameter platformString: A null-terminated platform string.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init?(platformString: [CInterop.PlatformChar]) {
+    guard let _ = platformString.firstIndex(of: 0) else {
+      fatalError(
+        "input of FilePath.Component.init?(platformString:) must be null-terminated"
+      )
+    }
+    guard let component = platformString.withUnsafeBufferPointer({
+      FilePath.Component(platformString: $0.baseAddress!)
+    }) else {
+      return nil
+    }
+    self = component
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Use FilePath.Component.init(_: String).")
+  public init?(platformString: inout CInterop.PlatformChar) {
+    guard platformString == 0 else {
+      fatalError(
+        "input of FilePath.Component.init?(platformString:) must be null-terminated"
+      )
+    }
+    return nil
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Use FilePath.Component.init(_: String).")
+  public init?(platformString: String) {
+    let string: String
+    if let nullLoc = platformString.firstIndex(of: "\0") {
+      string = String(platformString[..<nullLoc])
+    } else {
+      string = platformString
+    }
+    guard let component = FilePath.Component(string) else { return nil }
+    self = component
+  }
+
   /// Calls the given closure with a pointer to the contents of the file path
   /// component, represented as a null-terminated platform string.
   ///
@@ -94,6 +190,58 @@ extension FilePath.Root {
   ///
   public init?(platformString: UnsafePointer<CInterop.PlatformChar>) {
     self.init(_platformString: platformString)
+  }
+
+  /// Creates a file path root by copying bytes from a null-terminated platform
+  /// string. It is a precondition that a null byte indicates the end of
+  /// the string. The absence of a null byte will trigger a runtime error.
+  ///
+  /// Returns `nil` if `platformString` is empty or is not a root.
+  ///
+  /// - Note It is a precondition that `platformString` must be null-terminated.
+  /// The absence of a null byte will trigger a runtime error.
+  ///
+  /// - Parameter platformString: A null-terminated platform string.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init?(platformString: [CInterop.PlatformChar]) {
+    guard let _ = platformString.firstIndex(of: 0) else {
+      fatalError(
+        "input of FilePath.Root.init?(platformString:) must be null-terminated"
+      )
+    }
+    guard let component = platformString.withUnsafeBufferPointer({
+      FilePath.Root(platformString: $0.baseAddress!)
+    }) else {
+      return nil
+    }
+    self = component
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Use FilePath.Root.init(_: String).")
+  public init?(platformString: inout CInterop.PlatformChar) {
+    guard platformString == 0 else {
+      fatalError(
+        "input of FilePath.Root.init?(platformString:) must be null-terminated"
+      )
+    }
+    return nil
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Use FilePath.Root.init(_: String).")
+  public init?(platformString: String) {
+    let string: String
+    if let nullLoc = platformString.firstIndex(of: "\0") {
+      string = String(platformString[..<nullLoc])
+    } else {
+      string = platformString
+    }
+    guard let root = FilePath.Root(string) else { return nil }
+    self = root
   }
 
   /// Calls the given closure with a pointer to the contents of the file path
@@ -148,7 +296,7 @@ extension FilePath.Component: ExpressibleByStringLiteral {
   public init(stringLiteral: String) {
     guard let s = FilePath.Component(stringLiteral) else {
       // TODO: static assert
-      preconditionFailure("""
+      fatalError("""
         FilePath.Component must be created from exactly one non-root component
         """)
     }
@@ -172,7 +320,7 @@ extension FilePath.Root: ExpressibleByStringLiteral {
   public init(stringLiteral: String) {
     guard let s = FilePath.Root(stringLiteral) else {
       // TODO: static assert
-      preconditionFailure("""
+      fatalError("""
         FilePath.Root must be created from a root
         """)
     }
@@ -405,7 +553,23 @@ extension String {
 extension FilePath {
   /// For backwards compatibility only. This initializer is equivalent to
   /// the preferred `FilePath(platformString:)`.
+  @available(*, deprecated, renamed: "init(platformString:)")
   public init(cString: UnsafePointer<CChar>) {
+    self.init(platformString: cString)
+  }
+
+  @available(*, deprecated, renamed: "init(platformString:)")
+  public init(cString: [CChar]) {
+    self.init(platformString: cString)
+  }
+
+  @available(*, deprecated, renamed: "init(platformString:)")
+  public init(cString: inout CChar) {
+    self.init(platformString: &cString)
+  }
+
+  @available(*, deprecated, renamed: "init(platformString:)")
+  public init(cString: String) {
     self.init(platformString: cString)
   }
 

--- a/Sources/System/FilePath/FilePathString.swift
+++ b/Sources/System/FilePath/FilePathString.swift
@@ -42,7 +42,7 @@ extension FilePath {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use FilePath(_: String) to create a path from a String.")
+  @available(*, deprecated, message: "Use FilePath.init(_ scalar: Unicode.Scalar)")
   public init(platformString: inout CInterop.PlatformChar) {
     guard platformString == 0 else {
       fatalError(
@@ -54,7 +54,7 @@ extension FilePath {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use FilePath(_: String) to create a path from a String.")
+  @available(*, deprecated, message: "Use FilePath(_: String) to create a path from a String")
   public init(platformString: String) {
     if let nullLoc = platformString.firstIndex(of: "\0") {
       self = FilePath(String(platformString[..<nullLoc]))
@@ -132,7 +132,7 @@ extension FilePath.Component {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use FilePath.Component.init(_: String).")
+  @available(*, deprecated, message: "Use FilePath.Component.init(_ scalar: Unicode.Scalar)")
   public init?(platformString: inout CInterop.PlatformChar) {
     guard platformString == 0 else {
       fatalError(
@@ -144,7 +144,7 @@ extension FilePath.Component {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use FilePath.Component.init(_: String).")
+  @available(*, deprecated, message: "Use FilePath.Component.init(_: String)")
   public init?(platformString: String) {
     let string: String
     if let nullLoc = platformString.firstIndex(of: "\0") {
@@ -220,7 +220,7 @@ extension FilePath.Root {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use FilePath.Root.init(_: String).")
+  @available(*, deprecated, message: "Use FilePath.Root.init(_ scalar: Unicode.Scalar)")
   public init?(platformString: inout CInterop.PlatformChar) {
     guard platformString == 0 else {
       fatalError(
@@ -232,7 +232,7 @@ extension FilePath.Root {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use FilePath.Root.init(_: String).")
+  @available(*, deprecated, message: "Use FilePath.Root.init(_: String)")
   public init?(platformString: String) {
     let string: String
     if let nullLoc = platformString.firstIndex(of: "\0") {

--- a/Sources/System/PlatformString.swift
+++ b/Sources/System/PlatformString.swift
@@ -51,9 +51,9 @@ extension String {
     }
   }
 
-  @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   @inlinable
   @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Use String.init(_ scalar: Unicode.Scalar)")
   public init(platformString: inout CInterop.PlatformChar) {
     guard platformString == 0 else {
       fatalError(
@@ -63,9 +63,9 @@ extension String {
     self = ""
   }
 
-  @available(*, deprecated, message: "Use a copy of the String argument")
   @inlinable
   @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Use a copy of the String argument")
   public init(platformString: String) {
     if let nullLoc = platformString.firstIndex(of: "\0") {
       self = String(platformString[..<nullLoc])
@@ -117,9 +117,9 @@ extension String {
     self = string
   }
 
-  @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   @inlinable
   @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public init?(
     validatingPlatformString platformString: inout CInterop.PlatformChar
   ) {
@@ -131,9 +131,9 @@ extension String {
     self = ""
   }
 
-  @available(*, deprecated, message: "Use a copy of the String argument")
   @inlinable
   @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Use a copy of the String argument")
   public init?(
     validatingPlatformString platformString: String
   ) {

--- a/Sources/System/PlatformString.swift
+++ b/Sources/System/PlatformString.swift
@@ -30,12 +30,118 @@ extension String {
   /// - Parameter platformString: The null-terminated platform string to be
   ///  interpreted as `CInterop.PlatformUnicodeEncoding`.
   ///
+  /// - Note It is a precondition that `platformString` must be null-terminated.
+  /// The absence of a null byte will trigger a runtime error.
+  ///
+  /// If the content of the platform string isn't well-formed Unicode,
+  /// this initializer replaces invalid bytes with U+FFFD.
+  /// This means that, depending on the semantics of the specific platform,
+  /// conversion to a string and back might result in a value that's different
+  /// from the original platform string.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init(platformString: [CInterop.PlatformChar]) {
+    guard let _ = platformString.firstIndex(of: 0) else {
+      fatalError(
+        "input of String.init(platformString:) must be null-terminated"
+      )
+    }
+    self = platformString.withUnsafeBufferPointer {
+      String(platformString: $0.baseAddress!)
+    }
+  }
+
+  @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init(platformString: inout CInterop.PlatformChar) {
+    guard platformString == 0 else {
+      fatalError(
+        "input of String.init(platformString:) must be null-terminated"
+      )
+    }
+    self = ""
+  }
+
+  @available(*, deprecated, message: "Use a copy of the String argument")
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init(platformString: String) {
+    if let nullLoc = platformString.firstIndex(of: "\0") {
+      self = String(platformString[..<nullLoc])
+    } else {
+      self = platformString
+    }
+  }
+
+  /// Creates a string by interpreting the null-terminated platform string as
+  /// UTF-8 on Unix and UTF-16 on Windows.
+  ///
+  /// - Parameter platformString: The null-terminated platform string to be
+  ///  interpreted as `CInterop.PlatformUnicodeEncoding`.
+  ///
   /// If the contents of the platform string isn't well-formed Unicode,
   /// this initializer returns `nil`.
   public init?(
     validatingPlatformString platformString: UnsafePointer<CInterop.PlatformChar>
   ) {
     self.init(_platformString: platformString)
+  }
+
+  /// Creates a string by interpreting the null-terminated platform string as
+  /// UTF-8 on Unix and UTF-16 on Windows.
+  ///
+  /// - Parameter platformString: The null-terminated platform string to be
+  ///  interpreted as `CInterop.PlatformUnicodeEncoding`.
+  ///
+  /// - Note It is a precondition that `platformString` must be null-terminated.
+  /// The absence of a null byte will trigger a runtime error.
+  ///
+  /// If the contents of the platform string isn't well-formed Unicode,
+  /// this initializer returns `nil`.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init?(
+    validatingPlatformString platformString: [CInterop.PlatformChar]
+  ) {
+    guard let _ = platformString.firstIndex(of: 0) else {
+      fatalError(
+        "input of String.init(validatingPlatformString:) must be null-terminated"
+      )
+    }
+    guard let string = platformString.withUnsafeBufferPointer({
+      String(validatingPlatformString: $0.baseAddress!)
+    }) else {
+      return nil
+    }
+    self = string
+  }
+
+  @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init?(
+    validatingPlatformString platformString: inout CInterop.PlatformChar
+  ) {
+    guard platformString == 0 else {
+      fatalError(
+        "input of String.init(validatingPlatformString:) must be null-terminated"
+      )
+    }
+    self = ""
+  }
+
+  @available(*, deprecated, message: "Use a copy of the String argument")
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init?(
+    validatingPlatformString platformString: String
+  ) {
+    if let nullLoc = platformString.firstIndex(of: "\0") {
+      self = String(platformString[..<nullLoc])
+    } else {
+      self = platformString
+    }
   }
 
   /// Calls the given closure with a pointer to the contents of the string,

--- a/Tests/SystemTests/SystemStringTests.swift
+++ b/Tests/SystemTests/SystemStringTests.swift
@@ -252,3 +252,165 @@ final class SystemStringTest: XCTestCase {
 
 }
 
+extension SystemStringTest {
+  func test_String_initWithArrayConversion() {
+    let source: [CInterop.PlatformChar] = [0x61, 0x62, 0, 0x63]
+    let str = String(platformString: source)
+    source.withUnsafeBufferPointer {
+      XCTAssertEqual(str, String(platformString: $0.baseAddress!))
+    }
+  }
+
+  @available(*, deprecated) // silence the warning for using a deprecated api
+  func test_String_initWithStringConversion() {
+    let source = "ab\0c"
+    var str: String
+    str = String(platformString: source)
+    source.withPlatformString {
+      XCTAssertEqual(str, String(platformString: $0))
+    }
+    str = String(platformString: "")
+    XCTAssertEqual(str.isEmpty, true)
+  }
+
+  @available(*, deprecated) // silence the warning for using a deprecated api
+  func test_String_initWithInoutConversion() {
+    var c: CInterop.PlatformChar = 0
+    let str = String(platformString: &c)
+    // Any other value of `c` would violate the null-terminated precondition
+    XCTAssertEqual(str.isEmpty, true)
+  }
+
+  func test_String_validatingPlatformStringWithArrayConversion() {
+    var source: [CInterop.PlatformChar] = [0x61, 0x62, 0, 0x63]
+    var str: String?
+    str = String(validatingPlatformString: source)
+    source.withUnsafeBufferPointer {
+      XCTAssertEqual(str, String(validatingPlatformString: $0.baseAddress!))
+    }
+    source[1] = CInterop.PlatformChar(truncatingIfNeeded: 0xffff)
+    str = String(validatingPlatformString: source)
+    XCTAssertNil(str)
+  }
+
+  @available(*, deprecated) // silence the warning for using a deprecated api
+  func test_String_validatingPlatformStringWithStringConversion() {
+    let source = "ab\0c"
+    var str: String?
+    str = String(validatingPlatformString: source)
+    XCTAssertNotNil(str)
+    source.withPlatformString {
+      XCTAssertEqual(str, String.init(validatingPlatformString: $0))
+    }
+    str = String(validatingPlatformString: "")
+    XCTAssertNotNil(str)
+    XCTAssertEqual(str?.isEmpty, true)
+  }
+
+  @available(*, deprecated) // silence the warning for using a deprecated api
+  func test_String_validatingPlatformStringWithInoutConversion() {
+    var c: CInterop.PlatformChar = 0
+    let str = String(validatingPlatformString: &c)
+    // Any other value of `c` would violate the null-terminated precondition
+    XCTAssertNotNil(str)
+    XCTAssertEqual(str?.isEmpty, true)
+  }
+
+  func test_FilePath_initWithArrayConversion() {
+    let source: [CInterop.PlatformChar] = [0x61, 0x62, 0, 0x63]
+    let path = FilePath(platformString: source)
+    source.withUnsafeBufferPointer {
+      XCTAssertEqual(path, FilePath(platformString: $0.baseAddress!))
+    }
+  }
+
+  @available(*, deprecated) // silence the warning for using a deprecated api
+  func test_FilePath_initWithStringConversion() {
+    let source = "ab\0c"
+    var path: FilePath
+    path = FilePath(platformString: source)
+    source.withPlatformString {
+      XCTAssertEqual(path, FilePath(platformString: $0))
+    }
+    path = FilePath(platformString: "")
+    XCTAssertEqual(path.string.isEmpty, true)
+  }
+
+  @available(*, deprecated) // silence the warning for using a deprecated api
+  func test_FilePath_initWithInoutConversion() {
+    var c: CInterop.PlatformChar = 0
+    let path = FilePath(platformString: &c)
+    // Any other value of `c` would violate the null-terminated precondition
+    XCTAssertEqual(path.string.isEmpty, true)
+  }
+
+  func test_FilePathComponent_initWithArrayConversion() {
+    var source: [CInterop.PlatformChar] = [0x61, 0x62, 0, 0x63]
+    var component: FilePath.Component?
+    component = FilePath.Component(platformString: source)
+    source.withUnsafeBufferPointer {
+      XCTAssertEqual(component, .init(platformString: $0.baseAddress!))
+    }
+    source[1] = CInterop.PlatformChar(truncatingIfNeeded: 0xffff)
+    component = FilePath.Component(platformString: source)
+    source.withUnsafeBufferPointer {
+      XCTAssertEqual(component, .init(platformString: $0.baseAddress!))
+    }
+  }
+
+  @available(*, deprecated) // silence the warning for using a deprecated api
+  func test_FilePathComponent_initWithStringConversion() {
+    let source = "ab\0c"
+    var component: FilePath.Component?
+    component = FilePath.Component(platformString: source)
+    source.withPlatformString {
+      XCTAssertEqual(component, FilePath.Component(platformString: $0))
+    }
+    component = FilePath.Component(platformString: "")
+    XCTAssertNil(component)
+  }
+
+  @available(*, deprecated) // silence the warning for using a deprecated api
+  func test_FilePathComponent_initWithInoutConversion() {
+    var c: CInterop.PlatformChar = 0
+    let component = FilePath.Component(platformString: &c)
+    XCTAssertNil(component)
+  }
+
+  func test_FilePathRoot_initWithArrayConversion() {
+    let source: [CInterop.PlatformChar]
+    #if os(Windows)
+    source = [0x41, 0x3a, 0x5c, 0, 0x7f]
+    #else // unix
+    source = [0x2f, 0, 0x7f]
+    #endif
+    var root: FilePath.Root?
+    root = FilePath.Root(platformString: source)
+    source.withUnsafeBufferPointer {
+      XCTAssertEqual(root, FilePath.Root(platformString: $0.baseAddress!))
+    }
+  }
+
+  @available(*, deprecated) // silence the warning for using a deprecated api
+  func test_FilePathRoot_initWithStringConversion() {
+    #if os(Windows)
+    let source = "C:\\\0 and the rest"
+    #else // unix
+    let source = "/\0 and the rest"
+    #endif
+    var root: FilePath.Root?
+    root = FilePath.Root(platformString: source)
+    source.withPlatformString {
+      XCTAssertEqual(root, FilePath.Root(platformString: $0))
+    }
+    root = FilePath.Root(platformString: "")
+    XCTAssertNil(root)
+  }
+
+  @available(*, deprecated) // silence the warning for using a deprecated api
+  func test_FilePathRoot_initWithInoutConversion() {
+    var c: CInterop.PlatformChar = 0
+    let root = FilePath.Root(platformString: &c)
+    XCTAssertNil(root)
+  }
+}


### PR DESCRIPTION
This is a continuation of the work done in https://github.com/apple/swift/pull/42002, addressing the exact same issues.

The family of `String` (and `FilePath`) initializers that convert from C strings (null-terminated byte buffers) can be called with Swift arrays, which are converted to `UnsafePointer` arguments for C interoperability. However, when the array passed in to them violates the C string precondition of containing a zero byte, this can result in a buffer overflow.

This PR overloads every such initializer with a version for `[CodeUnit]` and `inout CodeUnit`, enforcing the null-terminated precondition. An overload for String is also added. The String overload may appear strictly useless, but it behaves differently than a direct copy when the source string contains an embedded null.

Addresses rdar://91436410.