### PR TITLE
MachPort: fix build issues with Swift 5.7

### DIFF
--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if $MoveOnly && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
+#if swift(>=5.8) && $MoveOnly && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
 
 import Darwin.Mach
 

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if $MoveOnly && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
+#if swift(>=5.8) && $MoveOnly && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
 
 import XCTest
 import Darwin.Mach


### PR DESCRIPTION
It seems that `#if $MoveOnly` check has no effect in Swift 5.7, so we should check whether Swift 5.8 or later are available first.

Resolves #117.