### PR TITLE
Add support for Musl libc

### DIFF
--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -9,9 +9,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
+#elseif canImport(Glibc)
 @_implementationOnly import CSystem
 import Glibc
+#elseif canImport(Musl)
+@_implementationOnly import CSystem
+import Musl
 #elseif os(Windows)
 import CSystem
 import ucrt

--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -9,15 +9,15 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
+#elseif os(Windows)
+import CSystem
+import ucrt
 #elseif canImport(Glibc)
 @_implementationOnly import CSystem
 import Glibc
 #elseif canImport(Musl)
 @_implementationOnly import CSystem
 import Musl
-#elseif os(Windows)
-import CSystem
-import ucrt
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -458,7 +458,7 @@ internal var _O_RDWR: CInt { O_RDWR }
 
 #if !os(Windows)
 #if canImport(Musl)
-internal var _O_ACCMODE: CInt { 03|O_SEARCH }
+internal var _O_ACCMODE: CInt { 0x03|O_SEARCH }
 #else
 // TODO: API?
 @_alwaysEmitIntoClient

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -13,14 +13,14 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
+#elseif os(Windows)
+import CSystem
+import ucrt
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
 import CSystem
 import Musl
-#elseif os(Windows)
-import CSystem
-import ucrt
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -13,8 +13,11 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import CSystem
+import Musl
 #elseif os(Windows)
 import CSystem
 import ucrt
@@ -454,9 +457,13 @@ internal var _O_WRONLY: CInt { O_WRONLY }
 internal var _O_RDWR: CInt { O_RDWR }
 
 #if !os(Windows)
+#if canImport(Musl)
+internal var _O_ACCMODE: CInt { 03|O_SEARCH }
+#else
 // TODO: API?
 @_alwaysEmitIntoClient
 internal var _O_ACCMODE: CInt { O_ACCMODE }
+#endif
 
 @_alwaysEmitIntoClient
 internal var _O_NONBLOCK: CInt { O_NONBLOCK }

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -14,9 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
+#elseif canImport(Glibc)
 @_implementationOnly import CSystem
 import Glibc
+#elseif canImport(Musl)
+import CSystem
+import Musl
 #elseif os(Windows)
 import CSystem
 import ucrt
@@ -45,10 +48,15 @@ internal var system_errno: CInt {
     _ = ucrt._set_errno(newValue)
   }
 }
-#else
+#elseif canImport(Glibc)
 internal var system_errno: CInt {
   get { Glibc.errno }
   set { Glibc.errno = newValue }
+}
+#elseif canImport(Musl)
+internal var system_errno: CInt {
+  get { Musl.errno }
+  set { Musl.errno = newValue }
 }
 #endif
 

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -14,15 +14,15 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
+#elseif os(Windows)
+import CSystem
+import ucrt
 #elseif canImport(Glibc)
 @_implementationOnly import CSystem
 import Glibc
 #elseif canImport(Musl)
-import CSystem
+@_implementationOnly import CSystem
 import Musl
-#elseif os(Windows)
-import CSystem
-import ucrt
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -9,8 +9,10 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import ucrt
 #else


### PR DESCRIPTION
Since Musl is sufficiently different from Glibc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html), it requires a different import, which now should be applied to files that have `import Glibc` in them.