### PR TITLE
Fix expand-availability syntax not to interfere with doc comment parsing

### DIFF
--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -10,7 +10,7 @@
 /// An error number used by system calls to communicate what kind of error
 /// occurred.
 @frozen
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 public struct Errno: RawRepresentable, Error, Hashable, Codable {
   /// The raw C error number.
   @_alwaysEmitIntoClient
@@ -1380,7 +1380,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
 }
 
 // Constants defined in header but not man page
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension Errno {
 
   /// Operation would block.
@@ -1474,7 +1474,7 @@ extension Errno {
 #endif
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension Errno {
   // TODO: We want to provide safe access to `errno`, but we need a
   // release-barrier to do so.
@@ -1489,14 +1489,14 @@ extension Errno {
 }
 
 // Use "hidden" entry points for `NSError` bridging
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension Errno {
   public var _code: Int { Int(rawValue) }
 
   public var _domain: String { "NSPOSIXErrorDomain" }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension Errno: CustomStringConvertible, CustomDebugStringConvertible {
   ///  A textual representation of the most recent error
   ///  returned by a system call.
@@ -1516,7 +1516,7 @@ extension Errno: CustomStringConvertible, CustomDebugStringConvertible {
   public var debugDescription: String { self.description }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension Errno {
   @_alwaysEmitIntoClient
   public static func ~=(_ lhs: Errno, _ rhs: Error) -> Bool {

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -14,7 +14,7 @@
 /// of `FileDescriptor` values,
 /// in the same way as you manage a raw C file handle.
 @frozen
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 public struct FileDescriptor: RawRepresentable, Hashable, Codable {
   /// The raw C file handle.
   @_alwaysEmitIntoClient
@@ -26,7 +26,7 @@ public struct FileDescriptor: RawRepresentable, Hashable, Codable {
 }
 
 // Standard file descriptors.
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FileDescriptor {
   /// The standard input file descriptor, with a numeric value of 0.
   @_alwaysEmitIntoClient
@@ -41,7 +41,7 @@ extension FileDescriptor {
   public static var standardError: FileDescriptor { .init(rawValue: 2) }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FileDescriptor {
   /// The desired read and write access for a newly opened file.
   @frozen
@@ -386,7 +386,7 @@ extension FileDescriptor {
   }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FileDescriptor.AccessMode
   : CustomStringConvertible, CustomDebugStringConvertible
 {
@@ -405,7 +405,7 @@ extension FileDescriptor.AccessMode
   public var debugDescription: String { self.description }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FileDescriptor.SeekOrigin
   : CustomStringConvertible, CustomDebugStringConvertible
 {
@@ -428,7 +428,7 @@ extension FileDescriptor.SeekOrigin
   public var debugDescription: String { self.description }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FileDescriptor.OpenOptions
   : CustomStringConvertible, CustomDebugStringConvertible
 {

--- a/Sources/System/FileHelpers.swift
+++ b/Sources/System/FileHelpers.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FileDescriptor {
   /// Runs a closure and then closes the file descriptor, even if an error occurs.
   ///

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FileDescriptor {
   /// Opens or creates a file for reading or writing.
   ///
@@ -369,7 +369,7 @@ extension FileDescriptor {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FileDescriptor {
   /// Duplicate this file descriptor and return the newly created copy.
   ///
@@ -399,7 +399,7 @@ extension FileDescriptor {
   ///
   /// The corresponding C functions are `dup` and `dup2`.
   @_alwaysEmitIntoClient
-  /*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+  @available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
   public func duplicate(
     as target: FileDescriptor? = nil,
     retryOnInterrupt: Bool = true
@@ -407,7 +407,7 @@ extension FileDescriptor {
     try _duplicate(as: target, retryOnInterrupt: retryOnInterrupt).get()
   }
 
-  /*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+  @available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
   @usableFromInline
   internal func _duplicate(
     as target: FileDescriptor?,
@@ -435,7 +435,7 @@ extension FileDescriptor {
 }
 
 #if !os(Windows)
-/*System 1.1.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
+@available(/*System 1.1.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 extension FileDescriptor {
   /// Create a pipe, a unidirectional data channel which can be used for interprocess communication.
   ///
@@ -443,12 +443,12 @@ extension FileDescriptor {
   ///
   /// The corresponding C function is `pipe`.
   @_alwaysEmitIntoClient
-  /*System 1.1.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
+  @available(/*System 1.1.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public static func pipe() throws -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
     try _pipe().get()
   }
 
-  /*System 1.1.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
+  @available(/*System 1.1.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   @usableFromInline
   internal static func _pipe() -> Result<(readEnd: FileDescriptor, writeEnd: FileDescriptor), Errno> {
     var fds: (Int32, Int32) = (-1, -1)
@@ -464,7 +464,7 @@ extension FileDescriptor {
 #endif
 
 #if !os(Windows)
-/*System 1.2.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
+@available(/*System 1.2.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 extension FileDescriptor {
   /// Truncate or extend the file referenced by this file descriptor.
   ///
@@ -486,7 +486,7 @@ extension FileDescriptor {
   /// associated with the file.
   ///
   /// The corresponding C function is `ftruncate`.
-  /*System 1.2.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
+  @available(/*System 1.2.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   @_alwaysEmitIntoClient
   public func resize(
     to newSize: Int64,
@@ -498,7 +498,7 @@ extension FileDescriptor {
     ).get()
   }
 
-  /*System 1.2.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
+  @available(/*System 1.2.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   @usableFromInline
   internal func _resize(
     to newSize: Int64,

--- a/Sources/System/FilePath/FilePath.swift
+++ b/Sources/System/FilePath/FilePath.swift
@@ -7,9 +7,6 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-// TODO(docs): Section on all the new syntactic operations, lexical normalization, decomposition,
-// components, etc.
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
 /// Represents a location in the file system.
 ///
 /// This structure recognizes directory separators  (e.g. `/`), roots, and
@@ -40,7 +37,10 @@
 /// However, the rules for path equivalence
 /// are file-system–specific and have additional considerations
 /// like case insensitivity, Unicode normalization, and symbolic links.
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 public struct FilePath {
+  // TODO(docs): Section on all the new syntactic operations, lexical normalization, decomposition,
+  // components, etc.
   internal var _storage: SystemString
 
   /// Creates an empty, null-terminated path.
@@ -59,13 +59,13 @@ public struct FilePath {
   }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath {
   /// The length of the file path, excluding the null terminator.
   public var length: Int { _storage.length }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath: Hashable, Codable {}
 
 #if compiler(>=5.5) && canImport(_Concurrency)

--- a/Sources/System/FilePath/FilePathComponentView.swift
+++ b/Sources/System/FilePath/FilePathComponentView.swift
@@ -9,7 +9,7 @@
 
 // MARK: - API
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   /// A bidirectional, range replaceable collection of the non-root components
   /// that make up a file path.
@@ -88,7 +88,7 @@ extension FilePath {
   #endif
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.ComponentView: BidirectionalCollection {
   public typealias Element = FilePath.Component
   public struct Index: Comparable, Hashable {
@@ -122,7 +122,7 @@ extension FilePath.ComponentView: BidirectionalCollection {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.ComponentView: RangeReplaceableCollection {
   public init() {
     self.init(FilePath())
@@ -172,7 +172,7 @@ extension FilePath.ComponentView: RangeReplaceableCollection {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   /// Create a file path from a root and a collection of components.
   public init<C: Collection>(
@@ -201,7 +201,7 @@ extension FilePath {
 
 // MARK: - Internals
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.ComponentView: _PathSlice {
   internal var _range: Range<SystemString.Index> {
     _start ..< _path._storage.endIndex
@@ -214,7 +214,7 @@ extension FilePath.ComponentView: _PathSlice {
 
 // MARK: - Invariants
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.ComponentView {
   internal func _invariantCheck() {
     #if DEBUG

--- a/Sources/System/FilePath/FilePathComponents.swift
+++ b/Sources/System/FilePath/FilePathComponents.swift
@@ -9,7 +9,7 @@
 
 // MARK: - API
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   /// Represents a root of a file path.
   ///
@@ -72,7 +72,7 @@ extension FilePath {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component {
 
   /// Whether a component is a regular file or directory name, or a special
@@ -97,7 +97,7 @@ extension FilePath.Component {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Root {
   // TODO: Windows analysis APIs
 }
@@ -183,17 +183,17 @@ extension _PathSlice {
   internal var _storage: SystemString { _path._storage }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component: _PathSlice {
 }
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Root: _PathSlice {
   internal var _range: Range<SystemString.Index> {
     (..<_rootEnd).relative(to: _path._storage)
   }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath: _PlatformStringable {
   func _withPlatformString<Result>(_ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result) rethrows -> Result {
     try _storage.withPlatformString(body)
@@ -205,7 +205,7 @@ extension FilePath: _PlatformStringable {
 
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component {
   // The index of the `.` denoting an extension
   internal func _extensionIndex() -> SystemString.Index? {
@@ -234,7 +234,7 @@ internal func _makeExtension(_ ext: String) -> SystemString {
   return result
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component {
   internal init?(_ str: SystemString) {
     // FIXME: explicit null root? Or something else?
@@ -247,7 +247,7 @@ extension FilePath.Component {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Root {
   internal init?(_ str: SystemString) {
     // FIXME: explicit null root? Or something else?
@@ -262,7 +262,7 @@ extension FilePath.Root {
 
 // MARK: - Invariants
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component {
   // TODO: ensure this all gets easily optimized away in release...
   internal func _invariantCheck() {
@@ -275,7 +275,7 @@ extension FilePath.Component {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Root {
   internal func _invariantCheck() {
     #if DEBUG

--- a/Sources/System/FilePath/FilePathParsing.swift
+++ b/Sources/System/FilePath/FilePathParsing.swift
@@ -111,7 +111,7 @@ extension SystemString {
   }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath {
   internal mutating func _removeTrailingSeparator() {
     _storage._removeTrailingSeparator()
@@ -192,7 +192,7 @@ extension SystemString {
   }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath {
   internal var _relativeStart: SystemString.Index {
     _storage._relativePathStart
@@ -204,7 +204,7 @@ extension FilePath {
 
 // Parse separators
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath {
   internal typealias _Index = SystemString.Index
 
@@ -268,7 +268,7 @@ extension FilePath {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.ComponentView {
   // TODO: Store this...
   internal var _relativeStart: SystemString.Index {
@@ -293,7 +293,7 @@ extension SystemString {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Root {
   // Asserting self is a root, returns whether this is an
   // absolute root.
@@ -318,7 +318,7 @@ extension FilePath.Root {
   }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath {
   internal var _portableDescription: String {
     guard _windowsPaths else { return description }
@@ -337,7 +337,7 @@ internal var _windowsPaths: Bool {
   #endif
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath {
   // Whether we should add a separator when doing an append
   internal var _needsSeparatorForAppend: Bool {
@@ -365,7 +365,7 @@ extension FilePath {
 }
 
 // MARK: - Invariants
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath {
   internal func _invariantCheck() {
     #if DEBUG

--- a/Sources/System/FilePath/FilePathString.swift
+++ b/Sources/System/FilePath/FilePathString.swift
@@ -9,7 +9,7 @@
 
 // MARK: - Platform string
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   /// Creates a file path by copying bytes from a null-terminated platform
   /// string.
@@ -109,7 +109,7 @@ extension FilePath {
 #endif
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component {
   /// Creates a file path component by copying bytes from a null-terminated
   /// platform string.
@@ -198,7 +198,7 @@ extension FilePath.Component {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Root {
   /// Creates a file path root by copying bytes from a null-terminated platform
   /// string.
@@ -287,7 +287,7 @@ extension FilePath.Root {
 
 // MARK: - String literals
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath: ExpressibleByStringLiteral {
   /// Creates a file path from a string literal.
   ///
@@ -306,7 +306,7 @@ extension FilePath: ExpressibleByStringLiteral {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component: ExpressibleByStringLiteral {
   /// Create a file path component from a string literal.
   ///
@@ -331,7 +331,7 @@ extension FilePath.Component: ExpressibleByStringLiteral {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Root: ExpressibleByStringLiteral {
   /// Create a file path root from a string literal.
   ///
@@ -356,7 +356,7 @@ extension FilePath.Root: ExpressibleByStringLiteral {
 
 // MARK: - Printing and dumping
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the file path.
   ///
@@ -372,7 +372,7 @@ extension FilePath: CustomStringConvertible, CustomDebugStringConvertible {
   public var debugDescription: String { description.debugDescription }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component: CustomStringConvertible, CustomDebugStringConvertible {
 
   /// A textual representation of the path component.
@@ -389,7 +389,7 @@ extension FilePath.Component: CustomStringConvertible, CustomDebugStringConverti
   public var debugDescription: String { description.debugDescription }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Root: CustomStringConvertible, CustomDebugStringConvertible {
 
   /// A textual representation of the path root.
@@ -409,7 +409,7 @@ extension FilePath.Root: CustomStringConvertible, CustomDebugStringConvertible {
 // MARK: - Convenience helpers
 
 // Convenience helpers
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   /// Creates a string by interpreting the path’s content as UTF-8 on Unix
   /// and UTF-16 on Windows.
@@ -420,7 +420,7 @@ extension FilePath {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component {
   /// Creates a string by interpreting the component’s content as UTF-8 on Unix
   /// and UTF-16 on Windows.
@@ -431,7 +431,7 @@ extension FilePath.Component {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Root {
   /// On Unix, this returns `"/"`.
   ///
@@ -445,7 +445,7 @@ extension FilePath.Root {
 
 // MARK: - Decoding and validating
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension String {
   /// Creates a string by interpreting the file path's content as UTF-8 on Unix
   /// and UTF-16 on Windows.
@@ -475,7 +475,7 @@ extension String {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension String {
   /// Creates a string by interpreting the path component's content as UTF-8 on
   /// Unix and UTF-16 on Windows.
@@ -505,7 +505,7 @@ extension String {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension String {
   /// On Unix, creates the string `"/"`
   ///
@@ -558,7 +558,7 @@ extension String {
 
 // MARK: - Deprecations
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension String {
   @available(*, deprecated, renamed: "init(decoding:)")
   public init(_ path: FilePath) { self.init(decoding: path) }
@@ -568,7 +568,7 @@ extension String {
 }
 
 #if !os(Windows)
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath {
   /// For backwards compatibility only. This initializer is equivalent to
   /// the preferred `FilePath(platformString:)`.

--- a/Sources/System/FilePath/FilePathSyntax.swift
+++ b/Sources/System/FilePath/FilePathSyntax.swift
@@ -9,7 +9,7 @@
 
 // MARK: - Query API
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   /// Returns true if this path uniquely identifies the location of
   /// a file without reference to an additional starting location.
@@ -99,7 +99,7 @@ extension FilePath {
 }
 
 // MARK: - Decompose a path
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   /// Returns the root of a path if there is one, otherwise `nil`.
   ///
@@ -182,7 +182,7 @@ extension FilePath {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   /// Returns the final component of the path.
   /// Returns `nil` if the path is empty or only contains a root.
@@ -252,7 +252,7 @@ extension FilePath {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component {
   /// The extension of this file or directory component.
   ///
@@ -283,7 +283,7 @@ extension FilePath.Component {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
 
   /// The extension of the file or directory last component.
@@ -349,7 +349,7 @@ extension FilePath {
 
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   /// Whether the path is in lexical-normal form, that is `.` and `..`
   /// components have been collapsed lexically (i.e. without following
@@ -430,7 +430,7 @@ extension FilePath {
 }
 
 // Modification and concatenation API
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   // TODO(Windows docs): example with roots
   /// If `prefix` is a prefix of `self`, removes it and returns `true`.
@@ -583,7 +583,7 @@ extension FilePath {
 }
 
 // MARK - Renamed
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   @available(*, unavailable, renamed: "removingLastComponent()")
   public var dirname: FilePath { removingLastComponent() }

--- a/Sources/System/FilePermissions.swift
+++ b/Sources/System/FilePermissions.swift
@@ -17,7 +17,7 @@
 ///     let perms = FilePermissions(rawValue: 0o644)
 ///     perms == [.ownerReadWrite, .groupRead, .otherRead] // true
 @frozen
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 public struct FilePermissions: OptionSet, Hashable, Codable {
   /// The raw C file permissions.
   @_alwaysEmitIntoClient
@@ -135,7 +135,7 @@ public struct FilePermissions: OptionSet, Hashable, Codable {
   public static var saveText: FilePermissions { FilePermissions(0o1000) }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePermissions
   : CustomStringConvertible, CustomDebugStringConvertible
 {

--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -29,12 +29,12 @@ import ucrt
 public typealias CModeT = CInt
 #else
 /// The C `mode_t` type.
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 public typealias CModeT = mode_t
 #endif
 
 /// A namespace for C and platform types
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 public enum CInterop {
 #if os(Windows)
   public typealias Mode = CInt

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -24,7 +24,7 @@ internal func _machPrecondition(
   precondition(kr == expected, file: file, line: line)
 }
 
-/*System 1.3.0, @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)*/
+@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 @frozen
 public enum Mach {
   @_moveOnly

--- a/Sources/System/PlatformString.swift
+++ b/Sources/System/PlatformString.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension String {
   /// Creates a string by interpreting the null-terminated platform string as
   /// UTF-8 on Unix and UTF-16 on Windows.
@@ -164,7 +164,7 @@ extension String {
 
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension CInterop.PlatformChar {
   internal var _platformCodeUnit: CInterop.PlatformUnicodeEncoding.CodeUnit {
     #if os(Windows)
@@ -175,7 +175,7 @@ extension CInterop.PlatformChar {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension CInterop.PlatformUnicodeEncoding.CodeUnit {
   internal var _platformChar: CInterop.PlatformChar {
     #if os(Windows)

--- a/Sources/System/Util.swift
+++ b/Sources/System/Util.swift
@@ -8,21 +8,21 @@
 */
 
 // Results in errno if i == -1
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 private func valueOrErrno<I: FixedWidthInteger>(
   _ i: I
 ) -> Result<I, Errno> {
   i == -1 ? .failure(Errno.current) : .success(i)
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 private func nothingOrErrno<I: FixedWidthInteger>(
   _ i: I
 ) -> Result<(), Errno> {
   valueOrErrno(i).map { _ in () }
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 internal func valueOrErrno<I: FixedWidthInteger>(
   retryOnInterrupt: Bool, _ f: () -> I
 ) -> Result<I, Errno> {
@@ -36,7 +36,7 @@ internal func valueOrErrno<I: FixedWidthInteger>(
   } while true
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 internal func nothingOrErrno<I: FixedWidthInteger>(
   retryOnInterrupt: Bool, _ f: () -> I
 ) -> Result<(), Errno> {

--- a/Tests/SystemTests/ErrnoTest.swift
+++ b/Tests/SystemTests/ErrnoTest.swift
@@ -19,7 +19,7 @@ import System
 import WinSDK
 #endif
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 final class ErrnoTest: XCTestCase {
   func testConstants() {
     XCTAssert(EPERM == Errno.notPermitted.rawValue)

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -15,7 +15,7 @@ import SystemPackage
 import System
 #endif
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 final class FileOperationsTest: XCTestCase {
   func testSyscalls() {
     let fd = FileDescriptor(rawValue: 1)

--- a/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
@@ -15,7 +15,7 @@ import XCTest
 @testable import System
 #endif
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 struct TestPathComponents: TestCase {
   var path: FilePath
   var expectedRoot: FilePath.Root?
@@ -100,7 +100,7 @@ struct TestPathComponents: TestCase {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 final class FilePathComponentsTest: XCTestCase {
   func testAdHocRRC() {
     var path: FilePath = "/usr/local/bin"

--- a/Tests/SystemTests/FilePathTests/FilePathExtras.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathExtras.swift
@@ -6,7 +6,7 @@
 #endif
 
 // Why can't I write this extension on `FilePath.ComponentView.SubSequence`?
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension Slice where Base == FilePath.ComponentView {
   internal var _storageSlice: SystemString.SubSequence {
     base._path._storage[self.startIndex._storage ..< self.endIndex._storage]
@@ -15,7 +15,7 @@ extension Slice where Base == FilePath.ComponentView {
 
 
 // Proposed API that didn't make the cut, but we stil want to keep our testing for
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath {
   /// Returns `self` relative to `base`.
   /// This does not cosult the file system or resolve symlinks.

--- a/Tests/SystemTests/FilePathTests/FilePathParsingTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathParsingTest.swift
@@ -68,7 +68,7 @@ extension ParsingTestCase {
 @testable import System
 #endif
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 final class FilePathParsingTest: XCTestCase {
   func testNormalization() {
     let unixPaths: Array<ParsingTestCase> = [

--- a/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
@@ -146,7 +146,7 @@ extension SyntaxTestCase {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension SyntaxTestCase {
   func testComponents(_ path: FilePath, expected: [String]) {
     let expectedComponents = expected.map { FilePath.Component($0)! }
@@ -342,7 +342,7 @@ private struct WindowsRootTestCase: TestCase {
   var line: UInt
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension WindowsRootTestCase {
   func runAllTests() {
     withWindowsPaths(enabled: true) {
@@ -357,7 +357,7 @@ extension WindowsRootTestCase {
   }
 }
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 final class FilePathSyntaxTest: XCTestCase {
   func testPathSyntax() {
     let unixPaths: Array<SyntaxTestCase> = [

--- a/Tests/SystemTests/FilePathTests/FilePathTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTest.swift
@@ -15,7 +15,7 @@ import SystemPackage
 import System
 #endif
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 func filePathFromUnterminatedBytes<S: Sequence>(_ bytes: S) -> FilePath where S.Element == UInt8 {
   var array = Array(bytes)
   assert(array.last != 0, "already null terminated")
@@ -29,7 +29,7 @@ func filePathFromUnterminatedBytes<S: Sequence>(_ bytes: S) -> FilePath where S.
 }
 let invalidBytes: [UInt8] = [0x2F, 0x61, 0x2F, 0x62, 0x2F, 0x83]
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 final class FilePathTest: XCTestCase {
   struct TestPath {
     let filePath: FilePath

--- a/Tests/SystemTests/FileTypesTest.swift
+++ b/Tests/SystemTests/FileTypesTest.swift
@@ -15,7 +15,7 @@ import SystemPackage
 import System
 #endif
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 final class FileDescriptorTest: XCTestCase {
   func testStandardDescriptors() {
     XCTAssertEqual(FileDescriptor.standardInput.rawValue, 0)
@@ -64,7 +64,7 @@ final class FileDescriptorTest: XCTestCase {
 
 }
 
-/*System 0.0.1, @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)*/
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 final class FilePermissionsTest: XCTestCase {
 
   func testPermissions() {

--- a/Tests/SystemTests/MockingTest.swift
+++ b/Tests/SystemTests/MockingTest.swift
@@ -15,7 +15,7 @@ import XCTest
 @testable import System
 #endif
 
-/*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 final class MockingTest: XCTestCase {
   func testMocking() {
     XCTAssertFalse(mockingEnabled)

--- a/Utilities/expand-availability.py
+++ b/Utilities/expand-availability.py
@@ -6,10 +6,17 @@
 # In order for this to work, ABI-impacting declarations need to be annotated
 # with special comments in the following format:
 #
-#     /*System 0.0.2*/
+#     @available(/*System 0.0.2*/iOS 8, *)
 #     public func greeting() -> String {
 #       "Hello"
 #     }
+#
+# (The iOS 8 availability is a dummy no-op declaration -- it only has to be there because
+# `@available(*)` isn't valid syntax, and commenting out the entire `@available` attribute
+# would interfere with parser tools for doc comments. `iOS 8` is the shortest version string that
+# matches the minimum possible deployment target for Swift code, so we use that as our dummy
+# availability version. `@available(iOS 8, *)` is functionally equivalent to not having an
+# `@available` attribute at all.)
 #
 # The script adds full availability incantations to these comments. It can run
 # in one of two modes:
@@ -19,16 +26,16 @@
 # availability across `SystemPackage` and the ABI-stable `System` module that
 # ships in Apple's OS releases:
 #
-#     /*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+#     @available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 #     public func greeting() -> String {
 #       "Hello"
 #     }
 #
-# `expand-availability.py --attributes` adds actual availability attributes.
+# `expand-availability.py --attributes` adds actual availability declarations.
 # This is used by maintainers to build ABI stable releases of System on Apple's
 # platforms:
 #
-#     /*System 0.0.2*/@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+#     @available(/*System 0.0.2: */macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 #     public func greeting() -> String {
 #       "Hello"
 #     }
@@ -65,22 +72,44 @@ def swift_sources_in(path):
                 result.append(os.path.join(dir, file))
     return result
 
-macro_pattern = re.compile(
+# Old-style syntax:
+# /*System 0.0.2*/
+# /*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
+# /*System 0.0.2*/@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+old_macro_pattern = re.compile(
     r"/\*(System [^ *]+)(, @available\([^)]*\))?\*/(@available\([^)]*\))?")
+
+# New-style comments:
+# @available(/*SwiftSystem 0.0.2*/macOS 10, *)
+# @available(/*SwiftSystem 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
+# @available(/*SwiftSystem 0.0.2*/macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+#
+# These do not interfere with our tools' ability to find doc comments.
+macro_pattern = re.compile(
+    r"@available\(/\*(System [^ *:]+)[^*/)]*\*/([^)]*)\*\)")
+
+def available_attribute(filename, lineno, symbolic_version):
+    expansion = versions[symbolic_version]
+    if expansion is None:
+        raise ValueError("{0}:{1}: error: Unknown System version '{0}'"
+            .format(fileinput.filename(), fileinput.lineno(), symbolic_version))
+    if args.attributes:
+        attribute = "@available(/*{0}*/{1}, *)".format(symbolic_version, expansion)
+    else:
+        # Sadly `@available(*)` is not valid syntax, so we have to mention at least one actual
+        # platform here.
+        attribute = "@available(/*{0}: {1}*/iOS 8, *)".format(symbolic_version, expansion)
+    return attribute
+
 
 sources = swift_sources_in("Sources") + swift_sources_in("Tests")
 for line in fileinput.input(files=sources, inplace=True):
     match = re.search(macro_pattern, line)
+    if match is None:
+        match = re.search(old_macro_pattern, line)
     if match:
-        system_version = match.group(1)
-        expansion = versions[system_version]
-        if expansion is None:
-            raise ValueError("{0}:{1}: error: Unknown System version '{0}'"
-                             .format(fileinput.filename(), fileinput.lineno(),
-                                     system_version))
-        if args.attributes:
-            replacement = "/*{0}*/@available({1}, *)".format(system_version, expansion)
-        else:
-            replacement = "/*{0}, @available({1}, *)*/".format(system_version, expansion)
+        symbolic_version = match.group(1)
+        replacement = available_attribute(
+            fileinput.filename(), fileinput.lineno(), symbolic_version)
         line = line[:match.start()] + replacement + line[match.end():]
     print(line, end="")

--- a/Utilities/expand-availability.py
+++ b/Utilities/expand-availability.py
@@ -11,12 +11,13 @@
 #       "Hello"
 #     }
 #
-# (The iOS 8 availability is a dummy no-op declaration -- it only has to be there because
-# `@available(*)` isn't valid syntax, and commenting out the entire `@available` attribute
-# would interfere with parser tools for doc comments. `iOS 8` is the shortest version string that
-# matches the minimum possible deployment target for Swift code, so we use that as our dummy
-# availability version. `@available(iOS 8, *)` is functionally equivalent to not having an
-# `@available` attribute at all.)
+# (The iOS 8 availability is a dummy no-op declaration -- it only has to be
+# there because `@available(*)` isn't valid syntax, and commenting out the
+# entire `@available` attribute would interfere with parser tools for doc
+# comments. `iOS 8` is the shortest version string that matches the minimum
+# possible deployment target for Swift code, so we use that as our dummy
+# availability version. `@available(iOS 8, *)` is functionally equivalent to not
+# having an `@available` attribute at all.)
 #
 # The script adds full availability incantations to these comments. It can run
 # in one of two modes:
@@ -96,8 +97,8 @@ def available_attribute(filename, lineno, symbolic_version):
     if args.attributes:
         attribute = "@available(/*{0}*/{1}, *)".format(symbolic_version, expansion)
     else:
-        # Sadly `@available(*)` is not valid syntax, so we have to mention at least one actual
-        # platform here.
+        # Sadly `@available(*)` is not valid syntax, so we have to mention at
+        # least one actual platform here.
         attribute = "@available(/*{0}: {1}*/iOS 8, *)".format(symbolic_version, expansion)
     return attribute
 


### PR DESCRIPTION
swift-system is shipping both as an ABI stable module in Apple SDKs, and as a source-stable package. Both variants are built from the same codebase, but for the SDK builds, we need to annotate each declaration with the first OS versions that shipped them.

We use the script `Utilities/expand-availability.py` to add or remove availability annotations from our sources, depending on context. 

(The Swift compiler supports actual availability macros these days, however, unfortunately they require the use of command-line options that are considered "unsafe" by SwiftPM -- so we cannot use availability macros in packages.)

The script uses specially formatted comments to find the appropriate places for availability expansions. Our previous syntax convention was this:

    /// Fiddle with the thing.
    /*System 0.0.2*/
    public func foo()

    /// Fiddle with the thing.
    /*System 0.0.2, @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)*/
    public func foo()

    /// Fiddle with the thing.
    /*System 0.0.2*/@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
    public func foo()

Unfortunately, regular comments in between a declaration and its preceding doc comments interfere with documentation tools.

This PR changes things to the style below instead:

    /// Fiddle with the thing.
    @available(/*System 0.0.2*/macOS 10, *)
    public func foo()

    /// Fiddle with the thing.
    @available(/*SwiftSystem 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/macOS 10, *)
    public func foo()

    /// Fiddle with the thing.
    @available(/*SwiftSystem 0.0.2*/macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
    public func foo()

Unfortunately, `@available(*)` isn’t valid syntax, so we have to add a dummy “macOS 10” version spec. It should have no actual effect.