### PR TITLE
Add availability attributes to `Sendable` conformances

### DIFF
--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -481,7 +481,12 @@ extension FileDescriptor.OpenOptions
 //@available(*, unavailable, message: "File descriptors are not completely thread-safe.")
 //extension FileDescriptor: Sendable {}
 
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FileDescriptor.AccessMode: Sendable {}
+
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FileDescriptor.OpenOptions: Sendable {}
+
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FileDescriptor.SeekOrigin: Sendable {}
 #endif

--- a/Sources/System/FilePath/FilePath.swift
+++ b/Sources/System/FilePath/FilePath.swift
@@ -69,5 +69,6 @@ extension FilePath {
 extension FilePath: Hashable, Codable {}
 
 #if compiler(>=5.5) && canImport(_Concurrency)
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePath: Sendable {}
 #endif

--- a/Sources/System/FilePath/FilePathComponentView.swift
+++ b/Sources/System/FilePath/FilePathComponentView.swift
@@ -241,6 +241,9 @@ extension FilePath.ComponentView {
 }
 
 #if compiler(>=5.5) && canImport(_Concurrency)
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.ComponentView: Sendable {}
+
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.ComponentView.Index: Sendable {}
 #endif

--- a/Sources/System/FilePath/FilePathComponents.swift
+++ b/Sources/System/FilePath/FilePathComponents.swift
@@ -287,7 +287,12 @@ extension FilePath.Root {
 }
 
 #if compiler(>=5.5) && canImport(_Concurrency)
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Root: Sendable {}
+
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component: Sendable {}
+
+@available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FilePath.Component.Kind: Sendable {}
 #endif

--- a/Sources/System/FilePermissions.swift
+++ b/Sources/System/FilePermissions.swift
@@ -177,5 +177,6 @@ extension FilePermissions
 }
 
 #if compiler(>=5.5) && canImport(_Concurrency)
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension FilePermissions: Sendable {}
 #endif


### PR DESCRIPTION
It is desirable to attach the same availability to the extensions declaring `Sendable` as to their base types.