### PR TITLE
disable broken test case on Windows

### DIFF
--- a/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
@@ -249,6 +249,7 @@ final class FilePathComponentsTest: XCTestCase {
       TestPathComponents("/./..//", root: "/", [".", ".."]),
     ]
 #if !os(Windows)
+    // See https://github.com/apple/swift-system/issues/137
     testPaths += [
       TestPathComponents("//foo///bar/baz/", root: "/", ["foo", "bar", "baz"]),
     ]

--- a/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
@@ -231,7 +231,7 @@ final class FilePathComponentsTest: XCTestCase {
   }
 
   func testCases() {
-    let testPaths: Array<TestPathComponents> = [
+    var testPaths: Array<TestPathComponents> = [
       TestPathComponents("", root: nil, []),
       TestPathComponents("/", root: "/", []),
       TestPathComponents("foo", root: nil, ["foo"]),
@@ -244,11 +244,15 @@ final class FilePathComponentsTest: XCTestCase {
       TestPathComponents("/foo///bar", root: "/", ["foo", "bar"]),
       TestPathComponents("foo/bar/", root: nil, ["foo", "bar"]),
       TestPathComponents("foo///bar/baz/", root: nil, ["foo", "bar", "baz"]),
-      TestPathComponents("//foo///bar/baz/", root: "/", ["foo", "bar", "baz"]),
       TestPathComponents("./", root: nil, ["."]),
       TestPathComponents("./..", root: nil, [".", ".."]),
       TestPathComponents("/./..//", root: "/", [".", ".."]),
     ]
+#if !os(Windows)
+    testPaths += [
+      TestPathComponents("//foo///bar/baz/", root: "/", ["foo", "bar", "baz"]),
+    ]
+#endif
     testPaths.forEach { $0.runAllTests() }
   }
 


### PR DESCRIPTION
This test triggers an assertion failure.  It is unclear why this is
currently being parsed improperly.