### PR TITLE
FileOperations: Fix _open precondition

### DIFF
--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -77,7 +77,7 @@ extension FileDescriptor {
       if let permissions = permissions {
         return system_open(path, oFlag, permissions.rawValue)
       }
-      precondition(!options.contains(.create),
+      precondition(options.contains(.create),
         "Create must be given permissions")
       return system_open(path, oFlag)
     }

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -29,10 +29,10 @@ final class FileOperationsTest: XCTestCase {
     let writeBufAddr = writeBuf.baseAddress
 
     let syscallTestCases: Array<MockTestCase> = [
-      MockTestCase(name: "open", .interruptable, "a path", O_RDWR | O_APPEND) {
+      MockTestCase(name: "open", .interruptable, "a path", O_RDWR | O_CREAT | O_APPEND) {
         retryOnInterrupt in
         _ = try FileDescriptor.open(
-          "a path", .readWrite, options: [.append], retryOnInterrupt: retryOnInterrupt)
+          "a path", .readWrite, options: [.create, .append], retryOnInterrupt: retryOnInterrupt)
       },
 
       MockTestCase(name: "open", .interruptable, "a path", O_WRONLY | O_CREAT | O_APPEND, 0o777) {


### PR DESCRIPTION
I _think_ this precondition is filpped. Without this patch, the following code would fail the precondition:

```swift
try FileDescriptor.open(somePath, .writeOnly, options: [.create])
```

While it should translate to `O_WRONLY | O_CREAT`, a very common flag.

(I also think this precondition's existence is debatable. But I understand it guards against some surprises for those unfamiliar with this corner of POSIX)