### PR TITLE
Tests: change the conversion for string to array

### DIFF
--- a/Tests/SystemTests/SystemStringTests.swift
+++ b/Tests/SystemTests/SystemStringTests.swift
@@ -23,7 +23,11 @@ private func makeRaw(
   _ str: String
 ) -> [CInterop.PlatformChar] {
   var str = str
+#if os(Windows)
+  var array = Array(str.utf16)
+#else
   var array = str.withUTF8 { $0.withMemoryRebound(to: CChar.self, Array.init) }
+#endif
   array.append(0)
   return array
 }


### PR DESCRIPTION
Windows uses UTF16 for the platform character, not UTF8, and does not
map to CChar.  Add a Windows path for the conversion.