### PR TITLE
Import new Android overlay

### DIFF
--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -20,6 +20,9 @@ import Glibc
 import Musl
 #elseif canImport(WASILibc)
 import WASILibc
+#elseif canImport(Bionic)
+@_implementationOnly import CSystem
+import Bionic
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -24,6 +24,8 @@ import Musl
 #elseif canImport(WASILibc)
 import CSystem
 import WASILibc
+#elseif canImport(Android)
+import Android
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -25,6 +25,9 @@ import Glibc
 import Musl
 #elseif canImport(WASILibc)
 import WASILibc
+#elseif canImport(Android)
+@_implementationOnly import CSystem
+import Android
 #else
 #error("Unsupported Platform")
 #endif
@@ -64,6 +67,11 @@ internal var system_errno: CInt {
 internal var system_errno: CInt {
   get { WASILibc.errno }
   set { WASILibc.errno = newValue }
+}
+#elseif canImport(Android)
+internal var system_errno: CInt {
+  get { Android.errno }
+  set { Android.errno = newValue }
 }
 #endif
 

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -17,6 +17,8 @@ import Musl
 import WASILibc
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Android)
+import Android
 #else
 #error("Unsupported Platform")
 #endif


### PR DESCRIPTION
This new overlay was recently added to trunk in swiftlang/swift#72161 and swiftlang/swift#72634, then to 6.0 in swiftlang/swift#74758. I've been building it with this patch on my daily Android CI since the trunk addition, finagolfin/swift-android-sdk#151, and natively on Android too.

@glessard, should be an easy review.