### PR TITLE
SystemString api consistency improvements

### DIFF
--- a/Sources/System/FilePath/FilePathComponents.swift
+++ b/Sources/System/FilePath/FilePathComponents.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/System/FilePath/FilePathComponents.swift
+++ b/Sources/System/FilePath/FilePathComponents.swift
@@ -146,7 +146,7 @@ extension _StrSlice {
   internal func _withSystemChars<T>(
     _ f: (UnsafeBufferPointer<SystemChar>) throws -> T
   ) rethrows -> T {
-    try _storage.withSystemChars {
+    try _storage.withNullTerminatedSystemChars {
       try f(UnsafeBufferPointer(rebasing: $0[_range]))
     }
   }

--- a/Sources/System/SystemString.swift
+++ b/Sources/System/SystemString.swift
@@ -169,18 +169,17 @@ extension SystemString: Hashable, Codable {}
 
 extension SystemString {
 
-  // withSystemChars includes the null terminator
-  internal func withSystemChars<T>(
+  internal func withNullTerminatedSystemChars<T>(
     _ f: (UnsafeBufferPointer<SystemChar>) throws -> T
   ) rethrows -> T {
-    try nullTerminatedStorage.withContiguousStorageIfAvailable(f)!
+    try nullTerminatedStorage.withUnsafeBufferPointer(f)
   }
 
   // withCodeUnits does not include the null terminator
   internal func withCodeUnits<T>(
     _ f: (UnsafeBufferPointer<CInterop.PlatformUnicodeEncoding.CodeUnit>) throws -> T
   ) rethrows -> T {
-    try withSystemChars {
+    try withNullTerminatedSystemChars {
       try $0.withMemoryRebound(to: CInterop.PlatformUnicodeEncoding.CodeUnit.self) {
         assert($0.last == .zero)
         return try f(.init(start: $0.baseAddress, count: $0.count&-1))
@@ -286,7 +285,7 @@ extension SystemString {
   internal func withPlatformString<T>(
     _ f: (UnsafePointer<CInterop.PlatformChar>) throws -> T
   ) rethrows -> T {
-    try withSystemChars { chars in
+    try withNullTerminatedSystemChars { chars in
       let length = chars.count * MemoryLayout<SystemChar>.stride
       return try chars.baseAddress!.withMemoryRebound(
         to: CInterop.PlatformChar.self,

--- a/Sources/System/SystemString.swift
+++ b/Sources/System/SystemString.swift
@@ -202,7 +202,9 @@ extension Slice where Base == SystemString {
   }
 
   internal var string: String {
-    withCodeUnits { String(decoding: $0, as: CInterop.PlatformUnicodeEncoding.self) }
+    withCodeUnits {
+      String(decoding: $0, as: CInterop.PlatformUnicodeEncoding.self)
+    }
   }
 
   internal func withPlatformString<T>(
@@ -244,7 +246,11 @@ extension SystemString: ExpressibleByStringLiteral {
 }
 
 extension SystemString: CustomStringConvertible, CustomDebugStringConvertible {
-  internal var string: String { String(decoding: self) }
+  internal var string: String {
+    self.withCodeUnits {
+      String(decoding: $0, as: CInterop.PlatformUnicodeEncoding.self)
+    }
+  }
 
   internal var description: String { string }
   internal var debugDescription: String { description.debugDescription }

--- a/Sources/System/SystemString.swift
+++ b/Sources/System/SystemString.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/System/SystemString.swift
+++ b/Sources/System/SystemString.swift
@@ -176,17 +176,14 @@ extension SystemString {
     try nullTerminatedStorage.withContiguousStorageIfAvailable(f)!
   }
 
+  // withCodeUnits does not include the null terminator
   internal func withCodeUnits<T>(
     _ f: (UnsafeBufferPointer<CInterop.PlatformUnicodeEncoding.CodeUnit>) throws -> T
   ) rethrows -> T {
-    try withSystemChars { chars in
-      let length = chars.count * MemoryLayout<SystemChar>.stride
-      let count = length / MemoryLayout<CInterop.PlatformUnicodeEncoding.CodeUnit>.stride
-      return try chars.baseAddress!.withMemoryRebound(
-        to: CInterop.PlatformUnicodeEncoding.CodeUnit.self,
-        capacity: count
-      ) { pointer in
-        try f(UnsafeBufferPointer(start: pointer, count: count))
+    try withSystemChars {
+      try $0.withMemoryRebound(to: CInterop.PlatformUnicodeEncoding.CodeUnit.self) {
+        assert($0.last == .zero)
+        return try f(.init(start: $0.baseAddress, count: $0.count&-1))
       }
     }
   }

--- a/Tests/SystemTests/SystemStringTests.swift
+++ b/Tests/SystemTests/SystemStringTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SystemTests/SystemStringTests.swift
+++ b/Tests/SystemTests/SystemStringTests.swift
@@ -101,7 +101,7 @@ struct StringTest: TestCase {
     // Test null insertion
     let rawChars = raw.lazy.map { SystemChar($0) }
     expectEqual(sysRaw, SystemString(rawChars.dropLast()))
-    sysRaw.withSystemChars {  // TODO: assuming we want null in withSysChars
+    sysRaw.withNullTerminatedSystemChars {
       expectEqualSequence(rawChars, $0, "rawChars")
     }
 

--- a/Tests/SystemTests/SystemStringTests.swift
+++ b/Tests/SystemTests/SystemStringTests.swift
@@ -254,6 +254,11 @@ final class SystemStringTest: XCTestCase {
     XCTAssert(str == "abcd")
   }
 
+  func testStringProperty() {
+    let source: [CInterop.PlatformChar] = [0x61, 0x62, 0, 0x63]
+    let str = SystemString(platformString: source)
+    XCTAssertEqual(str.string, str[...].string)
+  }
 }
 
 extension SystemStringTest {


### PR DESCRIPTION
While working on https://github.com/apple/swift-system/pull/154, I found a few little inconsistencies in the implementation of the `SystemString` type. This PR fixes the inconsistencies I found.