### PR TITLE
Revert "FileOperations: Add Windows implementation for FileDescriptor.resize(to:)"

### DIFF
--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -401,6 +401,7 @@ extension FileDescriptor {
 }
 #endif
 
+#if !os(Windows)
 /*System 1.2.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
 extension FileDescriptor {
   /// Truncate or extend the file referenced by this file descriptor.
@@ -446,3 +447,4 @@ extension FileDescriptor {
     }
   }
 }
+#endif

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -105,11 +105,4 @@ internal func pwrite(
   return Int(nNumberOfBytesWritten)
 }
 
-@inline(__always)
-internal func ftruncate(
-  _ fd: Int32,
-  _ length: off_t
-) -> Int32 {
-  _chsize_s(fd, numericCast(length))
-}
 #endif


### PR DESCRIPTION
Reverts apple/swift-system#89

Resolves #92.
