### PR TITLE
Add explicit minimum supported darwin platforms to manifest

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 
 /*
  This source file is part of the Swift System open source project
@@ -11,11 +11,11 @@
 
 import PackageDescription
 
-let DarwinPlatforms: [Platform] = [.macOS, .iOS, .watchOS, .tvOS]
+let DarwinPlatforms: [Platform] = [.macOS, .iOS, .watchOS, .tvOS, .visionOS]
 
 let package = Package(
     name: "swift-system",
-    platforms: [.macOS(.v10_13), .iOS(.v12), .watchOS(.v4), .tvOS(.v12)],
+    platforms: [.macOS(.v10_13), .iOS(.v12), .watchOS(.v4), .tvOS(.v12), .visionOS(.v1)],
     products: [
       .library(name: "SystemPackage", targets: ["SystemPackage"])
     ],


### PR DESCRIPTION
It's my understanding that SwiftPM implicitly includes these platform minimums. It would be nice if they're explicitly specified for clarity. For tools that need to parse the manifest, it can make a big difference.

With the minimum tools version of 5.8, visionOS couldn't be included so a 5.9 specific manifest was added.

I based this branch and PR off of dev/merge-1.3.0-back-to-main because that seems to be the current leading branch.