### PR TITLE
[cmake] Install libraries in standard directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ cmake_minimum_required(VERSION 3.16.0)
 project(SwiftSystem
   LANGUAGES C Swift)
 
+include(GNUInstallDirs)
+
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -69,6 +69,28 @@ function(get_swift_host_os result_var_name)
   endif()
 endfunction()
 
+if(NOT Swift_MODULE_TRIPLE)
+  # Attempt to get the module triple from the Swift compiler.
+  set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+  if(CMAKE_Swift_COMPILER_TARGET)
+    list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
+  endif()
+  execute_process(COMMAND ${module_triple_command}
+    OUTPUT_VARIABLE target_info_json)
+  string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+
+  # Exit now if we failed to infer the triple.
+  if(NOT module_triple)
+    message(FATAL_ERROR
+      "Failed to get module triple from Swift compiler. "
+      "Compiler output: ${target_info_json}")
+  endif()
+
+  # Cache the module triple for future use.
+  set(Swift_MODULE_TRIPLE "${module_triple}" CACHE STRING "swift module triple used for installed swiftmodule and swiftinterface files")
+  mark_as_advanced(Swift_MODULE_TRIPLE)
+endif()
+
 function(_install_target module)
   get_swift_host_os(swift_os)
   get_target_property(type ${module} TYPE)
@@ -79,24 +101,20 @@ function(_install_target module)
     set(swift swift)
   endif()
 
-  install(TARGETS ${module}
-    ARCHIVE DESTINATION lib/${swift}/${swift_os}
-    LIBRARY DESTINATION lib/${swift}/${swift_os}
-    RUNTIME DESTINATION bin)
+  install(TARGETS ${module})
   if(type STREQUAL EXECUTABLE)
     return()
   endif()
 
-  get_swift_host_arch(swift_arch)
   get_target_property(module_name ${module} Swift_MODULE_NAME)
   if(NOT module_name)
     set(module_name ${module})
   endif()
 
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
-    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
-    RENAME ${swift_arch}.swiftdoc)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${Swift_MODULE_TRIPLE}.swiftdoc)
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
-    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
-    RENAME ${swift_arch}.swiftmodule)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${Swift_MODULE_TRIPLE}.swiftmodule)
 endfunction()


### PR DESCRIPTION
Previously, libs were installed under `lib/swift/${os}`. They should be installed in the default library directory for the relevant target system.
In addition, swiftmodules were installed in the older layout format. This changes to use the standard modern layout format for swiftmodules.