### PR TITLE
CSystem: Set build and install interfaces on included headers

### DIFF
--- a/Sources/CSystem/CMakeLists.txt
+++ b/Sources/CSystem/CMakeLists.txt
@@ -9,8 +9,8 @@ See https://swift.org/LICENSE.txt for license information
 
 add_library(CSystem INTERFACE)
 target_include_directories(CSystem INTERFACE
-  include)
-
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  $<INSTALL_INTERFACE:include/CSystem>)
 
 install(FILES
   include/CSystemLinux.h


### PR DESCRIPTION
This prevents a CMake error when including the project via FetchContent:

```
CMake Error in Build/release/_deps/swiftsystem-src/Sources/System/CMakeLists.txt:
  Target "CSystem" contains relative path in its
  INTERFACE_INCLUDE_DIRECTORIES:

    "include"
```