### PR TITLE
FileOperations: Add Windows implementation for FileDescriptor.resize(to:)

### DIFF
--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -401,7 +401,6 @@ extension FileDescriptor {
 }
 #endif
 
-#if !os(Windows)
 /*System 1.2.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
 extension FileDescriptor {
   /// Truncate or extend the file referenced by this file descriptor.
@@ -447,4 +446,3 @@ extension FileDescriptor {
     }
   }
 }
-#endif

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -105,4 +105,11 @@ internal func pwrite(
   return Int(nNumberOfBytesWritten)
 }
 
+@inline(__always)
+internal func ftruncate(
+  _ fd: Int32,
+  _ length: off_t
+) -> Int32 {
+  _chsize(fd, numericCast(length))
+}
 #endif


### PR DESCRIPTION
#82 added `FileDescriptor.resize(to:)`. The original PR included adding `ftruncate` to `WindowsSycallAdapters.swift` but it was [removed during review](https://github.com/apple/swift-system/pull/82#discussion_r866323055), and so there is currently no implementation for `resize(to:)` on Windows.

The justification was that we didn't want to shoehorn Windows support into the POSIX code paths and that the Windows SDK was different enough to justify its own platform-specific implementation. However, looking at `chsize` (renamed `_chsize`) it looks like it's supposed to be the equivalent to the POSIX-like functions in UCRT.

In order to move discussion forward on an appropriate Windows implementation I have reinstated the syscall adapter as a strawman proposal.
