### PR TITLE
Re-enable Mach.Port

### DIFF
--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -81,17 +81,17 @@ public enum Mach {
     }
 
     deinit {
-      if _name == 0xFFFFFFFF /* MACH_PORT_DEAD */ {
-        precondition(RightType.self != ReceiveRight.self, "Receive rights cannot be dead names")
-        _machPrecondition(mach_port_mod_refs(mach_task_self_, _name, MACH_PORT_RIGHT_DEAD_NAME, -1))
+      if RightType.self == ReceiveRight.self {
+        precondition(_name != 0xffffffff, "Receive rights cannot be dead names")
+        _machPrecondition(
+          mach_port_destruct(mach_task_self_, _name, 0, _context)
+        )
       } else {
-        if RightType.self == ReceiveRight.self {
-          _machPrecondition(mach_port_destruct(mach_task_self_, _name, 0, _context))
-        } else if RightType.self == SendRight.self {
-          _machPrecondition(mach_port_deallocate(mach_task_self_, _name))
-        } else if RightType.self == SendOnceRight.self {
-          _machPrecondition(mach_port_mod_refs(mach_task_self_, _name, MACH_PORT_RIGHT_SEND_ONCE, -1))
-        }
+        assert(
+          RightType.self == SendRight.self ||
+          RightType.self == SendOnceRight.self
+        )
+        _machPrecondition(mach_port_deallocate(mach_task_self_, _name))
       }
     }
   }

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -167,9 +167,11 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// After this function completes, the Mach.Port is destroyed and no longer
   /// usable.
   @inlinable
-  public __consuming func relinquish(
+  public consuming func relinquish(
   ) -> (name: mach_port_name_t, context: mach_port_context_t) {
-    return (name: _name, context: _context)
+    let destructured = (name: _name, context: _context)
+    discard self
+    return destructured
   }
 
   /// Remove guard and transfer ownership of the underlying port right to
@@ -187,9 +189,11 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// Mach.ReceiveRights. Use relinquish() to avoid the syscall and extract
   /// the context value along with the port name.
   @inlinable
-  public __consuming func unguardAndRelinquish() -> mach_port_name_t {
-    _machPrecondition(mach_port_unguard(mach_task_self_, _name, _context))
-    return _name
+  public consuming func unguardAndRelinquish() -> mach_port_name_t {
+    let (name, context) = (_name, _context)
+    discard self
+    _machPrecondition(mach_port_unguard(mach_task_self_, name, context))
+    return name
   }
 
   /// Borrow access to the port name in a block that can perform
@@ -288,8 +292,10 @@ extension Mach.Port where RightType == Mach.SendRight {
   /// After this function completes, the Mach.Port is destroyed and no longer
   /// usable.
   @inlinable
-  public __consuming func relinquish() -> mach_port_name_t {
-    return _name
+  public consuming func relinquish() -> mach_port_name_t {
+    let name = _name
+    discard self
+    return name
   }
 
   /// Create another send right from a given send right.
@@ -326,8 +332,10 @@ extension Mach.Port where RightType == Mach.SendOnceRight {
   /// After this function completes, the Mach.Port is destroyed and no longer
   /// usable.
   @inlinable
-  public __consuming func relinquish() -> mach_port_name_t {
-    return _name
+  public consuming func relinquish() -> mach_port_name_t {
+    let name = _name
+    discard self
+    return name
   }
 }
 

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -86,7 +86,7 @@ public enum Mach {
         _machPrecondition(mach_port_mod_refs(mach_task_self_, _name, MACH_PORT_RIGHT_DEAD_NAME, -1))
       } else {
         if RightType.self == ReceiveRight.self {
-          _machPrecondition(mach_port_destruct(mach_task_self_, _name, -1, _context))
+          _machPrecondition(mach_port_destruct(mach_task_self_, _name, 0, _context))
         } else if RightType.self == SendRight.self {
           _machPrecondition(mach_port_mod_refs(mach_task_self_, _name, MACH_PORT_RIGHT_SEND, -1))
         } else if RightType.self == SendOnceRight.self {

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -308,7 +308,7 @@ extension Mach.Port where RightType == Mach.SendRight {
 
     // name is the same because send rights are coalesced
     let kr = mach_port_insert_right(mach_task_self_, _name, _name, mach_msg_type_name_t(how))
-    if kr == KERN_INVALID_CAPABILITY {
+    if kr == KERN_INVALID_NAME {
       throw Mach.PortRightError.deadName
     }
     _machPrecondition(kr)

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -135,6 +135,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// The underlying port right will be automatically deallocated when
   /// the Mach.Port object is destroyed.
   public init(name: mach_port_name_t, context: mach_port_context_t) {
+    precondition(name != mach_port_name_t(MACH_PORT_NULL), "Mach.Port cannot be initialized with MACH_PORT_NULL")
     self._name = name
     self._context = context
   }

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if false && swift(>=5.8) && $MoveOnly && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
+#if swift(>=5.9) && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
 
 import Darwin.Mach
 

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -190,8 +190,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// the context value along with the port name.
   @inlinable
   public consuming func unguardAndRelinquish() -> mach_port_name_t {
-    let (name, context) = (_name, _context)
-    discard self
+    let (name, context) = self.relinquish()
     _machPrecondition(mach_port_unguard(mach_task_self_, name, context))
     return name
   }

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -88,7 +88,7 @@ public enum Mach {
         if RightType.self == ReceiveRight.self {
           _machPrecondition(mach_port_destruct(mach_task_self_, _name, 0, _context))
         } else if RightType.self == SendRight.self {
-          _machPrecondition(mach_port_mod_refs(mach_task_self_, _name, MACH_PORT_RIGHT_SEND, -1))
+          _machPrecondition(mach_port_deallocate(mach_task_self_, _name))
         } else if RightType.self == SendOnceRight.self {
           _machPrecondition(mach_port_mod_refs(mach_task_self_, _name, MACH_PORT_RIGHT_SEND_ONCE, -1))
         }

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -48,11 +48,13 @@ public enum Mach {
     ///
     /// This initializer makes a syscall to guard the right.
     public init(name: mach_port_name_t) {
-      precondition(name != mach_port_name_t(MACH_PORT_NULL), "Mach.Port cannot be initialized with MACH_PORT_NULL")
+      precondition(name != mach_port_name_t(MACH_PORT_NULL),
+                   "Mach.Port cannot be initialized with MACH_PORT_NULL")
       self._name = name
 
       if RightType.self == ReceiveRight.self {
-        precondition(name != 0xFFFFFFFF /* MACH_PORT_DEAD */, "Receive rights cannot be dead names")
+        precondition(name != 0xFFFFFFFF /* MACH_PORT_DEAD */,
+                     "Receive rights cannot be dead names")
 
         let secret = mach_port_context_t(arc4random())
         _machPrecondition(mach_port_guard(mach_task_self_, name, secret, 0))
@@ -82,7 +84,8 @@ public enum Mach {
 
     deinit {
       if RightType.self == ReceiveRight.self {
-        precondition(_name != 0xffffffff, "Receive rights cannot be dead names")
+        precondition(_name != 0xFFFFFFFF /* MACH_PORT_DEAD */,
+                     "Receive rights cannot be dead names")
         _machPrecondition(
           mach_port_destruct(mach_task_self_, _name, 0, _context)
         )
@@ -135,7 +138,8 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// The underlying port right will be automatically deallocated when
   /// the Mach.Port object is destroyed.
   public init(name: mach_port_name_t, context: mach_port_context_t) {
-    precondition(name != mach_port_name_t(MACH_PORT_NULL), "Mach.Port cannot be initialized with MACH_PORT_NULL")
+    precondition(name != mach_port_name_t(MACH_PORT_NULL),
+                 "Mach.Port cannot be initialized with MACH_PORT_NULL")
     self._name = name
     self._context = context
   }
@@ -251,7 +255,11 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
     let how = MACH_MSG_TYPE_MAKE_SEND
 
     // name is the same because send and recv rights are coalesced
-    _machPrecondition(mach_port_insert_right(mach_task_self_, _name, _name, mach_msg_type_name_t(how)))
+    _machPrecondition(
+      mach_port_insert_right(
+        mach_task_self_, _name, _name, mach_msg_type_name_t(how)
+      )
+    )
 
     return Mach.Port(name: _name)
   }
@@ -316,7 +324,9 @@ extension Mach.Port where RightType == Mach.SendRight {
     let how = MACH_MSG_TYPE_COPY_SEND
 
     // name is the same because send rights are coalesced
-    let kr = mach_port_insert_right(mach_task_self_, _name, _name, mach_msg_type_name_t(how))
+    let kr = mach_port_insert_right(
+      mach_task_self_, _name, _name, mach_msg_type_name_t(how)
+    )
     if kr == KERN_INVALID_NAME || kr == KERN_INVALID_CAPABILITY {
       throw Mach.PortRightError.deadName
     }

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -147,9 +147,9 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   @inlinable
   public init() {
     var storage: mach_port_name_t = mach_port_name_t(MACH_PORT_NULL)
-    withUnsafeMutablePointer(to: &storage) { storage in
-      _machPrecondition(mach_port_allocate(mach_task_self_, MACH_PORT_RIGHT_RECEIVE, storage))
-    }
+    _machPrecondition(
+      mach_port_allocate(mach_task_self_, MACH_PORT_RIGHT_RECEIVE, &storage)
+    )
 
     // name-only init will guard ReceiveRights
     self.init(name: storage)
@@ -224,17 +224,15 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
     var newRight: mach_port_name_t = mach_port_name_t(MACH_PORT_NULL)
     var newRightType: mach_port_type_t = MACH_PORT_TYPE_NONE
 
-    withUnsafeMutablePointer(to: &newRight) { newRight in
-      withUnsafeMutablePointer(to: &newRightType) { newRightType in
-        _machPrecondition(
-          mach_port_extract_right(mach_task_self_,
-                                  _name,
-                                  mach_msg_type_name_t(MACH_MSG_TYPE_MAKE_SEND_ONCE),
-                                  newRight,
-                                  newRightType)
-        )
-      }
-    }
+    _machPrecondition(
+      mach_port_extract_right(
+        mach_task_self_,
+        _name,
+        mach_msg_type_name_t(MACH_MSG_TYPE_MAKE_SEND_ONCE),
+        &newRight,
+        &newRightType
+      )
+    )
 
     // The value of newRight is validated by the Mach.Port initializer
     precondition(newRightType == MACH_MSG_TYPE_MOVE_SEND_ONCE)

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -309,7 +309,7 @@ extension Mach.Port where RightType == Mach.SendRight {
 
     // name is the same because send rights are coalesced
     let kr = mach_port_insert_right(mach_task_self_, _name, _name, mach_msg_type_name_t(how))
-    if kr == KERN_INVALID_NAME {
+    if kr == KERN_INVALID_NAME || kr == KERN_INVALID_CAPABILITY {
       throw Mach.PortRightError.deadName
     }
     _machPrecondition(kr)

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -188,15 +188,25 @@ final class MachPortTests: XCTestCase {
         let recv = Mach.Port<Mach.ReceiveRight>()
         let send = recv.makeSendRight()
         _ = consume recv // and turn `send` into a dead name
-        XCTAssertThrowsError(try send.copySendRight(), "Copying a dead name should throw") { error in
-            XCTAssertEqual(error, Mach.PortRightError.deadName)
+        XCTAssertThrowsError(
+          _ = try send.copySendRight(),
+          "Copying a dead name should throw"
+        ) { error in
+            XCTAssertEqual(
+              error as! Mach.PortRightError, Mach.PortRightError.deadName
+            )
         }
     }
 
     func testCopyDeadName2() throws {
         let send = Mach.Port<Mach.SendRight>(name: 0xffffffff)
-        XCTAssertThrowsError(try send.copySendRight(), "Copying a dead name should throw") { error in
-            XCTAssertEqual(error, Mach.PortRightError.deadName)
+        XCTAssertThrowsError(
+          _ = try send.copySendRight(),
+          "Copying a dead name should throw"
+        ) { error in
+            XCTAssertEqual(
+              error as! Mach.PortRightError, Mach.PortRightError.deadName
+            )
         }
     }
 

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -210,6 +210,20 @@ final class MachPortTests: XCTestCase {
             XCTAssertEqual(context, $1)
         }
     }
+
+    func testDeinitDeadSendRight() throws {
+        let send = Mach.Port<Mach.SendRight>(name: 0xffffffff)
+        send.withBorrowedName {
+            XCTAssertEqual($0, .max)
+        }
+        _ = consume send
+
+        let send1 = Mach.Port<Mach.SendOnceRight>(name: 0xffffffff)
+        send1.withBorrowedName {
+            XCTAssertEqual($0, .max)
+        }
+        _ = consume send1
+    }
 }
 
 #endif

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -193,6 +193,7 @@ final class MachPortTests: XCTestCase {
             _ = copy
         }
         catch Mach.PortRightError.deadName {
+          // success
         }
     }
 
@@ -203,10 +204,11 @@ final class MachPortTests: XCTestCase {
             _ = copy
         }
         catch Mach.PortRightError.deadName {
+          // success
         }
     }
 
-    func testMakeReceivedRightFromExistingName() throws {
+    func testMakeReceiveRightFromExistingName() throws {
         var name = mach_port_name_t(MACH_PORT_NULL)
         var kr = mach_port_allocate(mach_task_self_, MACH_PORT_RIGHT_RECEIVE, &name)
         XCTAssertEqual(kr, KERN_SUCCESS)
@@ -222,17 +224,14 @@ final class MachPortTests: XCTestCase {
         }
     }
 
-    func testDeinitDeadSendRight() throws {
-        let send = Mach.Port<Mach.SendRight>(name: 0xffffffff)
-        send.withBorrowedName {
-            XCTAssertEqual($0, .max)
-        }
-        _ = consume send
+    func testDeinitDeadSendRights() throws {
+        let recv = Mach.Port<Mach.ReceiveRight>()
+        let send = recv.makeSendRight()
+        let send1 = recv.makeSendOnceRight()
 
-        let send1 = Mach.Port<Mach.SendOnceRight>(name: 0xffffffff)
-        send1.withBorrowedName {
-            XCTAssertEqual($0, .max)
-        }
+        _ = consume recv
+        // `send` and `send1` have become dead names
+        _ = consume send
         _ = consume send1
     }
 }

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -194,6 +194,22 @@ final class MachPortTests: XCTestCase {
             _ = send.relinquish()
         }
     }
+
+    func testMakeReceivedRightFromExistingName() throws {
+        var name = mach_port_name_t(MACH_PORT_NULL)
+        var kr = mach_port_allocate(mach_task_self_, MACH_PORT_RIGHT_RECEIVE, &name)
+        XCTAssertEqual(kr, KERN_SUCCESS)
+        XCTAssertNotEqual(name, mach_port_name_t(MACH_PORT_NULL))
+        let context = mach_port_context_t(arc4random())
+        kr = mach_port_guard(mach_task_self_, name, context, 0)
+        XCTAssertEqual(kr, KERN_SUCCESS)
+
+        let right = Mach.Port<Mach.ReceiveRight>(name: name, context: context)
+        right.withBorrowedName {
+            XCTAssertEqual(name, $0)
+            XCTAssertEqual(context, $1)
+        }
+    }
 }
 
 #endif

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -185,13 +185,24 @@ final class MachPortTests: XCTestCase {
     }
 
     func testCopyDeadName() throws {
+        let recv = Mach.Port<Mach.ReceiveRight>()
+        let send = recv.makeSendRight()
+        _ = consume recv // and turn `send` into a dead name
+        do {
+            let copy = try send.copySendRight()
+            _ = copy
+        }
+        catch Mach.PortRightError.deadName {
+        }
+    }
+
+    func testCopyDeadName2() throws {
         let send = Mach.Port<Mach.SendRight>(name: 0xffffffff)
         do {
             let copy = try send.copySendRight()
             _ = copy
         }
         catch Mach.PortRightError.deadName {
-            _ = send.relinquish()
         }
     }
 

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -188,23 +188,15 @@ final class MachPortTests: XCTestCase {
         let recv = Mach.Port<Mach.ReceiveRight>()
         let send = recv.makeSendRight()
         _ = consume recv // and turn `send` into a dead name
-        do {
-            let copy = try send.copySendRight()
-            _ = copy
-        }
-        catch Mach.PortRightError.deadName {
-          // success
+        XCTAssertThrowsError(try send.copySendRight(), "Copying a dead name should throw") { error in
+            XCTAssertEqual(error, Mach.PortRightError.deadName)
         }
     }
 
     func testCopyDeadName2() throws {
         let send = Mach.Port<Mach.SendRight>(name: 0xffffffff)
-        do {
-            let copy = try send.copySendRight()
-            _ = copy
-        }
-        catch Mach.PortRightError.deadName {
-          // success
+        XCTAssertThrowsError(try send.copySendRight(), "Copying a dead name should throw") { error in
+            XCTAssertEqual(error, Mach.PortRightError.deadName)
         }
     }
 

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -23,7 +23,7 @@ final class MachPortTests: XCTestCase {
         var refCount:mach_port_urefs_t = 0
         withUnsafeMutablePointer(to: &refCount) { refCount in
             let kr = mach_port_get_refs(mach_task_self_, name, kind, refCount)
-            assert(kr == KERN_SUCCESS)
+            XCTAssertEqual(kr, KERN_SUCCESS)
         }
         return refCount
     }
@@ -33,20 +33,20 @@ final class MachPortTests: XCTestCase {
         return refCountForMachPortName(name:name, kind:MACH_PORT_RIGHT_RECEIVE)
     }
 
-    func testRecieveRightDeallocation() throws {
+    func testReceiveRightDeallocation() throws {
         var name:mach_port_name_t = 0 // Never read
         withUnsafeMutablePointer(to:&name) { name in
             let kr = mach_port_allocate(mach_task_self_, MACH_PORT_RIGHT_RECEIVE, name)
-            assert(kr == KERN_SUCCESS)
+            XCTAssertEqual(kr, KERN_SUCCESS)
         }
 
-        XCTAssert(name != 0xFFFFFFFF)
+        XCTAssertNotEqual(name, 0xFFFFFFFF)
 
         let one = scopedReceiveRight(name:name)
         let zero = refCountForMachPortName(name:name, kind: MACH_PORT_RIGHT_RECEIVE)
 
-        XCTAssert(one == 1);
-        XCTAssert(zero == 0);
+        XCTAssertEqual(one, 1);
+        XCTAssertEqual(zero, 0);
     }
 
     func consumeSendRightAutomatically(name:mach_port_name_t) -> mach_port_urefs_t {
@@ -61,11 +61,11 @@ final class MachPortTests: XCTestCase {
         let recv = Mach.Port<Mach.ReceiveRight>()
         recv.withBorrowedName { name in
             let kr = mach_port_insert_right(mach_task_self_, name, name, mach_msg_type_name_t(MACH_MSG_TYPE_MAKE_SEND))
-            XCTAssert(kr == KERN_SUCCESS)
+            XCTAssertEqual(kr, KERN_SUCCESS)
             let one = consumeSendRightAutomatically(name:name)
-            XCTAssert(one == 1);
+            XCTAssertEqual(one, 1);
             let zero = refCountForMachPortName(name:name, kind:MACH_PORT_RIGHT_SEND)
-            XCTAssert(zero == 0);
+            XCTAssertEqual(zero, 0);
         }
     }
 
@@ -77,29 +77,29 @@ final class MachPortTests: XCTestCase {
             let one = send.withBorrowedName { name in
                 return self.refCountForMachPortName(name:name, kind:MACH_PORT_RIGHT_SEND)
             }
-            XCTAssert(one == 1)
+            XCTAssertEqual(one, 1)
 
             return send.relinquish()
         })()
 
         let stillOne = refCountForMachPortName(name:name, kind:MACH_PORT_RIGHT_SEND)
-        XCTAssert(stillOne == 1)
+        XCTAssertEqual(stillOne, 1)
     }
 
     func testMakeSendCountSettable() throws {
         var recv = Mach.Port<Mach.ReceiveRight>()
-        XCTAssert(recv.makeSendCount == 0)
+        XCTAssertEqual(recv.makeSendCount, 0)
         recv.makeSendCount = 7
-        XCTAssert(recv.makeSendCount == 7)
+        XCTAssertEqual(recv.makeSendCount, 7)
     }
 
     func makeSendRight() throws -> Mach.Port<Mach.SendRight> {
         let recv = Mach.Port<Mach.ReceiveRight>()
         let zero = recv.makeSendCount
-        XCTAssert(zero == 0)
+        XCTAssertEqual(zero, 0)
         let send = recv.makeSendRight()
         let one = recv.makeSendCount
-        XCTAssert(one == 1)
+        XCTAssertEqual(one, 1)
         return send
     }
 
@@ -110,10 +110,10 @@ final class MachPortTests: XCTestCase {
     func testMakeSendOnceDoesntIncrementMakeSendCount() throws {
         let recv = Mach.Port<Mach.ReceiveRight>()
         let zero = recv.makeSendCount
-        XCTAssert(zero == 0)
+        XCTAssertEqual(zero, 0)
         _ = recv.makeSendOnceRight()
         let same = recv.makeSendCount
-        XCTAssert(same == zero)
+        XCTAssertEqual(same, zero)
     }
 
     func testMakeSendOnceIsUnique() throws {
@@ -121,8 +121,7 @@ final class MachPortTests: XCTestCase {
         let once = recv.makeSendOnceRight()
         recv.withBorrowedName { rname in
             once.withBorrowedName { oname in
-                print(oname, rname)
-                XCTAssert(oname != rname)
+                XCTAssertNotEqual(oname, rname)
             }
         }
     }
@@ -130,13 +129,13 @@ final class MachPortTests: XCTestCase {
     func testCopySend() throws {
         let recv = Mach.Port<Mach.ReceiveRight>()
         let zero = recv.makeSendCount
-        XCTAssert(zero == 0)
+        XCTAssertEqual(zero, 0)
         let send = recv.makeSendRight()
         let one = recv.makeSendCount
-        XCTAssert(one == 1)
+        XCTAssertEqual(one, 1)
         _ = try send.copySendRight()
         let same = recv.makeSendCount
-        XCTAssert(same == one)
+        XCTAssertEqual(same, one)
 
     }
 }

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -183,6 +183,17 @@ final class MachPortTests: XCTestCase {
         XCTAssertEqual(same, one)
 
     }
+
+    func testCopyDeadName() throws {
+        let send = Mach.Port<Mach.SendRight>(name: 0xffffffff)
+        do {
+            let copy = try send.copySendRight()
+            _ = copy
+        }
+        catch Mach.PortRightError.deadName {
+            _ = send.relinquish()
+        }
+    }
 }
 
 #endif

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if false && swift(>=5.8) && $MoveOnly && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
+#if swift(>=5.9) && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
 
 import XCTest
 import Darwin.Mach

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -29,7 +29,8 @@ final class MachPortTests: XCTestCase {
     }
 
     func scopedReceiveRight(name:mach_port_name_t) -> mach_port_urefs_t {
-        _ = Mach.Port<Mach.ReceiveRight>(name:name) // this should automatically deallocate when going out of scope
+        let right = Mach.Port<Mach.ReceiveRight>(name:name) // this should automatically deallocate when going out of scope
+        defer { _ = right }
         return refCountForMachPortName(name:name, kind:MACH_PORT_RIGHT_RECEIVE)
     }
 

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -92,6 +92,11 @@ final class MachPortTests: XCTestCase {
 
         let stillOne = refCountForMachPortName(name:name, kind:MACH_PORT_RIGHT_SEND)
         XCTAssertEqual(stillOne, 1)
+
+        recv.withBorrowedName {
+            let alsoOne = refCountForMachPortName(name: $0, kind: MACH_PORT_RIGHT_RECEIVE)
+            XCTAssertEqual(alsoOne, 1)
+        }
     }
 
     func testMakeSendCountSettable() throws {


### PR DESCRIPTION
Re-enabling was blocked on this issue: https://github.com/apple/swift/issues/66299 (rdar://110496872)
Now it is blocked on rdar://110926824.

`Mach.Port` was disabled in commit 7bcc01f0bfff8f33d75bc11fa099e95d3f3204e6 of https://github.com/apple/swift-system/pull/127

Once the fix is merged to https://github.com/apple/swift, then this can be merged.