### PR TITLE
Fix swift-system to work on Windows.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ import PackageDescription
 let package = Package(
     name: "swift-system",
     products: [
-        .library(name: "SystemPackage", targets: ["SystemPackage"]),
+      .library(name: "SystemPackage", targets: ["SystemPackage"])
     ],
     dependencies: [],
     targets: [
@@ -40,6 +40,6 @@ let package = Package(
         swiftSettings: [
           .define("SYSTEM_PACKAGE_DARWIN", .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .visionOS])),
           .define("SYSTEM_PACKAGE")
-        ]),
+        ])
     ]
 )

--- a/Sources/System/ErrnoWindows.swift
+++ b/Sources/System/ErrnoWindows.swift
@@ -1,0 +1,20 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+#if os(Windows)
+
+import WinSDK
+
+extension Errno {
+  public init(windowsError: DWORD) {
+    self.init(rawValue: mapWindowsErrorToErrno(windowsError))
+  }
+}
+
+#endif

--- a/Sources/System/ErrnoWindows.swift
+++ b/Sources/System/ErrnoWindows.swift
@@ -13,7 +13,7 @@ import WinSDK
 
 extension Errno {
   public init(windowsError: DWORD) {
-    self.init(rawValue: mapWindowsErrorToErrno(windowsError))
+    self.init(rawValue: _mapWindowsErrorToErrno(windowsError))
   }
 }
 

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -436,7 +436,7 @@ extension FileDescriptor {
 }
 #endif
 
-#if !os(Windows) && !os(WASI)
+#if !os(WASI)
 @available(/*System 1.1.0: macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4*/iOS 8, *)
 extension FileDescriptor {
   /// Creates a unidirectional data channel, which can be used for interprocess communication.
@@ -465,7 +465,6 @@ extension FileDescriptor {
 }
 #endif
 
-#if !os(Windows)
 @available(/*System 1.2.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 extension FileDescriptor {
   /// Truncates or extends the file referenced by this file descriptor.
@@ -511,4 +510,3 @@ extension FileDescriptor {
     }
   }
 }
-#endif

--- a/Sources/System/FilePath/FilePathParsing.swift
+++ b/Sources/System/FilePath/FilePathParsing.swift
@@ -89,6 +89,11 @@ extension SystemString {
       // `_prenormalizeWindowsRoots` and resume.
       readIdx = _prenormalizeWindowsRoots()
       writeIdx = readIdx
+
+      // Skip redundant separators
+      while readIdx < endIndex && isSeparator(self[readIdx]) {
+          self.formIndex(after: &readIdx)
+      }
     } else {
       assert(genericSeparator == platformSeparator)
     }
@@ -330,10 +335,13 @@ extension FilePath {
 // Whether we are providing Windows paths
 @inline(__always)
 internal var _windowsPaths: Bool {
+  if let forceWindowsPaths = forceWindowsPaths {
+    return forceWindowsPaths
+  }
   #if os(Windows)
   return true
   #else
-  return forceWindowsPaths
+  return false
   #endif
 }
 

--- a/Sources/System/FilePath/FilePathTemp.swift
+++ b/Sources/System/FilePath/FilePathTemp.swift
@@ -1,0 +1,256 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// MARK: - API
+
+public func withTemporaryPath<R>(basename: FilePath.Component,
+                                 _ body: (FilePath) throws -> R) throws -> R {
+  let temporaryDir = try createUniqueTemporaryDirectory(basename: basename)
+  defer {
+    try? recursiveRemove(at: temporaryDir)
+  }
+
+  return try body(temporaryDir)
+}
+
+// MARK: - Internals
+
+#if os(Windows)
+import WinSDK
+
+internal func getTemporaryDirectory() throws -> FilePath {
+  return try withUnsafeTemporaryAllocation(of: CInterop.PlatformChar.self,
+                                           capacity: Int(MAX_PATH) + 1) {
+    buffer in
+
+    let count = GetTempPath2W(DWORD(buffer.count), buffer.baseAddress)
+    if count == 0 {
+      throw Errno(windowsError: GetLastError())
+    }
+
+    return FilePath(SystemString(platformString: buffer.baseAddress!))
+  }
+}
+
+internal func forEachFile(
+  at path: FilePath,
+  _ body: (WIN32_FIND_DATAW) throws -> ()
+) rethrows {
+  let searchPath = path.appending("\\*")
+
+  try searchPath.withPlatformString { szPath in
+    var findData = WIN32_FIND_DATAW()
+    let hFind = FindFirstFileW(szPath, &findData)
+    if hFind == INVALID_HANDLE_VALUE {
+      throw Errno(windowsError: GetLastError())
+    }
+    defer {
+      FindClose(hFind)
+    }
+
+    repeat {
+      // Skip . and ..
+      if findData.cFileName.0 == 46
+           && (findData.cFileName.1 == 0
+                 || (findData.cFileName.1 == 46
+                       && findData.cFileName.2 == 0)) {
+        continue
+      }
+
+      try body(findData)
+    } while FindNextFileW(hFind, &findData)
+  }
+}
+
+internal func recursiveRemove(at path: FilePath) throws {
+  // First, deal with subdirectories
+  try forEachFile(at: path) { findData in
+    if (findData.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY)) != 0 {
+      let name = withUnsafeBytes(of: findData.cFileName) {
+        return SystemString(platformString: $0.assumingMemoryBound(
+                              to: CInterop.PlatformChar.self).baseAddress!)
+      }
+      let component = FilePath.Component(name)!
+      let subpath = path.appending(component)
+
+      try recursiveRemove(at: subpath)
+    }
+  }
+
+  // Now delete everything else
+  try forEachFile(at: path) { findData in
+    let name = withUnsafeBytes(of: findData.cFileName) {
+      return SystemString(platformString: $0.assumingMemoryBound(
+                            to: CInterop.PlatformChar.self).baseAddress!)
+    }
+    let component = FilePath.Component(name)!
+    let subpath = path.appending(component)
+
+    if (findData.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY)) == 0 {
+      try subpath.withPlatformString {
+        if !DeleteFileW($0) {
+          throw Errno(windowsError: GetLastError())
+        }
+      }
+    }
+  }
+
+  // Finally, delete the parent
+  try path.withPlatformString {
+    if !RemoveDirectoryW($0) {
+      throw Errno(windowsError: GetLastError())
+    }
+  }
+}
+
+#else
+internal func getTemporaryDirectory() throws -> FilePath {
+  return "/tmp"
+}
+
+internal func recursiveRemove(at path: FilePath) throws {
+  let dirfd = try FileDescriptor.open(path, .readOnly, options: .directory)
+  defer {
+    try? dirfd.close()
+  }
+
+  let dot: (CInterop.PlatformChar, CInterop.PlatformChar) = (46, 0)
+  try withUnsafeBytes(of: dot) {
+    try recursiveRemove(
+      in: dirfd.rawValue,
+      path: $0.assumingMemoryBound(to: CInterop.PlatformChar.self).baseAddress!
+    )
+  }
+
+  try path.withPlatformString {
+    if system_rmdir($0) != 0 {
+      throw Errno.current
+    }
+  }
+}
+
+fileprivate func impl_opendirat(
+  _ dirfd: CInt,
+  _ path: UnsafePointer<CInterop.PlatformChar>
+) -> UnsafeMutablePointer<system_DIR>? {
+  let fd = system_openat(dirfd, path,
+                         FileDescriptor.AccessMode.readOnly.rawValue
+                           | FileDescriptor.OpenOptions.directory.rawValue)
+  if fd < 0 {
+    return nil
+  }
+  return system_fdopendir(fd)
+}
+
+internal func forEachFile(
+  in dirfd: CInt, path: UnsafePointer<CInterop.PlatformChar>,
+  _ body: (system_dirent) throws -> ()
+) throws {
+  guard let dir = impl_opendirat(dirfd, path) else {
+    throw Errno.current
+  }
+  defer {
+    _ = system_closedir(dir)
+  }
+
+  while let dirent = system_readdir(dir) {
+    // Skip . and ..
+    if dirent.pointee.d_name.0 == 46
+         && (dirent.pointee.d_name.1 == 0
+               || (dirent.pointee.d_name.1 == 46
+                     && dirent.pointee.d_name.2 == 0)) {
+      continue
+    }
+
+    try body(dirent.pointee)
+  }
+}
+
+internal func recursiveRemove(
+  in dirfd: CInt,
+  path: UnsafePointer<CInterop.PlatformChar>
+) throws {
+  // First, deal with subdirectories
+  try forEachFile(in: dirfd, path: path) { dirent in
+    if dirent.d_type == SYSTEM_DT_DIR {
+      try withUnsafeBytes(of: dirent.d_name) {
+        try recursiveRemove(
+          in: dirfd,
+          path: $0.assumingMemoryBound(to: CInterop.PlatformChar.self)
+            .baseAddress!
+        )
+      }
+    }
+  }
+
+  // Now delete the contents of this directory
+  try forEachFile(in: dirfd, path: path) { dirent in
+    let flag: CInt
+
+    if dirent.d_type == SYSTEM_DT_DIR {
+      flag = SYSTEM_AT_REMOVE_DIR
+    } else {
+      flag = 0
+    }
+
+    let result = withUnsafeBytes(of: dirent.d_name) {
+      system_unlinkat(dirfd,
+                      $0.assumingMemoryBound(to: CInterop.PlatformChar.self)
+                        .baseAddress!,
+                      flag)
+    }
+
+    if result != 0 {
+      throw Errno.current
+    }
+  }
+}
+#endif
+
+internal let base64 = Array<UInt8>(
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".utf8
+)
+
+internal func makeDirectory(at: FilePath) throws -> Bool {
+  return try at.withPlatformString {
+    if system_mkdir($0, 0o700) == 0 {
+      return true
+    }
+    let err = system_errno
+    if err == Errno.fileExists.rawValue {
+      return false
+    } else {
+      throw Errno(rawValue: err)
+    }
+  }
+}
+
+internal func createRandomString(length: Int) -> String {
+  return String(
+    decoding: (0..<length).map{
+      _ in base64[Int.random(in: 0..<64)]
+    },
+    as: UTF8.self
+  )
+}
+
+internal func createUniqueTemporaryDirectory(
+  basename: FilePath.Component
+) throws -> FilePath {
+  var tempDir = try getTemporaryDirectory()
+  tempDir.append(basename)
+
+  while true {
+    tempDir.extension = createRandomString(length: 16)
+
+    if try makeDirectory(at: tempDir) {
+      return tempDir
+    }
+  }
+}

--- a/Sources/System/FilePath/FilePathTemp.swift
+++ b/Sources/System/FilePath/FilePathTemp.swift
@@ -29,8 +29,7 @@ internal func getTemporaryDirectory() throws -> FilePath {
                                            capacity: Int(MAX_PATH) + 1) {
     buffer in
 
-    let count = GetTempPath2W(DWORD(buffer.count), buffer.baseAddress)
-    if count == 0 {
+    guard GetTempPath2W(DWORD(buffer.count), buffer.baseAddress) != 0 else {
       throw Errno(windowsError: GetLastError())
     }
 
@@ -116,7 +115,7 @@ internal func getTemporaryDirectory() throws -> FilePath {
   while true {
     let path: FilePath? = withUnsafeTemporaryAllocation(
       of: CInterop.PlatformChar.self,
-      capacity: 1024) { buffer in
+      capacity: capacity) { buffer in
       let len = system_confstr(SYSTEM_CS_DARWIN_USER_TEMP_DIR,
                                buffer.baseAddress!,
                                buffer.count)

--- a/Sources/System/FilePath/FilePathTemp.swift
+++ b/Sources/System/FilePath/FilePathTemp.swift
@@ -9,8 +9,10 @@
 
 // MARK: - API
 
-public func withTemporaryPath<R>(basename: FilePath.Component,
-                                 _ body: (FilePath) throws -> R) throws -> R {
+public func withTemporaryPath<R>(
+  basename: FilePath.Component,
+  _ body: (FilePath) throws -> R
+) throws -> R {
   let temporaryDir = try createUniqueTemporaryDirectory(basename: basename)
   defer {
     try? recursiveRemove(at: temporaryDir)

--- a/Sources/System/FilePath/FilePathTemp.swift
+++ b/Sources/System/FilePath/FilePathTemp.swift
@@ -9,13 +9,22 @@
 
 // MARK: - API
 
-public func withTemporaryPath<R>(
+/// Create a temporary path for the duration of the closure.
+///
+/// - Parameters:
+///   - basename: The base name for the temporary path.
+///   - body: The closure to execute.
+///
+/// Creates a temporary directory with a name based on the given `basename`,
+/// executes `body`, passing in the path of the created directory, then
+/// deletes the directory and all of its contents before returning.
+public func withTemporaryFilePath<R>(
   basename: FilePath.Component,
   _ body: (FilePath) throws -> R
 ) throws -> R {
   let temporaryDir = try createUniqueTemporaryDirectory(basename: basename)
   defer {
-    try? recursiveRemove(at: temporaryDir)
+    try? _recursiveRemove(at: temporaryDir)
   }
 
   return try body(temporaryDir)
@@ -23,230 +32,20 @@ public func withTemporaryPath<R>(
 
 // MARK: - Internals
 
-#if os(Windows)
-import WinSDK
-
-fileprivate func getTemporaryDirectory() throws -> FilePath {
-  return try withUnsafeTemporaryAllocation(of: CInterop.PlatformChar.self,
-                                           capacity: Int(MAX_PATH) + 1) {
-    buffer in
-
-    guard GetTempPath2W(DWORD(buffer.count), buffer.baseAddress) != 0 else {
-      throw Errno(windowsError: GetLastError())
-    }
-
-    return FilePath(SystemString(platformString: buffer.baseAddress!))
-  }
-}
-
-fileprivate func forEachFile(
-  at path: FilePath,
-  _ body: (WIN32_FIND_DATAW) throws -> ()
-) rethrows {
-  let searchPath = path.appending("\\*")
-
-  try searchPath.withPlatformString { szPath in
-    var findData = WIN32_FIND_DATAW()
-    let hFind = FindFirstFileW(szPath, &findData)
-    if hFind == INVALID_HANDLE_VALUE {
-      throw Errno(windowsError: GetLastError())
-    }
-    defer {
-      FindClose(hFind)
-    }
-
-    repeat {
-      // Skip . and ..
-      if findData.cFileName.0 == 46
-           && (findData.cFileName.1 == 0
-                 || (findData.cFileName.1 == 46
-                       && findData.cFileName.2 == 0)) {
-        continue
-      }
-
-      try body(findData)
-    } while FindNextFileW(hFind, &findData)
-  }
-}
-
-fileprivate func recursiveRemove(at path: FilePath) throws {
-  // First, deal with subdirectories
-  try forEachFile(at: path) { findData in
-    if (findData.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY)) != 0 {
-      let name = withUnsafeBytes(of: findData.cFileName) {
-        return SystemString(platformString: $0.assumingMemoryBound(
-                              to: CInterop.PlatformChar.self).baseAddress!)
-      }
-      let component = FilePath.Component(name)!
-      let subpath = path.appending(component)
-
-      try recursiveRemove(at: subpath)
-    }
-  }
-
-  // Now delete everything else
-  try forEachFile(at: path) { findData in
-    let name = withUnsafeBytes(of: findData.cFileName) {
-      return SystemString(platformString: $0.assumingMemoryBound(
-                            to: CInterop.PlatformChar.self).baseAddress!)
-    }
-    let component = FilePath.Component(name)!
-    let subpath = path.appending(component)
-
-    if (findData.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY)) == 0 {
-      try subpath.withPlatformString {
-        if !DeleteFileW($0) {
-          throw Errno(windowsError: GetLastError())
-        }
-      }
-    }
-  }
-
-  // Finally, delete the parent
-  try path.withPlatformString {
-    if !RemoveDirectoryW($0) {
-      throw Errno(windowsError: GetLastError())
-    }
-  }
-}
-
-#else
-fileprivate func getTemporaryDirectory() throws -> FilePath {
-  #if SYSTEM_PACKAGE_DARWIN
-  var capacity = 1024
-  while true {
-    let path: FilePath? = withUnsafeTemporaryAllocation(
-      of: CInterop.PlatformChar.self,
-      capacity: capacity
-    ) { buffer in
-      let len = system_confstr(SYSTEM_CS_DARWIN_USER_TEMP_DIR,
-                               buffer.baseAddress!,
-                               buffer.count)
-      if len == 0 {
-        // Fall back to "/tmp" if we can't read the temp directory
-        return "/tmp"
-      }
-      // If it was truncated, increase capaciy and try again
-      if len > buffer.count {
-        capacity = len
-        return nil
-      }
-      return FilePath(SystemString(platformString: buffer.baseAddress!))
-    }
-    if let path = path {
-      return path
-    }
-  }
-  #else
-  return "/tmp"
-  #endif
-}
-
-fileprivate func recursiveRemove(at path: FilePath) throws {
-  let dirfd = try FileDescriptor.open(path, .readOnly, options: .directory)
-  defer {
-    try? dirfd.close()
-  }
-
-  let dot: (CInterop.PlatformChar, CInterop.PlatformChar) = (46, 0)
-  try withUnsafeBytes(of: dot) {
-    try recursiveRemove(
-      in: dirfd.rawValue,
-      path: $0.assumingMemoryBound(to: CInterop.PlatformChar.self).baseAddress!
-    )
-  }
-
-  try path.withPlatformString {
-    if system_rmdir($0) != 0 {
-      throw Errno.current
-    }
-  }
-}
-
-fileprivate func impl_opendirat(
-  _ dirfd: CInt,
-  _ path: UnsafePointer<CInterop.PlatformChar>
-) -> UnsafeMutablePointer<system_DIR>? {
-  let fd = system_openat(dirfd, path,
-                         FileDescriptor.AccessMode.readOnly.rawValue
-                           | FileDescriptor.OpenOptions.directory.rawValue)
-  if fd < 0 {
-    return nil
-  }
-  return system_fdopendir(fd)
-}
-
-fileprivate func forEachFile(
-  in dirfd: CInt, path: UnsafePointer<CInterop.PlatformChar>,
-  _ body: (system_dirent) throws -> ()
-) throws {
-  guard let dir = impl_opendirat(dirfd, path) else {
-    throw Errno.current
-  }
-  defer {
-    _ = system_closedir(dir)
-  }
-
-  while let dirent = system_readdir(dir) {
-    // Skip . and ..
-    if dirent.pointee.d_name.0 == 46
-         && (dirent.pointee.d_name.1 == 0
-               || (dirent.pointee.d_name.1 == 46
-                     && dirent.pointee.d_name.2 == 0)) {
-      continue
-    }
-
-    try body(dirent.pointee)
-  }
-}
-
-internal func recursiveRemove(
-  in dirfd: CInt,
-  path: UnsafePointer<CInterop.PlatformChar>
-) throws {
-  // First, deal with subdirectories
-  try forEachFile(in: dirfd, path: path) { dirent in
-    if dirent.d_type == SYSTEM_DT_DIR {
-      try withUnsafeBytes(of: dirent.d_name) {
-        try recursiveRemove(
-          in: dirfd,
-          path: $0.assumingMemoryBound(to: CInterop.PlatformChar.self)
-            .baseAddress!
-        )
-      }
-    }
-  }
-
-  // Now delete the contents of this directory
-  try forEachFile(in: dirfd, path: path) { dirent in
-    let flag: CInt
-
-    if dirent.d_type == SYSTEM_DT_DIR {
-      flag = SYSTEM_AT_REMOVE_DIR
-    } else {
-      flag = 0
-    }
-
-    let result = withUnsafeBytes(of: dirent.d_name) {
-      system_unlinkat(dirfd,
-                      $0.assumingMemoryBound(to: CInterop.PlatformChar.self)
-                        .baseAddress!,
-                      flag)
-    }
-
-    if result != 0 {
-      throw Errno.current
-    }
-  }
-}
-#endif
-
 fileprivate let base64 = Array<UInt8>(
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".utf8
 )
 
-fileprivate func makeTempDirectory(at: FilePath) throws -> Bool {
-  return try at.withPlatformString {
+/// Create a directory that is only accessible to the current user.
+///
+/// - Parameters:
+///   - path: The path of the directory to create.
+/// - Returns: `true` if a new directory was created.
+///
+/// This function will throw if there is an error, except if the error
+/// is that the directory exists, in which case it returns `false`.
+fileprivate func makeLockedDownDirectory(at path: FilePath) throws -> Bool {
+  return try path.withPlatformString {
     if system_mkdir($0, 0o700) == 0 {
       return true
     }
@@ -259,6 +58,11 @@ fileprivate func makeTempDirectory(at: FilePath) throws -> Bool {
   }
 }
 
+/// Generate a random string of base64 filename safe characters.
+///
+/// - Parameters:
+///   - length: The number of characters in the returned string.
+/// - Returns: A random string of length `length`.
 fileprivate func createRandomString(length: Int) -> String {
   return String(
     decoding: (0..<length).map{
@@ -268,16 +72,25 @@ fileprivate func createRandomString(length: Int) -> String {
   )
 }
 
-internal func createUniqueTemporaryDirectory(
+/// Given a base name, create a uniquely named temporary directory.
+///
+/// - Parameters:
+///   - basename: The base name for the new directory.
+/// - Returns: The path to the new directory.
+///
+/// Creates a directory in the system temporary directory whose name
+/// starts with `basename`, followed by a `.` and then a random
+/// string of characters.
+fileprivate func createUniqueTemporaryDirectory(
   basename: FilePath.Component
 ) throws -> FilePath {
-  var tempDir = try getTemporaryDirectory()
+  var tempDir = try _getTemporaryDirectory()
   tempDir.append(basename)
 
   while true {
     tempDir.extension = createRandomString(length: 16)
 
-    if try makeTempDirectory(at: tempDir) {
+    if try makeLockedDownDirectory(at: tempDir) {
       return tempDir
     }
   }

--- a/Sources/System/FilePath/FilePathTempPosix.swift
+++ b/Sources/System/FilePath/FilePathTempPosix.swift
@@ -60,7 +60,7 @@ internal func _recursiveRemove(
 fileprivate func impl_opendirat(
   _ dirfd: CInt,
   _ name: UnsafePointer<CInterop.PlatformChar>
-) -> UnsafeMutablePointer<system_DIR>? {
+) -> system_DIRPtr? {
   let fd = system_openat(dirfd, name,
                          FileDescriptor.AccessMode.readOnly.rawValue
                            | FileDescriptor.OpenOptions.directory.rawValue)

--- a/Sources/System/FilePath/FilePathTempPosix.swift
+++ b/Sources/System/FilePath/FilePathTempPosix.swift
@@ -1,0 +1,153 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ */
+
+#if !os(Windows)
+
+/// Get the path to the system temporary directory.
+internal func _getTemporaryDirectory() throws -> FilePath {
+  guard let tmp = system_getenv("TMPDIR") else {
+    return "/tmp"
+  }
+
+  return FilePath(SystemString(platformString: tmp))
+}
+
+/// Delete the entire contents of a directory, including its subdirectories.
+///
+/// - Parameters:
+///   - path: The directory to be deleted.
+///
+/// Removes a directory completely, including all of its contents.
+internal func _recursiveRemove(
+  at path: FilePath
+) throws {
+  let dirfd = try FileDescriptor.open(path, .readOnly, options: .directory)
+  defer {
+    try? dirfd.close()
+  }
+
+  let dot: (CInterop.PlatformChar, CInterop.PlatformChar) = (46, 0)
+  try withUnsafeBytes(of: dot) {
+    try recursiveRemove(
+      in: dirfd.rawValue,
+      name: $0.assumingMemoryBound(to: CInterop.PlatformChar.self).baseAddress!
+    )
+  }
+
+  try path.withPlatformString {
+    if system_rmdir($0) != 0 {
+      throw Errno.current
+    }
+  }
+}
+
+/// Open a directory by reference to its parent and name.
+///
+/// - Parameters:
+///   - dirfd: An open file descriptor for the parent directory.
+///   - name: The name of the directory to open.
+/// - Returns: A pointer to a `DIR` structure.
+///
+/// This is like `opendir()`, but instead of taking a path, it uses a
+/// file descriptor pointing at the parent, thus avoiding path length
+/// limits.
+fileprivate func impl_opendirat(
+  _ dirfd: CInt,
+  _ name: UnsafePointer<CInterop.PlatformChar>
+) -> UnsafeMutablePointer<system_DIR>? {
+  let fd = system_openat(dirfd, name,
+                         FileDescriptor.AccessMode.readOnly.rawValue
+                           | FileDescriptor.OpenOptions.directory.rawValue)
+  if fd < 0 {
+    return nil
+  }
+  return system_fdopendir(fd)
+}
+
+/// Invoke a closure for each file within a particular directory.
+///
+/// - Parameters:
+///   - dirfd: The parent of the directory to be enumerated.
+///   - subdir: The subdirectory to be enumerated.
+///   - body: The closure that will be invoked.
+///
+/// We skip the `.` and `..` pseudo-entries.
+fileprivate func forEachFile(
+  in dirfd: CInt,
+  subdir: UnsafePointer<CInterop.PlatformChar>,
+  _ body: (system_dirent) throws -> ()
+) throws {
+  guard let dir = impl_opendirat(dirfd, subdir) else {
+    throw Errno.current
+  }
+  defer {
+    _ = system_closedir(dir)
+  }
+
+  while let dirent = system_readdir(dir) {
+    // Skip . and ..
+    if dirent.pointee.d_name.0 == 46
+         && (dirent.pointee.d_name.1 == 0
+               || (dirent.pointee.d_name.1 == 46
+                     && dirent.pointee.d_name.2 == 0)) {
+      continue
+    }
+
+    try body(dirent.pointee)
+  }
+}
+
+/// Delete the entire contents of a directory, including its subdirectories.
+///
+/// - Parameters:
+///   - dirfd: The parent of the directory to be removed.
+///   - name: The name of the directory to be removed.
+///
+/// Removes a directory completely, including all of its contents.
+fileprivate func recursiveRemove(
+  in dirfd: CInt,
+  name: UnsafePointer<CInterop.PlatformChar>
+) throws {
+  // First, deal with subdirectories
+  try forEachFile(in: dirfd, subdir: name) { dirent in
+    if dirent.d_type == SYSTEM_DT_DIR {
+      try withUnsafeBytes(of: dirent.d_name) {
+        try recursiveRemove(
+          in: dirfd,
+          name: $0.assumingMemoryBound(to: CInterop.PlatformChar.self)
+            .baseAddress!
+        )
+      }
+    }
+  }
+
+  // Now delete the contents of this directory
+  try forEachFile(in: dirfd, subdir: name) { dirent in
+    let flag: CInt
+
+    if dirent.d_type == SYSTEM_DT_DIR {
+      flag = SYSTEM_AT_REMOVE_DIR
+    } else {
+      flag = 0
+    }
+
+    let result = withUnsafeBytes(of: dirent.d_name) {
+      system_unlinkat(dirfd,
+                      $0.assumingMemoryBound(to: CInterop.PlatformChar.self)
+                        .baseAddress!,
+                      flag)
+    }
+
+    if result != 0 {
+      throw Errno.current
+    }
+  }
+}
+
+#endif // !os(Windows)

--- a/Sources/System/FilePath/FilePathTempWindows.swift
+++ b/Sources/System/FilePath/FilePathTempWindows.swift
@@ -1,0 +1,114 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+#if os(Windows)
+
+import WinSDK
+
+/// Get the path to the system temporary directory.
+internal func _getTemporaryDirectory() throws -> FilePath {
+  return try withUnsafeTemporaryAllocation(of: CInterop.PlatformChar.self,
+                                           capacity: Int(MAX_PATH) + 1) {
+    buffer in
+
+    guard GetTempPath2W(DWORD(buffer.count), buffer.baseAddress) != 0 else {
+      throw Errno(windowsError: GetLastError())
+    }
+
+    return FilePath(SystemString(platformString: buffer.baseAddress!))
+  }
+}
+
+/// Invoke a closure for each file within a particular directory.
+///
+/// - Parameters:
+///   - path: The path at which we should enumerate items.
+///   - body: The closure that will be invoked.
+///
+/// We skip the `.` and `..` pseudo-entries.
+fileprivate func forEachFile(
+  at path: FilePath,
+  _ body: (WIN32_FIND_DATAW) throws -> ()
+) rethrows {
+  let searchPath = path.appending("\\*")
+
+  try searchPath.withPlatformString { szPath in
+    var findData = WIN32_FIND_DATAW()
+    let hFind = FindFirstFileW(szPath, &findData)
+    if hFind == INVALID_HANDLE_VALUE {
+      throw Errno(windowsError: GetLastError())
+    }
+    defer {
+      FindClose(hFind)
+    }
+
+    repeat {
+      // Skip . and ..
+      if findData.cFileName.0 == 46
+           && (findData.cFileName.1 == 0
+                 || (findData.cFileName.1 == 46
+                       && findData.cFileName.2 == 0)) {
+        continue
+      }
+
+      try body(findData)
+    } while FindNextFileW(hFind, &findData)
+  }
+}
+
+/// Delete the entire contents of a directory, including its subdirectories.
+///
+/// - Parameters:
+///   - path: The directory to be deleted.
+///
+/// Removes a directory completely, including all of its contents.
+internal func _recursiveRemove(
+  at path: FilePath
+) throws {
+  // First, deal with subdirectories
+  try forEachFile(at: path) { findData in
+    if (findData.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY)) != 0 {
+      let name = withUnsafeBytes(of: findData.cFileName) {
+        return SystemString(platformString: $0.assumingMemoryBound(
+                              to: CInterop.PlatformChar.self).baseAddress!)
+      }
+      let component = FilePath.Component(name)!
+      let subpath = path.appending(component)
+
+      try _recursiveRemove(at: subpath)
+    }
+  }
+
+  // Now delete everything else
+  try forEachFile(at: path) { findData in
+    let name = withUnsafeBytes(of: findData.cFileName) {
+      return SystemString(platformString: $0.assumingMemoryBound(
+                            to: CInterop.PlatformChar.self).baseAddress!)
+    }
+    let component = FilePath.Component(name)!
+    let subpath = path.appending(component)
+
+    if (findData.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY)) == 0 {
+      try subpath.withPlatformString {
+        if !DeleteFileW($0) {
+          throw Errno(windowsError: GetLastError())
+        }
+      }
+    }
+  }
+
+  // Finally, delete the parent
+  try path.withPlatformString {
+    if !RemoveDirectoryW($0) {
+      throw Errno(windowsError: GetLastError())
+    }
+  }
+}
+
+#endif // os(Windows)

--- a/Sources/System/Internals/Mocking.swift
+++ b/Sources/System/Internals/Mocking.swift
@@ -110,7 +110,7 @@ private var contextualMockingEnabled: Bool {
 extension MockingDriver {
   internal static var enabled: Bool { mockingEnabled }
 
-  internal static var forceWindowsPaths: Optional<Bool> {
+  internal static var forceWindowsPaths: Bool? {
     currentMockingDriver?.forceWindowsSyntaxForPaths
   }
 }
@@ -128,7 +128,7 @@ internal var mockingEnabled: Bool {
 }
 
 @inline(__always)
-internal var forceWindowsPaths: Optional<Bool> {
+internal var forceWindowsPaths: Bool? {
   #if !ENABLE_MOCKING
   return false
   #else

--- a/Sources/System/Internals/Mocking.swift
+++ b/Sources/System/Internals/Mocking.swift
@@ -63,7 +63,7 @@ internal class MockingDriver {
 
   // Whether we should pretend to be Windows for syntactic operations
   // inside FilePath
-  fileprivate var forceWindowsSyntaxForPaths = false
+  fileprivate var forceWindowsSyntaxForPaths: Bool? = nil
 }
 
 private let driverKey: _PlatformTLSKey = { makeTLSKey() }()
@@ -110,8 +110,8 @@ private var contextualMockingEnabled: Bool {
 extension MockingDriver {
   internal static var enabled: Bool { mockingEnabled }
 
-  internal static var forceWindowsPaths: Bool {
-    currentMockingDriver?.forceWindowsSyntaxForPaths ?? false
+  internal static var forceWindowsPaths: Optional<Bool> {
+    currentMockingDriver?.forceWindowsSyntaxForPaths
   }
 }
 
@@ -128,7 +128,7 @@ internal var mockingEnabled: Bool {
 }
 
 @inline(__always)
-internal var forceWindowsPaths: Bool {
+internal var forceWindowsPaths: Optional<Bool> {
   #if !ENABLE_MOCKING
   return false
   #else
@@ -196,15 +196,11 @@ internal func _mockOffT(
 #endif // ENABLE_MOCKING
 
 // Force paths to be treated as Windows syntactically if `enabled` is
-// true.
+// true, and as POSIX syntactically if not.
 internal func _withWindowsPaths(enabled: Bool, _ body: () -> ()) {
   #if ENABLE_MOCKING
-  guard enabled else {
-    body()
-    return
-  }
   MockingDriver.withMockingEnabled { driver in
-    driver.forceWindowsSyntaxForPaths = true
+    driver.forceWindowsSyntaxForPaths = enabled
     body()
   }
   #else

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -173,6 +173,18 @@ internal func system_rmdir(
   return rmdir(path)
 }
 
+#if SYSTEM_PACKAGE_DARWIN
+internal let SYSTEM_CS_DARWIN_USER_TEMP_DIR = _CS_DARWIN_USER_TEMP_DIR
+
+internal func system_confstr(
+  _ name: CInt,
+  _ buf: UnsafeMutablePointer<CInterop.PlatformChar>,
+  _ len: Int
+) -> Int {
+  return confstr(name, buf, len)
+}
+#endif
+
 #if !os(Windows)
 internal let SYSTEM_AT_REMOVE_DIR = AT_REMOVEDIR
 internal let SYSTEM_DT_DIR = DT_DIR

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -239,3 +239,15 @@ internal func system_openat(
   return openat(fd, path, oflag)
 }
 #endif
+
+internal func system_umask(
+  _ mode: CInterop.Mode
+) -> CInterop.Mode {
+  return umask(mode)
+}
+
+internal func system_getenv(
+  _ name: UnsafePointer<CChar>
+) -> UnsafeMutablePointer<CChar>? {
+  return getenv(name)
+}

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -138,7 +138,7 @@ internal func system_dup2(_ fd: Int32, _ fd2: Int32) -> Int32 {
 }
 #endif
 
-#if !os(Windows) && !os(WASI)
+#if !os(WASI)
 internal func system_pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
 #if ENABLE_MOCKING
   if mockingEnabled { return _mock(fds) }
@@ -147,11 +147,83 @@ internal func system_pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
 }
 #endif
 
-#if !os(Windows)
 internal func system_ftruncate(_ fd: Int32, _ length: off_t) -> Int32 {
 #if ENABLE_MOCKING
   if mockingEnabled { return _mock(fd, length) }
 #endif
   return ftruncate(fd, length)
+}
+
+internal func system_mkdir(
+    _ path: UnsafePointer<CInterop.PlatformChar>,
+    _ mode: CInterop.Mode
+) -> CInt {
+#if ENABLE_MOCKING
+  if mockingEnabled { return _mock(path: path, mode) }
+#endif
+  return mkdir(path, mode)
+}
+
+internal func system_rmdir(
+    _ path: UnsafePointer<CInterop.PlatformChar>
+) -> CInt {
+#if ENABLE_MOCKING
+  if mockingEnabled { return _mock(path: path) }
+#endif
+  return rmdir(path)
+}
+
+#if !os(Windows)
+internal let SYSTEM_AT_REMOVE_DIR = AT_REMOVEDIR
+internal let SYSTEM_DT_DIR = DT_DIR
+internal typealias system_dirent = dirent
+internal typealias system_DIR = DIR
+
+internal func system_unlinkat(
+  _ fd: CInt,
+  _ path: UnsafePointer<CInterop.PlatformChar>,
+  _ flag: CInt
+) -> CInt {
+#if ENABLE_MOCKING
+  if mockingEnabled { return _mock(fd, path, flag) }
+#endif
+return unlinkat(fd, path, flag)
+}
+
+internal func system_fdopendir(
+  _ fd: CInt
+) -> UnsafeMutablePointer<DIR>? {
+  return fdopendir(fd)
+}
+
+internal func system_readdir(
+  _ dir: UnsafeMutablePointer<DIR>
+) -> UnsafeMutablePointer<dirent>? {
+  return readdir(dir)
+}
+
+internal func system_rewinddir(
+  _ dir: UnsafeMutablePointer<DIR>
+) {
+  return rewinddir(dir)
+}
+
+internal func system_closedir(
+  _ dir: UnsafeMutablePointer<DIR>
+) -> CInt {
+  return closedir(dir)
+}
+
+internal func system_openat(
+  _ fd: CInt,
+  _ path: UnsafePointer<CInterop.PlatformChar>,
+  _ oflag: Int32
+) -> CInt {
+#if ENABLE_MOCKING
+  if mockingEnabled {
+    return _mock(fd, path, oflag)
+  }
+#endif
+  return openat(fd, path, oflag)
 }
 #endif

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -189,7 +189,11 @@ internal func system_confstr(
 internal let SYSTEM_AT_REMOVE_DIR = AT_REMOVEDIR
 internal let SYSTEM_DT_DIR = DT_DIR
 internal typealias system_dirent = dirent
-internal typealias system_DIR = DIR
+#if os(Linux)
+internal typealias system_DIRPtr = OpaquePointer
+#else
+internal typealias system_DIRPtr = UnsafeMutablePointer<DIR>
+#endif
 
 internal func system_unlinkat(
   _ fd: CInt,
@@ -204,24 +208,24 @@ return unlinkat(fd, path, flag)
 
 internal func system_fdopendir(
   _ fd: CInt
-) -> UnsafeMutablePointer<DIR>? {
+) -> system_DIRPtr? {
   return fdopendir(fd)
 }
 
 internal func system_readdir(
-  _ dir: UnsafeMutablePointer<DIR>
+  _ dir: system_DIRPtr
 ) -> UnsafeMutablePointer<dirent>? {
   return readdir(dir)
 }
 
 internal func system_rewinddir(
-  _ dir: UnsafeMutablePointer<DIR>
+  _ dir: system_DIRPtr
 ) {
   return rewinddir(dir)
 }
 
 internal func system_closedir(
-  _ dir: UnsafeMutablePointer<DIR>
+  _ dir: system_DIRPtr
 ) -> CInt {
   return closedir(dir)
 }

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -80,7 +80,7 @@ internal func pread(
   _ fd: Int32, _ buf: UnsafeMutableRawPointer!, _ nbyte: Int, _ offset: off_t
 ) -> Int {
   let handle: intptr_t = _get_osfhandle(fd)
-  if handle == /* INVALID_HANDLE_VALUE */ -1 { return Int(EBADF) }
+  if handle == /* INVALID_HANDLE_VALUE */ -1 { ucrt._set_errno(EBADF); return -1 }
 
   // NOTE: this is a non-owning handle, do *not* call CloseHandle on it
   let hFile: HANDLE = HANDLE(bitPattern: handle)!
@@ -91,8 +91,7 @@ internal func pread(
 
   var nNumberOfBytesRead: DWORD = 0
   if !ReadFile(hFile, buf, DWORD(nbyte), &nNumberOfBytesRead, &ovlOverlapped) {
-    let _ = GetLastError()
-    // TODO(compnerd) map windows error to errno
+    ucrt._set_errno(mapWindowsErrorToErrno(GetLastError()))
     return Int(-1)
   }
   return Int(nNumberOfBytesRead)
@@ -103,7 +102,7 @@ internal func pwrite(
   _ fd: Int32, _ buf: UnsafeRawPointer!, _ nbyte: Int, _ offset: off_t
 ) -> Int {
   let handle: intptr_t = _get_osfhandle(fd)
-  if handle == /* INVALID_HANDLE_VALUE */ -1 { return Int(EBADF) }
+  if handle == /* INVALID_HANDLE_VALUE */ -1 { ucrt._set_errno(EBADF); return -1 }
 
   // NOTE: this is a non-owning handle, do *not* call CloseHandle on it
   let hFile: HANDLE = HANDLE(bitPattern: handle)!
@@ -115,11 +114,133 @@ internal func pwrite(
   var nNumberOfBytesWritten: DWORD = 0
   if !WriteFile(hFile, buf, DWORD(nbyte), &nNumberOfBytesWritten,
                 &ovlOverlapped) {
-    let _ = GetLastError()
-    // TODO(compnerd) map windows error to errno
+    ucrt._set_errno(mapWindowsErrorToErrno(GetLastError()))
     return Int(-1)
   }
   return Int(nNumberOfBytesWritten)
+}
+
+@inline(__always)
+internal func pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
+  return _pipe(fds, 4096, _O_BINARY | _O_NOINHERIT);
+}
+
+@inline(__always)
+internal func ftruncate(_ fd: Int32, _ length: off_t) -> Int32 {
+  let handle: intptr_t = _get_osfhandle(fd)
+  if handle == /* INVALID_HANDLE_VALUE */ -1 { ucrt._set_errno(EBADF); return -1 }
+
+  // NOTE: this is a non-owning handle, do *not* call CloseHandle on it
+  let hFile: HANDLE = HANDLE(bitPattern: handle)!
+  let liDesiredLength = LARGE_INTEGER(QuadPart: LONGLONG(length))
+  var liCurrentOffset = LARGE_INTEGER(QuadPart: 0)
+
+  // Save the current position and restore it when we're done
+  if !SetFilePointerEx(hFile, liCurrentOffset, &liCurrentOffset,
+                       DWORD(FILE_CURRENT)) {
+    ucrt._set_errno(mapWindowsErrorToErrno(GetLastError()))
+    return -1
+  }
+  defer {
+    _ = SetFilePointerEx(hFile, liCurrentOffset, nil, DWORD(FILE_BEGIN));
+  }
+
+  // Truncate (or extend) the file
+  if !SetFilePointerEx(hFile, liDesiredLength, nil, DWORD(FILE_BEGIN))
+       || !SetEndOfFile(hFile) {
+    ucrt._set_errno(mapWindowsErrorToErrno(GetLastError()))
+    return -1
+  }
+
+  return 0;
+}
+
+@inline(__always)
+internal func mkdir(
+  _ path: UnsafePointer<CInterop.PlatformChar>,
+  _ mode: CInterop.Mode
+) -> CInt {
+  return _wmkdir(path)
+}
+
+@inline(__always)
+internal func rmdir(
+  _ path: UnsafePointer<CInterop.PlatformChar>
+) -> CInt {
+  return _wrmdir(path)
+}
+
+@usableFromInline
+internal func mapWindowsErrorToErrno(_ errorCode: DWORD) -> CInt {
+  switch Int32(errorCode) {
+  case ERROR_SUCCESS:
+    return 0
+  case ERROR_INVALID_FUNCTION,
+       ERROR_INVALID_ACCESS,
+       ERROR_INVALID_DATA,
+       ERROR_INVALID_PARAMETER,
+       ERROR_NEGATIVE_SEEK:
+    return EINVAL
+  case ERROR_FILE_NOT_FOUND,
+       ERROR_PATH_NOT_FOUND,
+       ERROR_INVALID_DRIVE,
+       ERROR_NO_MORE_FILES,
+       ERROR_BAD_NETPATH,
+       ERROR_BAD_NET_NAME,
+       ERROR_BAD_PATHNAME,
+       ERROR_FILENAME_EXCED_RANGE:
+    return ENOENT
+  case ERROR_TOO_MANY_OPEN_FILES:
+    return EMFILE
+  case ERROR_ACCESS_DENIED,
+       ERROR_CURRENT_DIRECTORY,
+       ERROR_LOCK_VIOLATION,
+       ERROR_NETWORK_ACCESS_DENIED,
+       ERROR_CANNOT_MAKE,
+       ERROR_FAIL_I24,
+       ERROR_DRIVE_LOCKED,
+       ERROR_SEEK_ON_DEVICE,
+       ERROR_NOT_LOCKED,
+       ERROR_LOCK_FAILED,
+       ERROR_WRITE_PROTECT...ERROR_SHARING_BUFFER_EXCEEDED:
+    return EACCES
+  case ERROR_INVALID_HANDLE,
+       ERROR_INVALID_TARGET_HANDLE,
+       ERROR_DIRECT_ACCESS_HANDLE:
+    return EBADF
+  case ERROR_ARENA_TRASHED,
+       ERROR_NOT_ENOUGH_MEMORY,
+       ERROR_INVALID_BLOCK,
+       ERROR_NOT_ENOUGH_QUOTA:
+    return ENOMEM
+  case ERROR_BAD_ENVIRONMENT:
+    return E2BIG
+  case ERROR_BAD_FORMAT,
+       ERROR_INVALID_STARTING_CODESEG...ERROR_INFLOOP_IN_RELOC_CHAIN:
+    return ENOEXEC
+  case ERROR_NOT_SAME_DEVICE:
+    return EXDEV
+  case ERROR_FILE_EXISTS,
+       ERROR_ALREADY_EXISTS:
+    return EEXIST
+  case ERROR_NO_PROC_SLOTS,
+       ERROR_MAX_THRDS_REACHED,
+       ERROR_NESTING_NOT_ALLOWED:
+    return EAGAIN
+  case ERROR_BROKEN_PIPE:
+    return EPIPE
+  case ERROR_DISK_FULL:
+    return ENOSPC
+  case ERROR_WAIT_NO_CHILDREN,
+       ERROR_CHILD_NOT_COMPLETE:
+    return ECHILD
+  case ERROR_DIR_NOT_EMPTY:
+    return ENOTEMPTY
+  case ERROR_NO_UNICODE_TRANSLATION:
+    return EILSEQ
+  default:
+    return EINVAL
+  }
 }
 
 #endif

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -160,14 +160,25 @@ internal func mkdir(
   _ path: UnsafePointer<CInterop.PlatformChar>,
   _ mode: CInterop.Mode
 ) -> CInt {
-  return _wmkdir(path)
+  // TODO: Read/write permissions (these need mapping to a SECURITY_DESCRIPTOR).
+  if !CreateDirectoryW(path, nil) {
+    ucrt._set_errno(mapWindowsErrorToErrno(GetLastError()))
+    return -1
+  }
+
+  return 0;
 }
 
 @inline(__always)
 internal func rmdir(
   _ path: UnsafePointer<CInterop.PlatformChar>
 ) -> CInt {
-  return _wrmdir(path)
+  if !RemoveDirectoryW(path) {
+    ucrt._set_errno(mapWindowsErrorToErrno(GetLastError()))
+    return -1
+  }
+
+  return 0;
 }
 
 @usableFromInline

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -137,7 +137,7 @@ final class FileOperationsTest: XCTestCase {
     // Ad-hoc test touching a file system.
     do {
       // TODO: Test this against a virtual in-memory file system
-      try withTemporaryPath(basename: "testAdhocOpen") { path in
+      try withTemporaryFilePath(basename: "testAdhocOpen") { path in
         let fd = try FileDescriptor.open(path.appending("b.txt"), .readWrite, options: [.create, .truncate], permissions: .ownerReadWrite)
         try fd.closeAfter {
           try fd.writeAll("abc".utf8)
@@ -186,7 +186,7 @@ final class FileOperationsTest: XCTestCase {
   }
 
   func testResizeFile() throws {
-    try withTemporaryPath(basename: "testResizeFile") { path in 
+    try withTemporaryFilePath(basename: "testResizeFile") { path in 
       let fd = try FileDescriptor.open(path.appending("\(UUID().uuidString).txt"), .readWrite, options: [.create, .truncate], permissions: .ownerReadWrite)
       try fd.closeAfter {
         // File should be empty initially.

--- a/Tests/SystemTests/FileOperationsTestWindows.swift
+++ b/Tests/SystemTests/FileOperationsTestWindows.swift
@@ -1,0 +1,241 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import XCTest
+
+#if os(Windows)
+
+#if SYSTEM_PACKAGE
+import SystemPackage
+#else
+import System
+#endif
+
+import WinSDK
+
+@available(iOS 8, *)
+final class FileOperationsTestWindows: XCTestCase {
+  private let r = ACCESS_MASK(
+    FILE_READ_ATTRIBUTES
+      | FILE_READ_DATA
+      | FILE_READ_EA
+      | STANDARD_RIGHTS_READ
+      | SYNCHRONIZE
+  )
+  private let w = ACCESS_MASK(
+    FILE_APPEND_DATA
+      | FILE_WRITE_ATTRIBUTES
+      | FILE_WRITE_DATA
+      | FILE_WRITE_EA
+      | STANDARD_RIGHTS_WRITE
+      | SYNCHRONIZE
+  )
+  private let x = ACCESS_MASK(
+    FILE_EXECUTE
+      | FILE_READ_ATTRIBUTES
+      | STANDARD_RIGHTS_EXECUTE
+      | SYNCHRONIZE
+  )
+
+  private struct Test {
+    var permissions: CModeT
+    var ownerAccess: ACCESS_MASK
+    var groupAccess: ACCESS_MASK
+    var otherAccess: ACCESS_MASK
+
+    init(_ permissions: CModeT,
+         _ ownerAccess: ACCESS_MASK,
+         _ groupAccess: ACCESS_MASK,
+         _ otherAccess: ACCESS_MASK) {
+      self.permissions = permissions
+      self.ownerAccess = ownerAccess
+      self.groupAccess = groupAccess
+      self.otherAccess = otherAccess
+    }
+  }
+
+  /// Retrieve the owner, group and other access masks for a given file.
+  ///
+  /// - Parameters:
+  ///   - path: The path to the file to inspect
+  /// - Returns: A tuple of ACCESS_MASK values.
+  func getAccessMasks(
+    path: FilePath
+  ) -> (ACCESS_MASK, ACCESS_MASK, ACCESS_MASK) {
+    var SIDAuthWorld = SID_IDENTIFIER_AUTHORITY(Value: (0, 0, 0, 0, 0, 1))
+    var psidEveryone: PSID? = nil
+
+    XCTAssert(AllocateAndInitializeSid(&SIDAuthWorld, 1,
+                                       DWORD(SECURITY_WORLD_RID),
+                                       0, 0, 0, 0, 0, 0, 0,
+                                       &psidEveryone))
+    defer {
+      FreeSid(psidEveryone)
+    }
+
+    var everyone = TRUSTEE_W(
+      pMultipleTrustee: nil,
+      MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+      TrusteeForm: TRUSTEE_IS_SID,
+      TrusteeType: TRUSTEE_IS_GROUP,
+      ptstrName:
+        psidEveryone!.assumingMemoryBound(to: CInterop.PlatformChar.self)
+    )
+
+    return path.withPlatformString { objectName in
+      var psidOwner: PSID? = nil
+      var psidGroup: PSID? = nil
+      var pDacl: PACL? = nil
+      var pSD: PSECURITY_DESCRIPTOR? = nil
+
+      XCTAssertEqual(GetNamedSecurityInfoW(
+                       objectName,
+                       SE_FILE_OBJECT,
+                       SECURITY_INFORMATION(
+                         DACL_SECURITY_INFORMATION
+                           | GROUP_SECURITY_INFORMATION
+                           | OWNER_SECURITY_INFORMATION
+                       ),
+                       &psidOwner,
+                       &psidGroup,
+                       &pDacl,
+                       nil,
+                       &pSD), DWORD(ERROR_SUCCESS))
+      defer {
+        LocalFree(pSD)
+      }
+
+      var owner = TRUSTEE_W(
+        pMultipleTrustee: nil,
+        MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+        TrusteeForm: TRUSTEE_IS_SID,
+        TrusteeType: TRUSTEE_IS_USER,
+        ptstrName:
+          psidOwner!.assumingMemoryBound(to: CInterop.PlatformChar.self)
+      )
+      var group = TRUSTEE_W(
+        pMultipleTrustee: nil,
+        MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+        TrusteeForm: TRUSTEE_IS_SID,
+        TrusteeType: TRUSTEE_IS_GROUP,
+        ptstrName:
+          psidGroup!.assumingMemoryBound(to: CInterop.PlatformChar.self)
+      )
+
+      var ownerAccess = ACCESS_MASK(0)
+      var groupAccess = ACCESS_MASK(0)
+      var otherAccess = ACCESS_MASK(0)
+
+      XCTAssertEqual(GetEffectiveRightsFromAclW(
+                       pDacl,
+                       &owner,
+                       &ownerAccess), DWORD(ERROR_SUCCESS))
+      XCTAssertEqual(GetEffectiveRightsFromAclW(
+                       pDacl,
+                       &group,
+                       &groupAccess), DWORD(ERROR_SUCCESS))
+      XCTAssertEqual(GetEffectiveRightsFromAclW(
+                       pDacl,
+                       &everyone,
+                       &otherAccess), DWORD(ERROR_SUCCESS))
+
+      return (ownerAccess, groupAccess, otherAccess)
+    }
+  }
+
+  private func runTests(_ tests: [Test], at path: FilePath) throws {
+    for test in tests {
+      let octal = String(test.permissions, radix: 8)
+      let testPath = path.appending("test-\(octal).txt")
+      let fd = try FileDescriptor.open(
+        testPath,
+        .readWrite,
+        options: [.create, .truncate],
+        permissions: FilePermissions(rawValue: test.permissions)
+      )
+      _ = try fd.closeAfter {
+        try fd.writeAll("Hello World".utf8)
+      }
+
+      let (ownerAccess, groupAccess, otherAccess)
+        = getAccessMasks(path: testPath)
+
+      XCTAssertEqual(ownerAccess, test.ownerAccess)
+      XCTAssertEqual(groupAccess, test.groupAccess)
+      XCTAssertEqual(otherAccess, test.otherAccess)
+    }
+  }
+
+  /// Test that the umask works properly
+  func testUmask() throws {
+    // Default mask should be 0o022
+    XCTAssertEqual(FilePermissions.creationMask, [.groupWrite, .otherWrite])
+
+    try withTemporaryFilePath(basename: "testUmask") { path in
+      let tests = [
+        Test(0o000, 0, 0, 0),
+        Test(0o700, r|w|x, 0, 0),
+        Test(0o770, r|w|x, r|x, 0),
+        Test(0o777, r|w|x, r|x, r|x)
+      ]
+
+      try runTests(tests, at: path)
+    }
+
+    try FilePermissions.withCreationMask([.groupWrite, .groupExecute,
+                                          .otherWrite, .otherExecute]) {
+      try withTemporaryFilePath(basename: "testUmask") { path in
+        let tests = [
+          Test(0o000, 0, 0, 0),
+          Test(0o700, r|w|x, 0, 0),
+          Test(0o770, r|w|x, r, 0),
+          Test(0o777, r|w|x, r, r)
+        ]
+
+        try runTests(tests, at: path)
+      }
+    }
+  }
+
+  /// Test that setting permissions on a file works as expected
+  func testPermissions() throws {
+    try FilePermissions.withCreationMask([]) {
+      try withTemporaryFilePath(basename: "testPermissions") { path in
+        let tests = [
+          Test(0o000, 0, 0, 0),
+
+          Test(0o400, r, 0, 0),
+          Test(0o200, w, 0, 0),
+          Test(0o100, x, 0, 0),
+          Test(0o040, 0, r, 0),
+          Test(0o020, 0, w, 0),
+          Test(0o010, 0, x, 0),
+          Test(0o004, 0, 0, r),
+          Test(0o002, 0, 0, w),
+          Test(0o001, 0, 0, x),
+
+          Test(0o700, r|w|x, 0, 0),
+          Test(0o770, r|w|x, r|w|x, 0),
+          Test(0o777, r|w|x, r|w|x, r|w|x),
+
+          Test(0o755, r|w|x, r|x, r|x),
+          Test(0o644, r|w, r, r),
+
+          Test(0o007, 0, 0, r|w|x),
+          Test(0o070, 0, r|w|x, 0),
+          Test(0o077, 0, r|w|x, r|w|x),
+        ]
+
+        try runTests(tests, at: path)
+      }
+    }
+  }
+}
+
+#endif // os(Windows)

--- a/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
@@ -231,7 +231,7 @@ final class FilePathComponentsTest: XCTestCase {
   }
 
   func testCases() {
-    let testPaths: Array<TestPathComponents> = [
+    var testPaths: Array<TestPathComponents> = [
       TestPathComponents("", root: nil, []),
       TestPathComponents("/", root: "/", []),
       TestPathComponents("foo", root: nil, ["foo"]),
@@ -240,16 +240,28 @@ final class FilePathComponentsTest: XCTestCase {
       TestPathComponents("foo/bar", root: nil, ["foo", "bar"]),
       TestPathComponents("foo/bar/", root: nil, ["foo", "bar"]),
       TestPathComponents("/foo/bar", root: "/", ["foo", "bar"]),
-      TestPathComponents("///foo//", root: "/", ["foo"]),
       TestPathComponents("/foo///bar", root: "/", ["foo", "bar"]),
       TestPathComponents("foo/bar/", root: nil, ["foo", "bar"]),
       TestPathComponents("foo///bar/baz/", root: nil, ["foo", "bar", "baz"]),
-      TestPathComponents("//foo///bar/baz/", root: "/", ["foo", "bar", "baz"]),
       TestPathComponents("./", root: nil, ["."]),
       TestPathComponents("./..", root: nil, [".", ".."]),
       TestPathComponents("/./..//", root: "/", [".", ".."]),
     ]
-    testPaths.forEach { $0.runAllTests() }
+#if !os(Windows)
+    testPaths.append(contentsOf:[
+        TestPathComponents("///foo//", root: "/", ["foo"]),
+        TestPathComponents("//foo///bar/baz/", root: "/", ["foo", "bar", "baz"])
+    ])
+#else
+    // On Windows, these are UNC paths
+    testPaths.append(contentsOf:[
+        TestPathComponents("///foo//", root: "///foo//", []),
+        TestPathComponents("//foo///bar/baz/", root: "//foo//", ["bar", "baz"])
+    ])
+#endif
+    testPaths.forEach {
+        $0.runAllTests()
+    }
   }
 
   func testSeparatorNormalization() {

--- a/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
@@ -1064,7 +1064,10 @@ final class FilePathSyntaxTest: XCTestCase {
       XCTAssert(path.lexicallyContains("usr"))
       XCTAssert(path.lexicallyContains("/usr"))
       XCTAssert(path.lexicallyContains("local/bin"))
+#if !os(Windows)
+      // On Windows, this is a relative path and is still contained
       XCTAssert(!path.lexicallyContains("/local/bin"))
+#endif
       path.append("..")
       XCTAssert(!path.lexicallyContains("local/bin"))
       XCTAssert(path.lexicallyContains("local/bin/.."))

--- a/Tests/SystemTests/FilePathTests/FilePathTempTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTempTest.swift
@@ -16,6 +16,15 @@ import System
 #endif
 
 final class TemporaryPathTest: XCTestCase {
+  #if SYSTEM_PACKAGE_DARWIN
+  func testNotInSlashTmp() throws {
+    try withTemporaryPath(basename: "NotInSlashTmp") { path in
+      // We shouldn't be using "/tmp" on Darwin
+      XCTAssertNotEqual(path.components.first!, "tmp")
+    }
+  }
+  #endif
+
   func testUnique() throws {
     try withTemporaryPath(basename: "test") { path in
       let strPath = String(decoding: path)

--- a/Tests/SystemTests/FilePathTests/FilePathTempTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTempTest.swift
@@ -18,7 +18,7 @@ import System
 final class TemporaryPathTest: XCTestCase {
   #if SYSTEM_PACKAGE_DARWIN
   func testNotInSlashTmp() throws {
-    try withTemporaryPath(basename: "NotInSlashTmp") { path in
+    try withTemporaryFilePath(basename: "NotInSlashTmp") { path in
       // We shouldn't be using "/tmp" on Darwin
       XCTAssertNotEqual(path.components.first!, "tmp")
     }
@@ -26,10 +26,10 @@ final class TemporaryPathTest: XCTestCase {
   #endif
 
   func testUnique() throws {
-    try withTemporaryPath(basename: "test") { path in
+    try withTemporaryFilePath(basename: "test") { path in
       let strPath = String(decoding: path)
       XCTAssert(strPath.contains("test"))
-      try withTemporaryPath(basename: "test") { path2 in
+      try withTemporaryFilePath(basename: "test") { path2 in
         let strPath2 = String(decoding: path2)
         XCTAssertNotEqual(strPath, strPath2)
       }
@@ -39,7 +39,7 @@ final class TemporaryPathTest: XCTestCase {
   func testCleanup() throws {
     var thePath: FilePath? = nil
 
-    try withTemporaryPath(basename: "test") { path in
+    try withTemporaryFilePath(basename: "test") { path in
       thePath = path.appending("foo.txt")
       let fd = try FileDescriptor.open(thePath!, .readWrite,
                                        options: [.create, .truncate],

--- a/Tests/SystemTests/FilePathTests/FilePathTempTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTempTest.swift
@@ -1,0 +1,49 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import XCTest
+
+#if SYSTEM_PACKAGE
+import SystemPackage
+#else
+import System
+#endif
+
+final class TemporaryPathTest: XCTestCase {
+  func testUnique() throws {
+    try withTemporaryPath(basename: "test") { path in
+      let strPath = String(decoding: path)
+      XCTAssert(strPath.contains("test"))
+      try withTemporaryPath(basename: "test") { path2 in
+        let strPath2 = String(decoding: path2)
+        XCTAssertNotEqual(strPath, strPath2)
+      }
+    }
+  }
+
+  func testCleanup() throws {
+    var thePath: FilePath? = nil
+
+    try withTemporaryPath(basename: "test") { path in
+      thePath = path.appending("foo.txt")
+      let fd = try FileDescriptor.open(thePath!, .readWrite,
+                                       options: [.create, .truncate],
+                                       permissions: .ownerReadWrite)
+      _ = try fd.closeAfter {
+        try fd.writeAll("Hello World".utf8)
+      }
+    }
+
+    XCTAssertThrowsError(try FileDescriptor.open(thePath!, .readOnly)) {
+      error in
+
+      XCTAssertEqual(error as! Errno, Errno.noSuchFileOrDirectory)
+    }
+  }
+}

--- a/Tests/SystemTests/FilePathTests/FilePathTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTest.swift
@@ -34,6 +34,16 @@ final class FilePathTest: XCTestCase {
     let filePath: FilePath
     let string: String
     let validString: Bool
+
+    init(filePath: FilePath, string: String, validString: Bool) {
+        self.filePath = filePath
+        #if os(Windows)
+        self.string = string.replacingOccurrences(of: "/", with: "\\")
+        #else
+        self.string = string
+        #endif
+        self.validString = validString
+    }
   }
 
 #if os(Windows)


### PR DESCRIPTION
The swift-system tests were not passing, for various reasons, mostly to do with path related confusion.

As part of this, add a function to create a temporary directory, as that was one of the problems.

Also add Windows support for pipe() and ftruncate(), which was missing.

rdar://125087707