### PR TITLE
[Windows] Use GetTempPathW in _getTemporaryDirectory for better compatibility

### DIFF
--- a/Sources/System/FilePath/FilePathTempWindows.swift
+++ b/Sources/System/FilePath/FilePathTempWindows.swift
@@ -17,7 +17,7 @@ internal func _getTemporaryDirectory() throws -> FilePath {
                                            capacity: Int(MAX_PATH) + 1) {
     buffer in
 
-    guard GetTempPath2W(DWORD(buffer.count), buffer.baseAddress) != 0 else {
+    guard GetTempPathW(DWORD(buffer.count), buffer.baseAddress) != 0 else {
       throw Errno(windowsError: GetLastError())
     }
 


### PR DESCRIPTION
The GetTempPath2W function used by swift-system is only available on Windows 10 build 20348 and later systems. This PR replaces GetTempPath2W with the more compatible GetTempPathW, similar to what is done in [swift-corelibs-foundation](https://github.com/swiftlang/swift-corelibs-foundation/blob/4c3228c00a17aca68d1a83d35dbd156a8aa169ee/Sources/Foundation/NSPathUtilities.swift#L647) and [swift-foundation](https://github.com/swiftlang/swift-foundation/blob/26fb3ba14a84317ac9b737f05f4306c7724d9192/Sources/FoundationEssentials/String/String%2BPath.swift#L558).