### PR TITLE
Support OpenBSD.

### DIFF
--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -1274,6 +1274,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "badMessage")
   public static var EBADMSG: Errno { badMessage }
 
+#if !os(OpenBSD)
   /// Reserved.
   ///
   /// This error is reserved for future use.
@@ -1333,6 +1334,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "notStream")
   public static var ENOSTR: Errno { notStream }
+#endif
 
   /// Protocol error.
   ///
@@ -1348,6 +1350,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "protocolError")
   public static var EPROTO: Errno { protocolError }
 
+#if !os(OpenBSD)
   /// Reserved.
   ///
   /// This error is reserved for future use.
@@ -1359,6 +1362,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "timeout")
   public static var ETIME: Errno { timeout }
+#endif
 #endif
 
   /// Operation not supported on socket.

--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -16,7 +16,7 @@ public typealias CModeT =  CInterop.Mode
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
 @_implementationOnly import CSystem
 import Glibc
 #elseif os(Windows)

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -13,7 +13,7 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
 import Glibc
 #elseif os(Windows)
 import CSystem
@@ -392,6 +392,7 @@ internal var _ENOATTR: CInt { ENOATTR }
 @_alwaysEmitIntoClient
 internal var _EBADMSG: CInt { EBADMSG }
 
+#if !os(OpenBSD)
 @_alwaysEmitIntoClient
 internal var _EMULTIHOP: CInt { EMULTIHOP }
 
@@ -406,12 +407,15 @@ internal var _ENOSR: CInt { ENOSR }
 
 @_alwaysEmitIntoClient
 internal var _ENOSTR: CInt { ENOSTR }
+#endif 
 
 @_alwaysEmitIntoClient
 internal var _EPROTO: CInt { EPROTO }
 
+#if !os(OpenBSD)
 @_alwaysEmitIntoClient
 internal var _ETIME: CInt { ETIME }
+#endif
 #endif
 
 @_alwaysEmitIntoClient

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -14,7 +14,7 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
 @_implementationOnly import CSystem
 import Glibc
 #elseif os(Windows)

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -9,7 +9,7 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
 import Glibc
 #elseif os(Windows)
 import ucrt


### PR DESCRIPTION
Add the usual `os` conditionals and exclude errno constants that aren't present on this platform.

Maybe availability annotations are a better way to deal with this, but that is likely something that requires more careful consideration.