### PR TITLE
Add support for `WASILibc` module

### DIFF
--- a/Sources/CSystem/include/CSystemWASI.h
+++ b/Sources/CSystem/include/CSystemWASI.h
@@ -11,6 +11,7 @@
 
 #if __wasi__
 
+#include <errno.h>
 #include <fcntl.h>
 
 // wasi-libc defines the following constants in a way that Clang Importer can't
@@ -23,5 +24,8 @@ static inline int32_t _getConst_O_EXCL(void) { return O_EXCL; }
 static inline int32_t _getConst_O_NONBLOCK(void) { return O_NONBLOCK; }
 static inline int32_t _getConst_O_TRUNC(void) { return O_TRUNC; }
 static inline int32_t _getConst_O_WRONLY(void) { return O_WRONLY; }
+
+static inline int32_t _getConst_EWOULDBLOCK(void) { return EWOULDBLOCK; }
+static inline int32_t _getConst_EOPNOTSUPP(void) { return EOPNOTSUPP; }
 
 #endif

--- a/Sources/CSystem/include/CSystemWASI.h
+++ b/Sources/CSystem/include/CSystemWASI.h
@@ -1,0 +1,27 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+#pragma once
+
+#if __wasi__
+
+#include <fcntl.h>
+
+// wasi-libc defines the following constants in a way that Clang Importer can't
+// understand, so we need to expose them manually.
+static inline int32_t _getConst_O_ACCMODE(void) { return O_ACCMODE; }
+static inline int32_t _getConst_O_APPEND(void) { return O_APPEND; }
+static inline int32_t _getConst_O_CREAT(void) { return O_CREAT; }
+static inline int32_t _getConst_O_DIRECTORY(void) { return O_DIRECTORY; }
+static inline int32_t _getConst_O_EXCL(void) { return O_EXCL; }
+static inline int32_t _getConst_O_NONBLOCK(void) { return O_NONBLOCK; }
+static inline int32_t _getConst_O_TRUNC(void) { return O_TRUNC; }
+static inline int32_t _getConst_O_WRONLY(void) { return O_WRONLY; }
+
+#endif

--- a/Sources/CSystem/include/module.modulemap
+++ b/Sources/CSystem/include/module.modulemap
@@ -1,5 +1,6 @@
 module CSystem {
   header "CSystemLinux.h"
+  header "CSystemWASI.h"
   header "CSystemWindows.h"
   export *
 }

--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -1297,7 +1297,6 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "multiHop")
   public static var EMULTIHOP: Errno { multiHop }
 
-
 #if !os(WASI)
   /// No message available.
   ///

--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2021 - 2024 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -229,7 +229,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "badAddress")
   public static var EFAULT: Errno { badAddress }
 
-#if !os(Windows)
+#if !os(Windows) && !os(WASI)
   /// Not a block device.
   ///
   /// You attempted a block device operation on a nonblock device or file.
@@ -621,6 +621,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "protocolNotSupported")
   public static var EPROTONOSUPPORT: Errno { protocolNotSupported }
 
+#if !os(WASI)
   /// Socket type not supported.
   ///
   /// Support for the socket type hasn't been configured into the system
@@ -633,6 +634,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "socketTypeNotSupported")
   public static var ESOCKTNOSUPPORT: Errno { socketTypeNotSupported }
+#endif
 
   /// Not supported.
   ///
@@ -647,6 +649,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "notSupported")
   public static var ENOTSUP: Errno { notSupported }
 
+#if !os(WASI)
   /// Protocol family not supported.
   ///
   /// The protocol family hasn't been configured into the system
@@ -659,6 +662,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "protocolFamilyNotSupported")
   public static var EPFNOSUPPORT: Errno { protocolFamilyNotSupported }
+#endif
 
   /// The address family isn't supported by the protocol family.
   ///
@@ -805,6 +809,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "socketNotConnected")
   public static var ENOTCONN: Errno { socketNotConnected }
 
+#if !os(WASI)
   /// Can't send after socket shutdown.
   ///
   /// A request to send data wasn't permitted
@@ -818,6 +823,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "socketShutdown")
   public static var ESHUTDOWN: Errno { socketShutdown }
+#endif
 
   /// Operation timed out.
   ///
@@ -874,6 +880,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "fileNameTooLong")
   public static var ENAMETOOLONG: Errno { fileNameTooLong }
 
+#if !os(WASI)
   /// The host is down.
   ///
   /// A socket operation failed because the destination host was down.
@@ -885,6 +892,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "hostIsDown")
   public static var EHOSTDOWN: Errno { hostIsDown }
+#endif
 
   /// No route to host.
   ///
@@ -923,6 +931,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   public static var EPROCLIM: Errno { tooManyProcesses }
 #endif
 
+#if !os(WASI)
   /// Too many users.
   ///
   /// The quota system ran out of table entries.
@@ -934,6 +943,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "tooManyUsers")
   public static var EUSERS: Errno { tooManyUsers }
+#endif
 
   /// Disk quota exceeded.
   ///
@@ -952,6 +962,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "diskQuotaExceeded")
   public static var EDQUOT: Errno { diskQuotaExceeded }
 
+#if !os(WASI)
   /// Stale NFS file handle.
   ///
   /// You attempted access an open file on an NFS filesystem,
@@ -966,6 +977,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "staleNFSFileHandle")
   public static var ESTALE: Errno { staleNFSFileHandle }
+#endif
 
 // TODO: Add Linux's RPC equivalents
 #if SYSTEM_PACKAGE_DARWIN
@@ -1287,6 +1299,8 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "multiHop")
   public static var EMULTIHOP: Errno { multiHop }
 
+
+#if !os(WASI)
   /// No message available.
   ///
   /// No message was available to be received by the requested operation.
@@ -1298,6 +1312,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "noData")
   public static var ENODATA: Errno { noData }
+#endif
 
   /// Reserved.
   ///
@@ -1311,6 +1326,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "noLink")
   public static var ENOLINK: Errno { noLink }
 
+#if !os(WASI)
   /// Reserved.
   ///
   /// This error is reserved for future use.
@@ -1335,6 +1351,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "notStream")
   public static var ENOSTR: Errno { notStream }
 #endif
+#endif
 
   /// Protocol error.
   ///
@@ -1350,7 +1367,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "protocolError")
   public static var EPROTO: Errno { protocolError }
 
-#if !os(OpenBSD)
+#if !os(OpenBSD) && !os(WASI)
   /// Reserved.
   ///
   /// This error is reserved for future use.
@@ -1365,6 +1382,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
 #endif
 #endif
 
+#if !os(WASI)
   /// Operation not supported on socket.
   ///
   /// The attempted operation isn't supported for the type of socket referenced;
@@ -1377,12 +1395,13 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "notSupportedOnSocket")
   public static var EOPNOTSUPP: Errno { notSupportedOnSocket }
+#endif
 }
 
 // Constants defined in header but not man page
 @available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension Errno {
-
+#if !os(WASI)
   /// Operation would block.
   ///
   /// The corresponding C error is `EWOULDBLOCK`.
@@ -1412,6 +1431,7 @@ extension Errno {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "tooManyRemoteLevels")
   public static var EREMOTE: Errno { tooManyRemoteLevels }
+#endif
 
 #if SYSTEM_PACKAGE_DARWIN
   /// No such policy registered.

--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -962,7 +962,6 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "diskQuotaExceeded")
   public static var EDQUOT: Errno { diskQuotaExceeded }
 
-#if !os(WASI)
   /// Stale NFS file handle.
   ///
   /// You attempted access an open file on an NFS filesystem,
@@ -977,7 +976,6 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "staleNFSFileHandle")
   public static var ESTALE: Errno { staleNFSFileHandle }
-#endif
 
 // TODO: Add Linux's RPC equivalents
 #if SYSTEM_PACKAGE_DARWIN

--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -1380,7 +1380,6 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
 #endif
 #endif
 
-#if !os(WASI)
   /// Operation not supported on socket.
   ///
   /// The attempted operation isn't supported for the type of socket referenced;
@@ -1393,13 +1392,11 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "notSupportedOnSocket")
   public static var EOPNOTSUPP: Errno { notSupportedOnSocket }
-#endif
 }
 
 // Constants defined in header but not man page
 @available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 extension Errno {
-#if !os(WASI)
   /// Operation would block.
   ///
   /// The corresponding C error is `EWOULDBLOCK`.
@@ -1410,6 +1407,7 @@ extension Errno {
   @available(*, unavailable, renamed: "wouldBlock")
   public static var EWOULDBLOCK: Errno { wouldBlock }
 
+#if !os(WASI)
   /// Too many references: can't splice.
   ///
   /// The corresponding C error is `ETOOMANYREFS`.

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -369,6 +369,7 @@ extension FileDescriptor {
   }
 }
 
+#if !os(WASI)
 @available(/*System 0.0.2: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0*/iOS 8, *)
 extension FileDescriptor {
   /// Duplicates this file descriptor and return the newly created copy.
@@ -433,8 +434,9 @@ extension FileDescriptor {
     fatalError("Not implemented")
   }
 }
+#endif
 
-#if !os(Windows)
+#if !os(Windows) && !os(WASI)
 @available(/*System 1.1.0: macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4*/iOS 8, *)
 extension FileDescriptor {
   /// Creates a unidirectional data channel, which can be used for interprocess communication.

--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -18,6 +18,8 @@ import Glibc
 #elseif canImport(Musl)
 @_implementationOnly import CSystem
 import Musl
+#elseif canImport(WASILibc)
+import WASILibc
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -143,10 +143,14 @@ internal var _ERANGE: CInt { ERANGE }
 @_alwaysEmitIntoClient
 internal var _EAGAIN: CInt { EAGAIN }
 
-#if !os(WASI)
 @_alwaysEmitIntoClient
-internal var _EWOULDBLOCK: CInt { EWOULDBLOCK }
+internal var _EWOULDBLOCK: CInt {
+#if os(WASI)
+  _getConst_EWOULDBLOCK()
+#else
+  EWOULDBLOCK
 #endif
+}
 
 @_alwaysEmitIntoClient
 internal var _EINPROGRESS: CInt { EINPROGRESS }
@@ -443,10 +447,14 @@ internal var _ETIME: CInt { ETIME }
 #endif
 
 
-#if !os(WASI)
 @_alwaysEmitIntoClient
-internal var _EOPNOTSUPP: CInt { EOPNOTSUPP }
+internal var _EOPNOTSUPP: CInt {
+#if os(WASI)
+  _getConst_EOPNOTSUPP()
+#else
+  EOPNOTSUPP
 #endif
+}
 
 #if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -310,7 +310,6 @@ internal var _EDQUOT: CInt {
 #endif
 }
 
-#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _ESTALE: CInt {
 #if os(Windows)
@@ -320,6 +319,7 @@ internal var _ESTALE: CInt {
 #endif
 }
 
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _EREMOTE: CInt {
 #if os(Windows)

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -21,6 +21,9 @@ import Glibc
 #elseif canImport(Musl)
 import CSystem
 import Musl
+#elseif canImport(WASILibc)
+import CSystem
+import WASILibc
 #else
 #error("Unsupported Platform")
 #endif
@@ -73,7 +76,7 @@ internal var _EACCES: CInt { EACCES }
 @_alwaysEmitIntoClient
 internal var _EFAULT: CInt { EFAULT }
 
-#if !os(Windows)
+#if !os(Windows) && !os(WASI)
 @_alwaysEmitIntoClient
 internal var _ENOTBLK: CInt { ENOTBLK }
 #endif
@@ -140,8 +143,10 @@ internal var _ERANGE: CInt { ERANGE }
 @_alwaysEmitIntoClient
 internal var _EAGAIN: CInt { EAGAIN }
 
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _EWOULDBLOCK: CInt { EWOULDBLOCK }
+#endif
 
 @_alwaysEmitIntoClient
 internal var _EINPROGRESS: CInt { EINPROGRESS }
@@ -167,6 +172,7 @@ internal var _ENOPROTOOPT: CInt { ENOPROTOOPT }
 @_alwaysEmitIntoClient
 internal var _EPROTONOSUPPORT: CInt { EPROTONOSUPPORT }
 
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _ESOCKTNOSUPPORT: CInt {
 #if os(Windows)
@@ -175,6 +181,7 @@ internal var _ESOCKTNOSUPPORT: CInt {
   return ESOCKTNOSUPPORT
 #endif
 }
+#endif
 
 @_alwaysEmitIntoClient
 internal var _ENOTSUP: CInt {
@@ -185,6 +192,7 @@ internal var _ENOTSUP: CInt {
 #endif
 }
 
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _EPFNOSUPPORT: CInt {
 #if os(Windows)
@@ -193,6 +201,7 @@ internal var _EPFNOSUPPORT: CInt {
   return EPFNOSUPPORT
 #endif
 }
+#endif
 
 @_alwaysEmitIntoClient
 internal var _EAFNOSUPPORT: CInt { EAFNOSUPPORT }
@@ -227,6 +236,7 @@ internal var _EISCONN: CInt { EISCONN }
 @_alwaysEmitIntoClient
 internal var _ENOTCONN: CInt { ENOTCONN }
 
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _ESHUTDOWN: CInt {
 #if os(Windows)
@@ -244,6 +254,7 @@ internal var _ETOOMANYREFS: CInt {
   return ETOOMANYREFS
 #endif
 }
+#endif
 
 @_alwaysEmitIntoClient
 internal var _ETIMEDOUT: CInt { ETIMEDOUT }
@@ -257,6 +268,7 @@ internal var _ELOOP: CInt { ELOOP }
 @_alwaysEmitIntoClient
 internal var _ENAMETOOLONG: CInt { ENAMETOOLONG }
 
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _EHOSTDOWN: CInt {
 #if os(Windows)
@@ -265,6 +277,7 @@ internal var _EHOSTDOWN: CInt {
   return EHOSTDOWN
 #endif
 }
+#endif
 
 @_alwaysEmitIntoClient
 internal var _EHOSTUNREACH: CInt { EHOSTUNREACH }
@@ -277,6 +290,7 @@ internal var _ENOTEMPTY: CInt { ENOTEMPTY }
 internal var _EPROCLIM: CInt { EPROCLIM }
 #endif
 
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _EUSERS: CInt {
 #if os(Windows)
@@ -285,6 +299,7 @@ internal var _EUSERS: CInt {
   return EUSERS
 #endif
 }
+#endif
 
 @_alwaysEmitIntoClient
 internal var _EDQUOT: CInt {
@@ -295,6 +310,7 @@ internal var _EDQUOT: CInt {
 #endif
 }
 
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _ESTALE: CInt {
 #if os(Windows)
@@ -312,6 +328,7 @@ internal var _EREMOTE: CInt {
   return EREMOTE
 #endif
 }
+#endif
 
 #if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
@@ -399,30 +416,37 @@ internal var _EBADMSG: CInt { EBADMSG }
 @_alwaysEmitIntoClient
 internal var _EMULTIHOP: CInt { EMULTIHOP }
 
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _ENODATA: CInt { ENODATA }
+#endif
 
 @_alwaysEmitIntoClient
 internal var _ENOLINK: CInt { ENOLINK }
 
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _ENOSR: CInt { ENOSR }
 
 @_alwaysEmitIntoClient
 internal var _ENOSTR: CInt { ENOSTR }
 #endif 
+#endif
 
 @_alwaysEmitIntoClient
 internal var _EPROTO: CInt { EPROTO }
 
-#if !os(OpenBSD)
+#if !os(OpenBSD) && !os(WASI)
 @_alwaysEmitIntoClient
 internal var _ETIME: CInt { ETIME }
 #endif
 #endif
 
+
+#if !os(WASI)
 @_alwaysEmitIntoClient
 internal var _EOPNOTSUPP: CInt { EOPNOTSUPP }
+#endif
 
 #if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
@@ -462,15 +486,33 @@ internal var _O_ACCMODE: CInt { 0x03|O_SEARCH }
 #else
 // TODO: API?
 @_alwaysEmitIntoClient
-internal var _O_ACCMODE: CInt { O_ACCMODE }
+internal var _O_ACCMODE: CInt {
+#if os(WASI)
+  _getConst_O_ACCMODE()
+#else
+  O_ACCMODE
+#endif
+}
 #endif
 
 @_alwaysEmitIntoClient
-internal var _O_NONBLOCK: CInt { O_NONBLOCK }
+internal var _O_NONBLOCK: CInt {
+#if os(WASI)
+  _getConst_O_NONBLOCK()
+#else
+  O_NONBLOCK
+#endif
+}
 #endif
 
 @_alwaysEmitIntoClient
-internal var _O_APPEND: CInt { O_APPEND }
+internal var _O_APPEND: CInt {
+#if os(WASI)
+  _getConst_O_APPEND()
+#else
+  O_APPEND
+#endif
+}
 
 #if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
@@ -481,22 +523,42 @@ internal var _O_EXLOCK: CInt { O_EXLOCK }
 #endif
 
 #if !os(Windows)
+#if !os(WASI)
 // TODO: API?
 @_alwaysEmitIntoClient
 internal var _O_ASYNC: CInt { O_ASYNC }
+#endif
 
 @_alwaysEmitIntoClient
 internal var _O_NOFOLLOW: CInt { O_NOFOLLOW }
 #endif
 
 @_alwaysEmitIntoClient
-internal var _O_CREAT: CInt { O_CREAT }
+internal var _O_CREAT: CInt {
+#if os(WASI)
+  _getConst_O_CREAT()
+#else
+  O_CREAT
+#endif
+}
 
 @_alwaysEmitIntoClient
-internal var _O_TRUNC: CInt { O_TRUNC }
+internal var _O_TRUNC: CInt {
+#if os(WASI)
+  _getConst_O_TRUNC()
+#else
+  O_TRUNC
+#endif
+}
 
 @_alwaysEmitIntoClient
-internal var _O_EXCL: CInt { O_EXCL }
+internal var _O_EXCL: CInt {
+#if os(WASI)
+  _getConst_O_EXCL()
+#else
+  O_EXCL
+#endif
+}
 
 #if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
@@ -509,7 +571,13 @@ internal var _O_EVTONLY: CInt { O_EVTONLY }
 internal var _O_NOCTTY: CInt { O_NOCTTY }
 
 @_alwaysEmitIntoClient
-internal var _O_DIRECTORY: CInt { O_DIRECTORY }
+internal var _O_DIRECTORY: CInt {
+#if os(WASI)
+  _getConst_O_DIRECTORY()
+#else
+  O_DIRECTORY
+#endif
+}
 #endif
 
 #if SYSTEM_PACKAGE_DARWIN

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,6 +13,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(WASILibc)
+import WASILibc
 #elseif os(Windows)
 import ucrt
 #else
@@ -120,6 +122,7 @@ internal func system_pwrite(
 #endif
 }
 
+#if !os(WASI)
 internal func system_dup(_ fd: Int32) -> Int32 {
   #if ENABLE_MOCKING
   if mockingEnabled { return _mock(fd) }
@@ -133,8 +136,9 @@ internal func system_dup2(_ fd: Int32, _ fd2: Int32) -> Int32 {
   #endif
   return dup2(fd, fd2)
 }
+#endif
 
-#if !os(Windows)
+#if !os(Windows) && !os(WASI)
 internal func system_pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
 #if ENABLE_MOCKING
   if mockingEnabled { return _mock(fds) }


### PR DESCRIPTION
Quoting the [wasi.dev landing page](https://wasi.dev):
> The WebAssembly System Interface (WASI) is a group of standard API specifications for software compiled to the W3C WebAssembly (Wasm) standard. WASI is designed to provide a secure standard interface for applications that can be compiled to Wasm from any language, and that may run anywhere—from browsers to clouds to embedded devices.

Currently support for WASI in Swift is based on [`wasi-libc`](https://github.com/WebAssembly/wasi-libc).

Adding support for `wasi-libc` mostly amounted to excluding unsupported errnos, adding TLS dictionary storage shim for single-threaded environment, and adding constants in C headers for macros that Clang importer currently doesn't support.