### PR TITLE
Add support for visionOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
           .define("_CRT_SECURE_NO_WARNINGS")
         ],
         swiftSettings: [
+          .define("SYSTEM_PACKAGE_DARWIN", .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .visionOS])),
           .define("SYSTEM_PACKAGE"),
           .define("ENABLE_MOCKING", .when(configuration: .debug))
         ]),
@@ -37,6 +38,7 @@ let package = Package(
         name: "SystemTests",
         dependencies: ["SystemPackage"],
         swiftSettings: [
+          .define("SYSTEM_PACKAGE_DARWIN", .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .visionOS])),
           .define("SYSTEM_PACKAGE")
         ]),
     ]

--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -23,7 +23,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   private init(_ raw: CInt) { self.init(rawValue: raw) }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
   /// Error. Not used.
   @_alwaysEmitIntoClient
   public static var notUsed: Errno { Errno(_ERRNO_NOT_USED) }
@@ -911,7 +911,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "directoryNotEmpty")
   public static var ENOTEMPTY: Errno { directoryNotEmpty }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
   /// Too many processes.
   ///
   /// The corresponding C error is `EPROCLIM`.
@@ -968,7 +968,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   public static var ESTALE: Errno { staleNFSFileHandle }
 
 // TODO: Add Linux's RPC equivalents
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 
   /// The structure of the remote procedure call (RPC) is bad.
   ///
@@ -1060,7 +1060,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   public static var ENOSYS: Errno { noFunction }
 
 // BSD
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
   /// Inappropriate file type or format.
   ///
   /// The file was the wrong type for the operation,
@@ -1075,7 +1075,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   public static var EFTYPE: Errno { badFileTypeOrFormat }
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
   /// Authentication error.
   ///
   /// The authentication ticket used to mount an NFS file system was invalid.
@@ -1102,7 +1102,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   public static var ENEEDAUTH: Errno { needAuthenticator }
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
   /// Device power is off.
   ///
   /// The corresponding C error is `EPWROFF`.
@@ -1142,7 +1142,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   public static var EOVERFLOW: Errno { overflow }
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
   /// Bad executable or shared library.
   ///
   /// The executable or shared library being referenced was malformed.
@@ -1246,7 +1246,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "illegalByteSequence")
   public static var EILSEQ: Errno { illegalByteSequence }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
   /// Attribute not found.
   ///
   /// The specified extended attribute doesn't exist.
@@ -1413,7 +1413,7 @@ extension Errno {
   @available(*, unavailable, renamed: "tooManyRemoteLevels")
   public static var EREMOTE: Errno { tooManyRemoteLevels }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
   /// No such policy registered.
   ///
   /// The corresponding C error is `ENOPOLICY`.
@@ -1447,7 +1447,7 @@ extension Errno {
   public static var EOWNERDEAD: Errno { previousOwnerDied }
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
   /// Interface output queue is full.
   ///
   /// The corresponding C error is `EQFULL`.

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -185,7 +185,7 @@ extension FileDescriptor {
     @available(*, unavailable, renamed: "exclusiveCreate")
     public static var O_EXCL: OpenOptions { exclusiveCreate }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     /// Indicates that opening the file
     /// atomically obtains a shared lock on the file.
     ///
@@ -253,7 +253,7 @@ extension FileDescriptor {
     public static var O_DIRECTORY: OpenOptions { directory }
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     /// Indicates that opening the file
     /// opens symbolic links instead of following them.
     ///
@@ -357,7 +357,7 @@ extension FileDescriptor {
 
 // TODO: These are available on some versions of Linux with appropriate
 // macro defines.
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     /// Indicates that the offset should be set
     /// to the next hole after the specified number of bytes.
     ///
@@ -419,7 +419,7 @@ extension FileDescriptor.SeekOrigin
     case .start: return "start"
     case .current: return "current"
     case .end: return "end"
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     case .nextHole: return "nextHole"
     case .nextData: return "nextData"
 #endif
@@ -438,7 +438,7 @@ extension FileDescriptor.OpenOptions
   /// A textual representation of the open options.
   @inline(never)
   public var description: String {
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     let descriptions: [(Element, StaticString)] = [
       (.nonBlocking, ".nonBlocking"),
       (.append, ".append"),

--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 import Darwin
 #elseif os(Windows)
 import CSystem

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -11,7 +11,7 @@
 // they can be used anywhere without imports and without confusion to
 // unavailable local decls.
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 import Darwin
 #elseif os(Windows)
 import CSystem
@@ -26,7 +26,7 @@ import Musl
 #endif
 
 // MARK: errno
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _ERRNO_NOT_USED: CInt { 0 }
 #endif
@@ -272,7 +272,7 @@ internal var _EHOSTUNREACH: CInt { EHOSTUNREACH }
 @_alwaysEmitIntoClient
 internal var _ENOTEMPTY: CInt { ENOTEMPTY }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _EPROCLIM: CInt { EPROCLIM }
 #endif
@@ -313,7 +313,7 @@ internal var _EREMOTE: CInt {
 #endif
 }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _EBADRPC: CInt { EBADRPC }
 
@@ -336,7 +336,7 @@ internal var _ENOLCK: CInt { ENOLCK }
 @_alwaysEmitIntoClient
 internal var _ENOSYS: CInt { ENOSYS }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _EFTYPE: CInt { EFTYPE }
 
@@ -358,7 +358,7 @@ internal var _EDEVERR: CInt { EDEVERR }
 internal var _EOVERFLOW: CInt { EOVERFLOW }
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _EBADEXEC: CInt { EBADEXEC }
 
@@ -386,7 +386,7 @@ internal var _ENOMSG: CInt { ENOMSG }
 @_alwaysEmitIntoClient
 internal var _EILSEQ: CInt { EILSEQ }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _ENOATTR: CInt { ENOATTR }
 #endif
@@ -424,7 +424,7 @@ internal var _ETIME: CInt { ETIME }
 @_alwaysEmitIntoClient
 internal var _EOPNOTSUPP: CInt { EOPNOTSUPP }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _ENOPOLICY: CInt { ENOPOLICY }
 #endif
@@ -437,7 +437,7 @@ internal var _ENOTRECOVERABLE: CInt { ENOTRECOVERABLE }
 internal var _EOWNERDEAD: CInt { EOWNERDEAD }
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _EQFULL: CInt { EQFULL }
 
@@ -472,7 +472,7 @@ internal var _O_NONBLOCK: CInt { O_NONBLOCK }
 @_alwaysEmitIntoClient
 internal var _O_APPEND: CInt { O_APPEND }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _O_SHLOCK: CInt { O_SHLOCK }
 
@@ -498,7 +498,7 @@ internal var _O_TRUNC: CInt { O_TRUNC }
 @_alwaysEmitIntoClient
 internal var _O_EXCL: CInt { O_EXCL }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _O_EVTONLY: CInt { O_EVTONLY }
 #endif
@@ -512,7 +512,7 @@ internal var _O_NOCTTY: CInt { O_NOCTTY }
 internal var _O_DIRECTORY: CInt { O_DIRECTORY }
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _O_SYMLINK: CInt { O_SYMLINK }
 #endif
@@ -531,7 +531,7 @@ internal var _SEEK_CUR: CInt { SEEK_CUR }
 @_alwaysEmitIntoClient
 internal var _SEEK_END: CInt { SEEK_END }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _SEEK_HOLE: CInt { SEEK_HOLE }
 

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -12,7 +12,7 @@
 
 // TODO: Should CSystem just include all the header files we need?
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 import Darwin
 #elseif os(Windows)
 import CSystem
@@ -31,7 +31,7 @@ internal typealias _COffT = off_t
 
 // MARK: syscalls and variables
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 internal var system_errno: CInt {
   get { Darwin.errno }
   set { Darwin.errno = newValue }

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
 import Darwin
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if swift(>=5.9) && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
+#if swift(>=5.9) && SYSTEM_PACKAGE_DARWIN
 
 import Darwin.Mach
 

--- a/Tests/SystemTests/ErrnoTest.swift
+++ b/Tests/SystemTests/ErrnoTest.swift
@@ -106,7 +106,7 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(EHOSTUNREACH == Errno.noRouteToHost.rawValue)
     XCTAssert(ENOTEMPTY == Errno.directoryNotEmpty.rawValue)
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssert(EPROCLIM == Errno.tooManyProcesses.rawValue)
 #endif
 
@@ -120,7 +120,7 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(ESTALE == Errno.staleNFSFileHandle.rawValue)
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssert(EBADRPC == Errno.rpcUnsuccessful.rawValue)
     XCTAssert(ERPCMISMATCH == Errno.rpcVersionMismatch.rawValue)
     XCTAssert(EPROGUNAVAIL == Errno.rpcProgramUnavailable.rawValue)
@@ -131,7 +131,7 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(ENOLCK == Errno.noLocks.rawValue)
     XCTAssert(ENOSYS == Errno.noFunction.rawValue)
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssert(EFTYPE == Errno.badFileTypeOrFormat.rawValue)
     XCTAssert(EAUTH == Errno.authenticationError.rawValue)
     XCTAssert(ENEEDAUTH == Errno.needAuthenticator.rawValue)
@@ -143,7 +143,7 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(EOVERFLOW == Errno.overflow.rawValue)
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssert(EBADEXEC == Errno.badExecutable.rawValue)
     XCTAssert(EBADARCH == Errno.badCPUType.rawValue)
     XCTAssert(ESHLIBVERS == Errno.sharedLibraryVersionMismatch.rawValue)
@@ -157,7 +157,7 @@ final class ErrnoTest: XCTestCase {
 #endif
     XCTAssert(EILSEQ == Errno.illegalByteSequence.rawValue)
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssert(ENOATTR == Errno.attributeNotFound.rawValue)
 #endif
 
@@ -183,7 +183,7 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(EREMOTE == Errno.tooManyRemoteLevels.rawValue)
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssert(ENOPOLICY == Errno.noSuchPolicy.rawValue)
 #endif
 
@@ -192,7 +192,7 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(EOWNERDEAD == Errno.previousOwnerDied.rawValue)
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssert(EQFULL == Errno.outputQueueFull.rawValue)
     XCTAssert(ELAST == Errno.lastErrnoValue.rawValue)
 #endif

--- a/Tests/SystemTests/FileTypesTest.swift
+++ b/Tests/SystemTests/FileTypesTest.swift
@@ -42,7 +42,7 @@ final class FileDescriptorTest: XCTestCase {
 #endif
 
     // BSD only
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssertEqual(O_SHLOCK, FileDescriptor.OpenOptions.sharedLock.rawValue)
     XCTAssertEqual(O_EXLOCK, FileDescriptor.OpenOptions.exclusiveLock.rawValue)
     XCTAssertEqual(O_SYMLINK, FileDescriptor.OpenOptions.symlink.rawValue)
@@ -53,7 +53,7 @@ final class FileDescriptorTest: XCTestCase {
     XCTAssertEqual(SEEK_CUR, FileDescriptor.SeekOrigin.current.rawValue)
     XCTAssertEqual(SEEK_END, FileDescriptor.SeekOrigin.end.rawValue)
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssertEqual(SEEK_HOLE, FileDescriptor.SeekOrigin.nextHole.rawValue)
     XCTAssertEqual(SEEK_DATA, FileDescriptor.SeekOrigin.nextData.rawValue)
 #endif

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if swift(>=5.9) && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
+#if swift(>=5.9) && SYSTEM_PACKAGE_DARWIN
 
 import XCTest
 import Darwin.Mach


### PR DESCRIPTION
Adds compilation support for visionOS. All tests pass. Closes #150.

I was unsure if I had to edit `Utilities/expand-availability.py`, so I didn't touch it.