### PR TITLE
Add support for macCatalyst

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let cSettings: [CSetting] = [
 let swiftSettings: [SwiftSetting] = [
   .define(
     "SYSTEM_PACKAGE_DARWIN",
-    .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .visionOS])),
+    .when(platforms: [.macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .visionOS])),
   .define("SYSTEM_PACKAGE"),
   .define("ENABLE_MOCKING", .when(configuration: .debug)),
 ]


### PR DESCRIPTION
Support building swift-system for macCatalyst

Backport of https://github.com/apple/swift-system/pull/193 to the 1.4.0 branch