### PR TITLE
Suppress unhandled CMakeLists.txt warning by SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,11 +28,13 @@ let package = Package(
     targets: [
       .target(
         name: "CSystem",
-        dependencies: []),
+        dependencies: [],
+        exclude: ["CMakeLists.txt"]),
       .target(
         name: "SystemPackage",
         dependencies: ["CSystem"],
         path: "Sources/System",
+        exclude: ["CMakeLists.txt"],
         cSettings: [
           .define("_CRT_SECURE_NO_WARNINGS")
         ],


### PR DESCRIPTION
The file should be excluded from SwiftPM source files

```
warning: 'swift-system': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    .build/checkouts/swift-system/Sources/System/CMakeLists.txt
```