### PR TITLE
fixup: Remove os(Windows) guards for resize internals

### DIFF
--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -125,11 +125,9 @@ internal func system_pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
 }
 #endif
 
-#if !os(Windows)
 internal func system_ftruncate(_ fd: Int32, _ length: off_t) -> Int32 {
 #if ENABLE_MOCKING
   if mockingEnabled { return _mock(fd, length) }
 #endif
   return ftruncate(fd, length)
 }
-#endif

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -161,7 +161,6 @@ final class FileOperationsTest: XCTestCase {
 
   }
 
-#if !os(Windows)
   func testResizeFile() throws {
     let fd = try FileDescriptor.open("/tmp/\(UUID().uuidString).txt", .readWrite, options: [.create, .truncate], permissions: .ownerReadWrite)
     try fd.closeAfter {
@@ -203,6 +202,5 @@ final class FileOperationsTest: XCTestCase {
       XCTAssertEqual(readBytesAfterTruncation, Array("ab".utf8))
     }
   }
-#endif
 }
 


### PR DESCRIPTION
#89 attempted to add `FileDescriptor.resize(to:)` for Windows too, but there was still an `#if !os(Windows)` guard around an implementation detail so the Windows build failed.

This PR removes the guards around the internal implementation and the tests.