### PR TITLE
Retarget pending changes to 1.4.0

### DIFF
--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -11,10 +11,10 @@
 
 import Darwin.Mach
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 public protocol MachPortRight {}
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 @inlinable
 internal func _machPrecondition(
   file: StaticString = #file,
@@ -26,10 +26,10 @@ internal func _machPrecondition(
   precondition(kr == expected, file: file, line: line)
 }
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 @frozen
 public enum Mach {
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public struct Port<RightType: MachPortRight>: ~Copyable {
     @usableFromInline
     internal var _name: mach_port_name_t
@@ -129,7 +129,7 @@ public enum Mach {
   public struct SendOnceRight: MachPortRight {}
 }
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 extension Mach.Port where RightType == Mach.ReceiveRight {
   /// Transfer ownership of an existing, unmanaged, but already guarded,
   /// Mach port right into a Mach.Port by name.
@@ -154,7 +154,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// This initializer will abort if the right could not be created.
   /// Callers may assert that a valid right is always returned.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public init() {
     var storage: mach_port_name_t = mach_port_name_t(MACH_PORT_NULL)
     _machPrecondition(
@@ -177,7 +177,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// After this function completes, the Mach.Port is destroyed and no longer
   /// usable.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public consuming func relinquish(
   ) -> (name: mach_port_name_t, context: mach_port_context_t) {
     let destructured = (name: _name, context: _context)
@@ -200,7 +200,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// Mach.ReceiveRights. Use relinquish() to avoid the syscall and extract
   /// the context value along with the port name.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public consuming func unguardAndRelinquish() -> mach_port_name_t {
     let (name, context) = self.relinquish()
     _machPrecondition(mach_port_unguard(mach_task_self_, name, context))
@@ -217,7 +217,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// The body block may optionally return something, which will then be
   /// returned to the caller of withBorrowedName.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public func withBorrowedName<ReturnType>(
     body: (mach_port_name_t, mach_port_context_t) -> ReturnType
   ) -> ReturnType {
@@ -231,7 +231,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// This function will abort if the right could not be created.
   /// Callers may assert that a valid right is always returned.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public func makeSendOnceRight() -> Mach.Port<Mach.SendOnceRight> {
     // send once rights do not coalesce
     var newRight: mach_port_name_t = mach_port_name_t(MACH_PORT_NULL)
@@ -260,7 +260,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// This function will abort if the right could not be created.
   /// Callers may assert that a valid right is always returned.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public func makeSendRight() -> Mach.Port<Mach.SendRight> {
     let how = MACH_MSG_TYPE_MAKE_SEND
 
@@ -278,7 +278,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   ///
   /// Each get/set of this property makes a syscall.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public var makeSendCount: mach_port_mscount_t {
     get {
       var status: mach_port_status = mach_port_status()
@@ -307,7 +307,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   }
 }
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 extension Mach.Port where RightType == Mach.SendRight {
   /// Transfer ownership of the underlying port right to the caller.
   ///
@@ -333,7 +333,7 @@ extension Mach.Port where RightType == Mach.SendRight {
   /// receiving side has been deallocated, then copySendRight() will throw
   /// a Mach.PortRightError.deadName error.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public func copySendRight() throws -> Mach.Port<Mach.SendRight> {
     let how = MACH_MSG_TYPE_COPY_SEND
 
@@ -350,7 +350,7 @@ extension Mach.Port where RightType == Mach.SendRight {
   }
 }
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 extension Mach.Port where RightType == Mach.SendOnceRight {
   /// Transfer ownership of the underlying port right to the caller.
   ///
@@ -362,7 +362,7 @@ extension Mach.Port where RightType == Mach.SendOnceRight {
   /// After this function completes, the Mach.Port is destroyed and no longer
   /// usable.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public consuming func relinquish() -> mach_port_name_t {
     let name = _name
     discard self

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -18,7 +18,7 @@ import SystemPackage
 import System
 #endif
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 final class MachPortTests: XCTestCase {
     func refCountForMachPortName(name:mach_port_name_t, kind:mach_port_right_t) -> mach_port_urefs_t {
         var refCount:mach_port_urefs_t = .max

--- a/Utilities/expand-availability.py
+++ b/Utilities/expand-availability.py
@@ -57,6 +57,7 @@ versions = {
     "System 1.1.0": "macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4",
     "System 1.2.0": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
     "System 1.3.0": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
+    "System 1.4.0": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
 }
 
 parser = argparse.ArgumentParser(description="Expand availability macros.")


### PR DESCRIPTION
We decided to spend the 1.3.0 version number on a small interim release; retarget the currently pending changes to 1.4.0.

I suspect there may be other additions elsewhere that are lacking an availability incantation. Resolving that remains a to do item for 1.4.0.