### PR TITLE
Android: DIR* is an OpaquePointer in Bionic too

### DIFF
--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -189,7 +189,7 @@ internal func system_confstr(
 internal let SYSTEM_AT_REMOVE_DIR = AT_REMOVEDIR
 internal let SYSTEM_DT_DIR = DT_DIR
 internal typealias system_dirent = dirent
-#if os(Linux)
+#if os(Linux) || os(Android)
 internal typealias system_DIRPtr = OpaquePointer
 #else
 internal typealias system_DIRPtr = UnsafeMutablePointer<DIR>


### PR DESCRIPTION
#158 broke [the build on my Android CI](https://github.com/finagolfin/swift-android-sdk/actions/runs/9015000558/job/24768803159#step:18:18), but this small tweak gets it working again, as I just confirmed with finagolfin/swift-android-sdk#149.