### PR TITLE
Remove unintentional public functions and fix a couple of Windows issues.

### DIFF
--- a/Sources/System/ErrnoWindows.swift
+++ b/Sources/System/ErrnoWindows.swift
@@ -12,7 +12,7 @@
 import WinSDK
 
 extension Errno {
-  public init(windowsError: DWORD) {
+  internal init(windowsError: DWORD) {
     self.init(rawValue: _mapWindowsErrorToErrno(windowsError))
   }
 }

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -516,7 +516,7 @@ extension FilePermissions {
   /// files or directories.  Note that this mask is process-wide, and that
   /// *getting* it is not thread safe.
   @_alwaysEmitIntoClient
-  public static var creationMask: FilePermissions {
+  internal static var creationMask: FilePermissions {
     get {
       let oldMask = _umask(0o22)
       _ = _umask(oldMask)
@@ -536,7 +536,7 @@ extension FilePermissions {
   /// This is more efficient than reading `creationMask` and restoring it
   /// afterwards, because of the way reading the creation mask works.
   @_alwaysEmitIntoClient
-  public static func withCreationMask<R>(
+  internal static func withCreationMask<R>(
     _ permissions: FilePermissions,
     body: () throws -> R
   ) rethrows -> R {

--- a/Sources/System/FilePath/FilePathTemp.swift
+++ b/Sources/System/FilePath/FilePathTemp.swift
@@ -18,7 +18,7 @@
 /// Creates a temporary directory with a name based on the given `basename`,
 /// executes `body`, passing in the path of the created directory, then
 /// deletes the directory and all of its contents before returning.
-public func withTemporaryFilePath<R>(
+internal func withTemporaryFilePath<R>(
   basename: FilePath.Component,
   _ body: (FilePath) throws -> R
 ) throws -> R {

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -621,14 +621,15 @@ fileprivate struct DecodedOpenFlags {
     }
 
     dwDesiredAccess = 0
-    if (oflag & _O_RDONLY) != 0 {
+    switch (oflag & (_O_RDONLY|_O_WRONLY|_O_RDWR)) {
+    case _O_RDONLY:
       dwDesiredAccess |= DWORD(GENERIC_READ)
-    }
-    if (oflag & _O_WRONLY) != 0 {
+    case _O_WRONLY:
       dwDesiredAccess |= DWORD(GENERIC_WRITE)
-    }
-    if (oflag & _O_RDWR) != 0 {
+    case _O_RDWR:
       dwDesiredAccess |= DWORD(GENERIC_READ) | DWORD(GENERIC_WRITE)
+    default:
+      break
     }
 
     bInheritHandle = WindowsBool((oflag & _O_NOINHERIT) == 0)

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -620,6 +620,9 @@ fileprivate struct DecodedOpenFlags {
       dwCreationDisposition = DWORD(OPEN_EXISTING)
     }
 
+    // The _O_RDONLY, _O_WRONLY and _O_RDWR flags are non-overlapping
+    // on Windows; in particular, _O_RDONLY is zero, which means we can't
+    // test for it by AND-ing.
     dwDesiredAccess = 0
     switch (oflag & (_O_RDONLY|_O_WRONLY|_O_RDWR)) {
     case _O_RDONLY:

--- a/Tests/SystemTests/FileOperationsTestWindows.swift
+++ b/Tests/SystemTests/FileOperationsTestWindows.swift
@@ -12,9 +12,9 @@ import XCTest
 #if os(Windows)
 
 #if SYSTEM_PACKAGE
-import SystemPackage
+@testable import SystemPackage
 #else
-import System
+@testable import System
 #endif
 
 import WinSDK

--- a/Tests/SystemTests/FilePathTests/FilePathTempTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathTempTest.swift
@@ -10,9 +10,9 @@
 import XCTest
 
 #if SYSTEM_PACKAGE
-import SystemPackage
+@testable import SystemPackage
 #else
-import System
+@testable import System
 #endif
 
 final class TemporaryPathTest: XCTestCase {


### PR DESCRIPTION
A few things were marked `public` that should not have been, so change those to `internal`.  That means we then have to fix the tests to use `@testable` imports, so do that too.

Finally, while testing this, I noticed that there was a bug in the Windows code that meant that files opened for read-only access would open, but were not in fact readable (because we weren't asking for read permission, because `_O_RDONLY` happens to be zero).  Fix that also.
