### PR TITLE
Internals: Remove non-breaking spaces from Windows syscall adapter

### DIFF
--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -187,7 +187,7 @@ internal func pwrite(
 internal func pipe(
   _ fds: UnsafeMutablePointer<Int32>, bytesReserved: UInt32 = 4096
 ) -> CInt {
-  return _pipe(fds, bytesReserved, _O_BINARY | _O_NOINHERIT);
+  return _pipe(fds, bytesReserved, _O_BINARY | _O_NOINHERIT);
 }
 
 @inline(__always)


### PR DESCRIPTION
This was causing a warning with Swift 6.0.2

Resolves the following compiler warning:

```
/Users/andrew/Source/ladybird-browser/Build/release/_deps/swiftsystem-src/Sources/System/Internals/WindowsSyscallAdapters.swift:190:4: warning: non-breaking space (U+00A0) used instead of regular space
188 |   _ fds: UnsafeMutablePointer<Int32>, bytesReserved: UInt32 = 4096
189 | ) -> CInt {
190 |   return _pipe(fds, bytesReserved, _O_BINARY | _O_NOINHERIT);
    |   `- warning: non-breaking space (U+00A0) used instead of regular space
191 | }
192 | 
```