### PR TITLE
Add Sendable conformances (except FileDescriptor)

### DIFF
--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -473,3 +473,14 @@ extension FileDescriptor.OpenOptions
   /// A textual representation of the open options, suitable for debugging.
   public var debugDescription: String { self.description }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+// The decision on whether to make FileDescriptor Sendable or not
+// is currently being discussed in https://github.com/apple/swift-system/pull/112
+//@available(*, unavailable, message: "File descriptors are not completely thread-safe.")
+//extension FileDescriptor: Sendable {}
+
+extension FileDescriptor.AccessMode: Sendable {}
+extension FileDescriptor.OpenOptions: Sendable {}
+extension FileDescriptor.SeekOrigin: Sendable {}
+#endif

--- a/Sources/System/FilePath/FilePath.swift
+++ b/Sources/System/FilePath/FilePath.swift
@@ -69,3 +69,6 @@ extension FilePath {
 /*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 extension FilePath: Hashable, Codable {}
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension FilePath: Sendable {}
+#endif

--- a/Sources/System/FilePath/FilePathComponentView.swift
+++ b/Sources/System/FilePath/FilePathComponentView.swift
@@ -238,3 +238,8 @@ extension FilePath.ComponentView {
     #endif // DEBUG
   }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension FilePath.ComponentView: Sendable {}
+extension FilePath.ComponentView.Index: Sendable {}
+#endif

--- a/Sources/System/FilePath/FilePathComponents.swift
+++ b/Sources/System/FilePath/FilePathComponents.swift
@@ -276,3 +276,9 @@ extension FilePath.Root {
     #endif
   }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension FilePath.Root: Sendable {}
+extension FilePath.Component: Sendable {}
+extension FilePath.Component.Kind: Sendable {}
+#endif

--- a/Sources/System/FilePermissions.swift
+++ b/Sources/System/FilePermissions.swift
@@ -175,3 +175,7 @@ extension FilePermissions
   /// A textual representation of the file permissions, suitable for debugging.
   public var debugDescription: String { self.description }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension FilePermissions: Sendable {}
+#endif

--- a/Sources/System/SystemString.swift
+++ b/Sources/System/SystemString.swift
@@ -288,6 +288,11 @@ extension SystemString {
   }
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension SystemChar: Sendable {}
+extension SystemString: Sendable {}
+#endif
+
 // TODO: SystemString should use a COW-interchangable storage form rather
 // than array, so you could "borrow" the storage from a non-bridged String
 // or Data or whatever


### PR DESCRIPTION
This adds `Sendable` conformances to all public types, as well as the necessary internal types (`SystemString` and `SystemChar`).

Whether or not `FileDescriptor` should be Sendable is currently being discussed in #112.
This PR splits off `FileDescriptor`s conformance to have the possibility to land the other conformances earlier.