### PR TITLE
Update availability declarations for swift-system 1.1.0 API

### DIFF
--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -435,7 +435,7 @@ extension FileDescriptor {
 }
 
 #if !os(Windows)
-@available(/*System 1.1.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.1.0: macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4*/iOS 8, *)
 extension FileDescriptor {
   /// Creates a unidirectional data channel, which can be used for interprocess communication.
   ///
@@ -443,12 +443,12 @@ extension FileDescriptor {
   ///
   /// The corresponding C function is `pipe`.
   @_alwaysEmitIntoClient
-  @available(/*System 1.1.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.1.0: macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4*/iOS 8, *)
   public static func pipe() throws -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
     try _pipe().get()
   }
 
-  @available(/*System 1.1.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.1.0: macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4*/iOS 8, *)
   @usableFromInline
   internal static func _pipe() -> Result<(readEnd: FileDescriptor, writeEnd: FileDescriptor), Errno> {
     var fds: (Int32, Int32) = (-1, -1)

--- a/Utilities/expand-availability.py
+++ b/Utilities/expand-availability.py
@@ -54,7 +54,7 @@ import argparse
 versions = {
     "System 0.0.1": "macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0",
     "System 0.0.2": "macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0",
-    "System 1.1.0": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
+    "System 1.1.0": "macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4",
     "System 1.2.0": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
     "System 1.3.0": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
 }


### PR DESCRIPTION
The commented-out availability declarations should have been updated earlier.