### PR TITLE
[windows] expose pipe’s buffer size parameter

### DIFF
--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -184,8 +184,10 @@ internal func pwrite(
 }
 
 @inline(__always)
-internal func pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
-  return _pipe(fds, 4096, _O_BINARY | _O_NOINHERIT);
+internal func pipe(
+  _ fds: UnsafeMutablePointer<Int32>, bytesReserved: UInt32 = 4096
+) -> CInt {
+  return _pipe(fds, bytesReserved, _O_BINARY | _O_NOINHERIT);
 }
 
 @inline(__always)


### PR DESCRIPTION
The wrapper for Windows's `_pipe()` call should at least expose its memory buffer reservation parameter.
It's perfectly fine to have a default value, so we use the previously hard-coded amount as that default.