### PR TITLE
Tests: ignore XCTest manifest on newer Swift

### DIFF
--- a/Tests/SystemTests/XCTestManifests.swift
+++ b/Tests/SystemTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !canImport(ObjectiveC)
+#if !canImport(ObjectiveC) && swift(<5.5)
 import XCTest
 
 extension ErrnoTest {


### PR DESCRIPTION
This is motivated by the desire to build the test suite on Windows.
Newer versions of SPM have test discovery which obviates the test
manifest, which incidentally repairs the build on Windows while adopting
newer functionality and reducing management complexity.