### PR TITLE
Tests: explicitly construct `FilePath`

### DIFF
--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -163,7 +163,7 @@ final class FileOperationsTest: XCTestCase {
 
 #if !os(Windows)
   func testResizeFile() throws {
-    let fd = try FileDescriptor.open("/tmp/\(UUID().uuidString).txt", .readWrite, options: [.create, .truncate], permissions: .ownerReadWrite)
+    let fd = try FileDescriptor.open(FilePath("/tmp/\(UUID().uuidString).txt"), .readWrite, options: [.create, .truncate], permissions: .ownerReadWrite)
     try fd.closeAfter {
       // File should be empty initially.
       XCTAssertEqual(try fd.fileSize(), 0)


### PR DESCRIPTION
The literal value needs to be converted on different platform.
Explicitly construct the type rather than trying to change the literal
to the platform character type.