### PR TITLE
Tests: explicitly reference `PlatformChar` rather than `CChar`

### DIFF
--- a/Tests/SystemTests/FilePathTests/FilePathTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTest.swift
@@ -22,7 +22,7 @@ func filePathFromUnterminatedBytes<S: Sequence>(_ bytes: S) -> FilePath where S.
   array += [0]
 
   return array.withUnsafeBufferPointer {
-    $0.withMemoryRebound(to: CChar.self) {
+    $0.withMemoryRebound(to: CInterop.PlatformChar.self) {
       FilePath(platformString: $0.baseAddress!)
     }
   }


### PR DESCRIPTION
There is no guarantee that the `PlatformChar` is `CChar`.  On Windows,
this needs to be UTF16 rather than UTF8.  Explicitly use the
`PlatformChar` rather than `CChar`.