### PR TITLE
Quote cmake include path

### DIFF
--- a/cmake/modules/SwiftSystemConfig.cmake.in
+++ b/cmake/modules/SwiftSystemConfig.cmake.in
@@ -8,5 +8,5 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 if(NOT TARGET SystemPackage)
-  include(@SWIFT_SYSTEM_EXPORTS_FILE@)
+  include("@SWIFT_SYSTEM_EXPORTS_FILE@")
 endif()


### PR DESCRIPTION
quote include path that helps if path contains eg. a space