### PR TITLE
Merge 1.4.0 into main

### DIFF
--- a/.swiftci/5_8_ubuntu2204
+++ b/.swiftci/5_8_ubuntu2204
@@ -1,5 +1,0 @@
-LinuxSwiftPackageJob {
-    swift_version_tag = "5.8-jammy"
-    repo = "swift-system"
-    branch = "main"
-}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Code of Conduct
+
+To be a truly great community, Swift.org needs to welcome developers from all walks of life, with different backgrounds, and with a wide range of experience. A diverse and friendly community will have more great ideas, more unique perspectives, and produce more great code. We will work diligently to make the Swift community welcoming to everyone.
+
+To give clarity of what is expected of our members, this code of conduct is based on [contributor-covenant.org](http://contributor-covenant.org). This document is used across many open source communities, and we think it articulates our values well.
+
+### Contributor Code of Conduct v1.4
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language (e.g., prefer non-gendered words like “folks” to “guys”, non-ableist words like “soundness check” to “sanity check”, etc.)
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+This Code of Conduct applies within all project spaces managed by Swift.org, including (but not limited to) source code repositories, bug trackers, web sites, documentation, and online forums. It also applies when an individual is representing the project or its community in public spaces. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a member of the [Swift Core Team](https://swift.org/community/#community-structure) or by flagging the behavior for moderation (e.g., in the Forums), whether you are the target of that behavior or not. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident. The site of the disputed behavior is usually not an acceptable place to discuss moderation decisions, and moderators may move or remove any such discussion.
+
+Project maintainers are held to a higher standard, and project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
+If you disagree with a moderation action, you can appeal to the Core Team (or individual Core Team members) privately.
+
+This policy is adapted from the Contributor Code of Conduct [version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct/).

--- a/Package.swift
+++ b/Package.swift
@@ -1,53 +1,51 @@
-// swift-tools-version:5.8
-
-/*
- This source file is part of the Swift System open source project
-
- Copyright (c) 2020-2024 Apple Inc. and the Swift System project authors
- Licensed under Apache License v2.0 with Runtime Library Exception
-
- See https://swift.org/LICENSE.txt for license information
-*/
+// swift-tools-version:5.9
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift System open source project
+//
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 import PackageDescription
 
-let DarwinPlatforms: [Platform]
-#if swift(<5.9)
-DarwinPlatforms = [.macOS, .macCatalyst, .iOS, .watchOS, .tvOS]
-#else
-DarwinPlatforms = [.macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .visionOS]
-#endif
+let cSettings: [CSetting] = [
+  .define("_CRT_SECURE_NO_WARNINGS", .when(platforms: [.windows])),
+]
+
+let swiftSettings: [SwiftSetting] = [
+  .define(
+    "SYSTEM_PACKAGE_DARWIN",
+    .when(platforms: [.macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .visionOS])),
+  .define("SYSTEM_PACKAGE"),
+  .define("ENABLE_MOCKING", .when(configuration: .debug)),
+]
 
 let package = Package(
-    name: "swift-system",
-    products: [
-      .library(name: "SystemPackage", targets: ["SystemPackage"])
-    ],
-    dependencies: [],
-    targets: [
-      .target(
-        name: "CSystem",
-        dependencies: [],
-        exclude: ["CMakeLists.txt"]),
-      .target(
-        name: "SystemPackage",
-        dependencies: ["CSystem"],
-        path: "Sources/System",
-        exclude: ["CMakeLists.txt"],
-        cSettings: [
-          .define("_CRT_SECURE_NO_WARNINGS", .when(platforms: [.windows]))
-        ],
-        swiftSettings: [
-          .define("SYSTEM_PACKAGE"),
-          .define("SYSTEM_PACKAGE_DARWIN", .when(platforms: DarwinPlatforms)),
-          .define("ENABLE_MOCKING", .when(configuration: .debug))
-        ]),
-      .testTarget(
-        name: "SystemTests",
-        dependencies: ["SystemPackage"],
-        swiftSettings: [
-          .define("SYSTEM_PACKAGE"),
-          .define("SYSTEM_PACKAGE_DARWIN", .when(platforms: DarwinPlatforms)),
-        ]),
-    ]
-)
+  name: "swift-system",
+  products: [
+    .library(name: "SystemPackage", targets: ["SystemPackage"]),
+  ],
+  dependencies: [],
+  targets: [
+    .target(
+      name: "CSystem",
+      dependencies: [],
+      exclude: ["CMakeLists.txt"],
+      cSettings: cSettings),
+    .target(
+      name: "SystemPackage",
+      dependencies: ["CSystem"],
+      path: "Sources/System",
+      exclude: ["CMakeLists.txt"],
+      cSettings: cSettings,
+      swiftSettings: swiftSettings),
+    .testTarget(
+      name: "SystemTests",
+      dependencies: ["SystemPackage"],
+      cSettings: cSettings,
+      swiftSettings: swiftSettings),
+  ])

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 Swift System provides idiomatic interfaces to system calls and low-level currency types. Our vision is for System to act as the single home for low-level system interfaces for all supported Swift platforms.
 
-## Multi-platform not Cross-platform
+## No Cross-platform Abstractions
 
-System is a multi-platform library, not a cross-platform one. It provides a separate set of APIs and behaviors on every supported platform, closely reflecting the underlying OS interfaces. A single import will pull in the native platform interfaces specific for the targeted OS.
+Swift System is not a cross-platform library. It provides a separate set of APIs and behaviors on every supported platform, closely reflecting the underlying OS interfaces. A single import will pull in the native platform interfaces specific for the targeted OS.
 
-Our immediate goal is to simplify building cross-platform libraries and applications such as SwiftNIO and SwiftPM. System does not eliminate the need for `#if os()` conditionals to implement cross-platform abstractions, but it does make it safer and more expressive to fill out the platform-specific parts.
+Our immediate goal is to simplify building cross-platform libraries and applications such as SwiftNIO and SwiftPM. It is not a design goal for System to eliminate the need for `#if os()` conditionals to implement cross-platform abstractions; rather, our goal is to make it safer and more expressive to fill out the platform-specific parts.
+
+(That said, it is desirable to avoid unnecessary differences -- for example, when two operating systems share the same C name for a system call, ideally Swift System would expose them using the same Swift name. This is a particularly obvious expectation for system interfaces that implement an industry standard, such as POSIX.)
 
 ## Usage
 
@@ -30,7 +32,7 @@ To use the `SystemPackage` library in a SwiftPM project,
 add the following line to the dependencies in your `Package.swift` file:
 
 ```swift
-.package(url: "https://github.com/apple/swift-system", from: "1.3.0"),
+.package(url: "https://github.com/apple/swift-system", from: "1.4.0"),
 ```
 
 Finally, include `"SystemPackage"` as a dependency for your executable target:
@@ -39,7 +41,7 @@ Finally, include `"SystemPackage"` as a dependency for your executable target:
 let package = Package(
     // name, platforms, products, etc.
     dependencies: [
-        .package(url: "https://github.com/apple/swift-system", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-system", from: "1.4.0"),
         // other dependencies
     ],
     targets: [
@@ -53,14 +55,70 @@ let package = Package(
 
 ## Source Stability
 
-The Swift System package is source stable. The version numbers follow [Semantic Versioning][semver] -- source breaking changes to public API can only land in a new major version.
+At this time, the Swift System package supports three types of operating systems: Darwin-based, POSIX-like, and Windows. The source-stability status of the package differs according to the platform:
+
+| Platform type     | Source Stability |
+| ----------------- | --------------- |
+| Darwin (macOS, iOS, etc.) | Stable |
+| POSIX (Linux, WASI, etc.) | Stable |
+| Windows | Unstable |
+
+The package version numbers follow [Semantic Versioning][semver] -- source breaking changes to source-stable public API can only land in a new major version. However, platforms for which support has not reached source stability may see source-breaking changes in a new minor version.
 
 [semver]: https://semver.org
 
-## Contributing
+The public API of the swift-system package consists of non-underscored declarations that are marked `public` in the `SystemPackage` module.
 
-Before contributing, please read [CONTRIBUTING.md](CONTRIBUTING.md). 
+By "underscored declarations" we mean declarations that have a leading underscore anywhere in their fully qualified name. For instance, here are some names that wouldn't be considered part of the public API, even if they were technically marked public:
 
-## LICENSE
+- `FooModule.Bar._someMember(value:)` (underscored member)
+- `FooModule._Bar.someMember` (underscored type)
+- `_FooModule.Bar` (underscored module)
+- `FooModule.Bar.init(_value:)` (underscored initializer)
+
+Interfaces that aren't part of the public API may continue to change in any release, including patch releases. If you have a use case that requires using non-public APIs, please submit a Feature Request describing it! We'd like the public interface to be as useful as possible -- although preferably without compromising safety or limiting future evolution.
+
+Future minor versions of the package may update these rules as needed.
+
+## Toolchain Requirements
+
+The following table maps existing package releases to their minimum required Swift toolchain release:
+
+| Package version         | Swift version   | Xcode release |
+| ----------------------- | --------------- | ------------- |
+| swift-system 1.3.x | >= Swift 5.8  | >= Xcode 14.3 |
+| swift-system 1.4.x | >= Swift 5.9  | >= Xcode 15.0 |
+
+We'd like this package to quickly embrace Swift language and toolchain improvements that are relevant to its mandate. Accordingly, from time to time, new versions of this package require clients to upgrade to a more recent Swift toolchain release. (This allows the package to make use of new language/stdlib features, build on compiler bug fixes, and adopt new package manager functionality as soon as they are available.) Patch (i.e., bugfix) releases will not increase the required toolchain version, but any minor (i.e., new feature) release may do so.
+
+(Note: the package has no minimum deployment target, so while it does require clients to use a recent Swift toolchain to build it, the code itself is able to run on any OS release that supports running Swift code.)
+
+## Licensing
 
 See [LICENSE](LICENSE.txt) for license information. 
+
+## Contributing
+
+Before contributing, please read [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### Branching Strategy
+
+We maintain separate branches for each active minor version of the package:
+
+| Package version         | Branch      | 
+| ----------------------- | ----------- |
+| swift-system 1.3.x | release/1.3 |
+| swift-system 1.4.x (unreleased) | release/1.4 |
+| swift-system 1.5.x (unreleased) | main        |
+
+Changes must land on the branch corresponding to the earliest release that they will need to ship on. They are periodically propagated to subsequent branches, in the following direction:
+
+`release/1.3` → `release/1.4` → `main`
+
+For example, anything landing on `release/1.3` will eventually appear on `release/1.4` and then `main` too; there is no need to file standalone PRs for each release line. (Change propagation currently requires manual work -- it is performed by project maintainers.)
+
+### Code of Conduct
+
+Like all Swift.org projects, we would like the Swift System project to foster a diverse and friendly community. We expect contributors to adhere to the [Swift.org Code of Conduct](https://swift.org/code-of-conduct/). A copy of this document is [available in this repository][coc].
+
+[coc]: CODE_OF_CONDUCT.md

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -515,7 +515,6 @@ extension FilePermissions {
   /// Permissions set in this mask will be cleared by functions that create
   /// files or directories.  Note that this mask is process-wide, and that
   /// *getting* it is not thread safe.
-  @_alwaysEmitIntoClient
   internal static var creationMask: FilePermissions {
     get {
       let oldMask = _umask(0o22)
@@ -535,7 +534,6 @@ extension FilePermissions {
   ///
   /// This is more efficient than reading `creationMask` and restoring it
   /// afterwards, because of the way reading the creation mask works.
-  @_alwaysEmitIntoClient
   internal static func withCreationMask<R>(
     _ permissions: FilePermissions,
     body: () throws -> R
@@ -547,7 +545,6 @@ extension FilePermissions {
     return try body()
   }
 
-  @usableFromInline
   internal static func _umask(_ mode: CModeT) -> CModeT {
     return system_umask(mode)
   }

--- a/Sources/System/FilePath/FilePath.swift
+++ b/Sources/System/FilePath/FilePath.swift
@@ -66,10 +66,13 @@ extension FilePath {
 }
 
 @available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
-extension FilePath: Hashable, Codable {
+extension FilePath: Hashable {}
+
+@available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
+extension FilePath: Codable {
   // Encoder is synthesized; it probably should have been explicit and used
   // a single-value container, but making that change now is somewhat risky.
-  
+
   // Decoder is written explicitly to ensure that we validate invariants on
   // untrusted input.
   public init(from decoder: any Decoder) throws {

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -184,8 +184,10 @@ internal func pwrite(
 }
 
 @inline(__always)
-internal func pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
-  return _pipe(fds, 4096, _O_BINARY | _O_NOINHERIT);
+internal func pipe(
+  _ fds: UnsafeMutablePointer<Int32>, bytesReserved: UInt32 = 4096
+) -> CInt {
+  return _pipe(fds, bytesReserved, _O_BINARY | _O_NOINHERIT);
 }
 
 @inline(__always)
@@ -260,7 +262,6 @@ internal func rmdir(
   return 0;
 }
 
-@usableFromInline
 internal func _mapWindowsErrorToErrno(_ errorCode: DWORD) -> CInt {
   switch Int32(errorCode) {
   case ERROR_SUCCESS:
@@ -397,7 +398,6 @@ fileprivate func getTokenInformation<T>(
   return nil
 }
 
-@usableFromInline
 internal enum _FileOrDirectory {
   case file
   case directory
@@ -406,7 +406,6 @@ internal enum _FileOrDirectory {
 /// Build a SECURITY_DESCRIPTOR from UNIX-style "mode" bits.  This only
 /// takes account of the rwx and sticky bits; there's really nothing that
 /// we can do about setuid/setgid.
-@usableFromInline
 internal func _createSecurityDescriptor(from mode: CInterop.Mode,
                                         for fileOrDirectory: _FileOrDirectory)
   -> PSECURITY_DESCRIPTOR? {

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -11,10 +11,10 @@
 
 import Darwin.Mach
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 public protocol MachPortRight {}
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 @inlinable
 internal func _machPrecondition(
   file: StaticString = #file,
@@ -26,10 +26,10 @@ internal func _machPrecondition(
   precondition(kr == expected, file: file, line: line)
 }
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 @frozen
 public enum Mach {
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public struct Port<RightType: MachPortRight>: ~Copyable {
     @usableFromInline
     internal var _name: mach_port_name_t
@@ -133,7 +133,7 @@ public enum Mach {
   public struct SendOnceRight: MachPortRight {}
 }
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 extension Mach.Port where RightType == Mach.ReceiveRight {
   /// Transfer ownership of an existing, unmanaged, but already guarded,
   /// Mach port right into a Mach.Port by name.
@@ -158,7 +158,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// This initializer will abort if the right could not be created.
   /// Callers may assert that a valid right is always returned.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public init() {
     var storage: mach_port_name_t = mach_port_name_t(MACH_PORT_NULL)
     _machPrecondition(
@@ -181,7 +181,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// After this function completes, the Mach.Port is destroyed and no longer
   /// usable.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public consuming func relinquish(
   ) -> (name: mach_port_name_t, context: mach_port_context_t) {
     let destructured = (name: _name, context: _context)
@@ -204,7 +204,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// Mach.ReceiveRights. Use relinquish() to avoid the syscall and extract
   /// the context value along with the port name.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public consuming func unguardAndRelinquish() -> mach_port_name_t {
     let (name, context) = self.relinquish()
     _machPrecondition(mach_port_unguard(mach_task_self_, name, context))
@@ -221,7 +221,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// The body block may optionally return something, which will then be
   /// returned to the caller of withBorrowedName.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public func withBorrowedName<ReturnType>(
     body: (mach_port_name_t, mach_port_context_t) -> ReturnType
   ) -> ReturnType {
@@ -235,7 +235,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// This function will abort if the right could not be created.
   /// Callers may assert that a valid right is always returned.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public func makeSendOnceRight() -> Mach.Port<Mach.SendOnceRight> {
     // send once rights do not coalesce
     var newRight: mach_port_name_t = mach_port_name_t(MACH_PORT_NULL)
@@ -264,7 +264,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   /// This function will abort if the right could not be created.
   /// Callers may assert that a valid right is always returned.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public func makeSendRight() -> Mach.Port<Mach.SendRight> {
     let how = MACH_MSG_TYPE_MAKE_SEND
 
@@ -282,7 +282,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   ///
   /// Each get/set of this property makes a syscall.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public var makeSendCount: mach_port_mscount_t {
     get {
       var status: mach_port_status = mach_port_status()
@@ -311,7 +311,7 @@ extension Mach.Port where RightType == Mach.ReceiveRight {
   }
 }
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 extension Mach.Port where RightType == Mach.SendRight {
   /// Transfer ownership of the underlying port right to the caller.
   ///
@@ -337,7 +337,7 @@ extension Mach.Port where RightType == Mach.SendRight {
   /// receiving side has been deallocated, then copySendRight() will throw
   /// a Mach.PortRightError.deadName error.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public func copySendRight() throws -> Mach.Port<Mach.SendRight> {
     let how = MACH_MSG_TYPE_COPY_SEND
 
@@ -354,7 +354,7 @@ extension Mach.Port where RightType == Mach.SendRight {
   }
 }
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 extension Mach.Port where RightType == Mach.SendOnceRight {
   /// Transfer ownership of the underlying port right to the caller.
   ///
@@ -366,7 +366,7 @@ extension Mach.Port where RightType == Mach.SendOnceRight {
   /// After this function completes, the Mach.Port is destroyed and no longer
   /// usable.
   @inlinable
-  @available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+  @available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
   public consuming func relinquish() -> mach_port_name_t {
     let name = _name
     discard self

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -18,7 +18,7 @@ import SystemPackage
 import System
 #endif
 
-@available(/*System 1.3.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
+@available(/*System 1.4.0: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999*/iOS 8, *)
 final class MachPortTests: XCTestCase {
     func refCountForMachPortName(name:mach_port_name_t, kind:mach_port_right_t) -> mach_port_urefs_t {
         var refCount:mach_port_urefs_t = .max

--- a/Utilities/expand-availability.py
+++ b/Utilities/expand-availability.py
@@ -57,6 +57,7 @@ versions = {
     "System 1.1.0": "macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4",
     "System 1.2.0": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
     "System 1.3.0": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
+    "System 1.4.0": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
 }
 
 parser = argparse.ArgumentParser(description="Expand availability macros.")


### PR DESCRIPTION
Manually resolved merge conflicts between `release/1.4.0` and `main` by preferring the configuration files from `main`, and otherwise picking code changes from `release/1.4.0`.