### PR TITLE
Tests: adjust invalid character

### DIFF
--- a/Tests/SystemTests/SystemStringTests.swift
+++ b/Tests/SystemTests/SystemStringTests.swift
@@ -288,7 +288,7 @@ extension SystemStringTest {
     source.withUnsafeBufferPointer {
       XCTAssertEqual(str, String(validatingPlatformString: $0.baseAddress!))
     }
-    source[1] = CInterop.PlatformChar(truncatingIfNeeded: 0xffff)
+    source[1] = CInterop.PlatformChar(truncatingIfNeeded: 0xdfff)
     str = String(validatingPlatformString: source)
     XCTAssertNil(str)
   }


### PR DESCRIPTION
Adjust the injected character to be an invalid UTF-16 and UTF-8
character.  This is required to make the tests pass on Windows.