### PR TITLE
Tests: explicitly convert to UTF16 on Windows

### DIFF
--- a/Tests/SystemTests/FilePathTests/FilePathTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTest.swift
@@ -69,7 +69,11 @@ final class FilePathTest: XCTestCase {
       }
 
       testPath.filePath.withPlatformString {
+#if os(Windows)
+        XCTAssertEqual(testPath.string, String(decodingCString: $0, as: UTF16.self))
+#else
         XCTAssertEqual(testPath.string, String(cString: $0))
+#endif
         XCTAssertEqual(testPath.filePath, FilePath(platformString: $0))
       }
     }


### PR DESCRIPTION
File paths on Windows are represented in UTF16, while Swift strings are
UTF8.  Explicitly convert from UTF16 on Windows.