### PR TITLE
Android: update pread/pwrite for nullability annotations in NDK 26

### DIFF
--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -71,7 +71,15 @@ internal func system_pread(
 #if ENABLE_MOCKING
   if mockingEnabled { return _mockInt(fd, buf, nbyte, offset) }
 #endif
-  return buf.map({ pread(fd, $0, nbyte, offset) }) ?? 0
+#if os(Android)
+  var zero = UInt8.zero
+  return withUnsafeMutablePointer(to: &zero) {
+    // this pread has a non-nullable `buf` pointer
+    pread(fd, buf ?? UnsafeMutableRawPointer($0), nbyte, offset)
+  }
+#else
+  return pread(fd, buf, nbyte, offset)
+#endif
 }
 
 // lseek
@@ -101,7 +109,15 @@ internal func system_pwrite(
 #if ENABLE_MOCKING
   if mockingEnabled { return _mockInt(fd, buf, nbyte, offset) }
 #endif
-  return buf.map({ pwrite(fd, $0, nbyte, offset) }) ?? 0
+#if os(Android)
+  var zero = UInt8.zero
+  return withUnsafeMutablePointer(to: &zero) {
+    // this pwrite has a non-nullable `buf` pointer
+    pwrite(fd, buf ?? UnsafeRawPointer($0), nbyte, offset)
+  }
+#else
+  return pwrite(fd, buf, nbyte, offset)
+#endif
 }
 
 internal func system_dup(_ fd: Int32) -> Int32 {

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -71,7 +71,7 @@ internal func system_pread(
 #if ENABLE_MOCKING
   if mockingEnabled { return _mockInt(fd, buf, nbyte, offset) }
 #endif
-  return pread(fd, buf, nbyte, offset)
+  return pread(fd, buf!, nbyte, offset)
 }
 
 // lseek
@@ -101,7 +101,7 @@ internal func system_pwrite(
 #if ENABLE_MOCKING
   if mockingEnabled { return _mockInt(fd, buf, nbyte, offset) }
 #endif
-  return pwrite(fd, buf, nbyte, offset)
+  return pwrite(fd, buf!, nbyte, offset)
 }
 
 internal func system_dup(_ fd: Int32) -> Int32 {

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -71,7 +71,7 @@ internal func system_pread(
 #if ENABLE_MOCKING
   if mockingEnabled { return _mockInt(fd, buf, nbyte, offset) }
 #endif
-  return pread(fd, buf!, nbyte, offset)
+  return buf.map({ pread(fd, $0, nbyte, offset) }) ?? 0
 }
 
 // lseek
@@ -101,7 +101,7 @@ internal func system_pwrite(
 #if ENABLE_MOCKING
   if mockingEnabled { return _mockInt(fd, buf, nbyte, offset) }
 #endif
-  return pwrite(fd, buf!, nbyte, offset)
+  return buf.map({ pwrite(fd, $0, nbyte, offset) }) ?? 0
 }
 
 internal func system_dup(_ fd: Int32) -> Int32 {

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -86,6 +86,30 @@ final class FileOperationsTest: XCTestCase {
     for test in syscallTestCases { test.runAllTests() }
   }
 
+  func testWriteFromEmptyBuffer() throws {
+    let fd = try FileDescriptor.open(FilePath("/dev/null"), .writeOnly)
+    let written1 = try fd.write(toAbsoluteOffset: 0, .init(start: nil, count: 0))
+    XCTAssertEqual(written1, 0)
+
+    let pointer = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
+    defer { pointer.deallocate() }
+    let empty = UnsafeRawBufferPointer(start: pointer, count: 0)
+    let written2 = try fd.write(toAbsoluteOffset: 0, empty)
+    XCTAssertEqual(written2, 0)
+  }
+
+  func testReadToEmptyBuffer() throws {
+    let fd = try FileDescriptor.open(FilePath("/dev/random"), .readOnly)
+    let read1 = try fd.read(fromAbsoluteOffset: 0, into: .init(start: nil, count: 0))
+    XCTAssertEqual(read1, 0)
+
+    let pointer = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
+    defer { pointer.deallocate() }
+    let empty = UnsafeMutableRawBufferPointer(start: pointer, count: 0)
+    let read2 = try fd.read(fromAbsoluteOffset: 0, into: empty)
+    XCTAssertEqual(read2, 0)
+  }
+
   func testHelpers() {
     // TODO: Test writeAll, writeAll(toAbsoluteOffset), closeAfter
   }


### PR DESCRIPTION
This is needed because [Bionic recently added a bunch of these annotations](https://android.googlesource.com/platform/bionic/+/3d59110f7234ddbb15b75328ed405e9fa4a913bc%5E%21/#F0), specifically marking these two buffers as `_Nonnull`. I made sure this pull doesn't break anything by testing it on linux x86_64 and with the previous NDK 25c too. I used this patch with others to build the Swift toolchain and this package for my Android CI, finagolfin/swift-android-sdk#122.