### PR TITLE
Cherry-pick changes from PR133

### DIFF
--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -16,12 +16,15 @@ public typealias CModeT =  CInterop.Mode
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
-@_implementationOnly import CSystem
-import Glibc
 #elseif os(Windows)
 import CSystem
 import ucrt
+#elseif canImport(Glibc)
+@_implementationOnly import CSystem
+import Glibc
+#elseif canImport(Musl)
+@_implementationOnly import CSystem
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -13,11 +13,14 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
-import Glibc
 #elseif os(Windows)
 import CSystem
 import ucrt
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import CSystem
+import Musl
 #else
 #error("Unsupported Platform")
 #endif
@@ -450,9 +453,13 @@ internal var _O_WRONLY: CInt { O_WRONLY }
 internal var _O_RDWR: CInt { O_RDWR }
 
 #if !os(Windows)
+#if canImport(Musl)
+internal var _O_ACCMODE: CInt { 0x03|O_SEARCH }
+#else
 // TODO: API?
 @_alwaysEmitIntoClient
 internal var _O_ACCMODE: CInt { O_ACCMODE }
+#endif
 
 @_alwaysEmitIntoClient
 internal var _O_NONBLOCK: CInt { O_NONBLOCK }

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -14,12 +14,15 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
-@_implementationOnly import CSystem
-import Glibc
 #elseif os(Windows)
 import CSystem
 import ucrt
+#elseif canImport(Glibc)
+@_implementationOnly import CSystem
+import Glibc
+#elseif canImport(Musl)
+@_implementationOnly import CSystem
+import Musl
 #else
 #error("Unsupported Platform")
 #endif
@@ -45,10 +48,15 @@ internal var system_errno: CInt {
     _ = ucrt._set_errno(newValue)
   }
 }
-#else
+#elseif canImport(Glibc)
 internal var system_errno: CInt {
   get { Glibc.errno }
   set { Glibc.errno = newValue }
+}
+#elseif canImport(Musl)
+internal var system_errno: CInt {
+  get { Musl.errno }
+  set { Musl.errno = newValue }
 }
 #endif
 

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -9,8 +9,10 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import ucrt
 #else


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-system/pull/133, supporting usage of the musl library.

Thanks @simonjbeaumont for the patch