### PR TITLE
Disfavor String.init(platformString: UnsafePointer<CChar>)

### DIFF
--- a/Sources/System/PlatformString.swift
+++ b/Sources/System/PlatformString.swift
@@ -20,6 +20,7 @@ extension String {
   /// This means that, depending on the semantics of the specific platform,
   /// conversion to a string and back might result in a value that's different
   /// from the original platform string.
+  @_disfavoredOverload
   public init(platformString: UnsafePointer<CInterop.PlatformChar>) {
     self.init(_errorCorrectingPlatformString: platformString)
   }


### PR DESCRIPTION
This change disfavors `String(platformString:)` so that it is not ambiguous with `String(cString:)` when the initializer is specified without noting the label (i.e. in usages such as `someUnsafePointer.map(String.init)`

Resolves rdar://127408859