### PR TITLE
[1.3.0] Require Swift 5.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.xcodeproj
 xcuserdata/
 .*.sw?
+/.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,9 @@
-// swift-tools-version:5.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version:5.8
 
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020-2024 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
It isn't reasonable to continue supporting obsolete Swift toolchains. Require Swift 5.8 or later.