### PR TITLE
OpenBSD support.

### DIFF
--- a/Sources/System/Internals/RawBuffer.swift
+++ b/Sources/System/Internals/RawBuffer.swift
@@ -80,7 +80,13 @@ extension _RawBuffer {
     internal static func create(minimumCapacity: Int) -> Storage {
       Storage.create(
         minimumCapacity: minimumCapacity,
-        makingHeaderWith: { $0.capacity }
+        makingHeaderWith: {
+#if os(OpenBSD)
+          minimumCapacity
+#else
+          $0.capacity
+#endif
+        }
       ) as! Storage
     }
   }

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -191,7 +191,7 @@ internal func system_confstr(
 internal let SYSTEM_AT_REMOVE_DIR = AT_REMOVEDIR
 internal let SYSTEM_DT_DIR = DT_DIR
 internal typealias system_dirent = dirent
-#if os(Linux) || os(Android) || os(FreeBSD)
+#if os(Linux) || os(Android) || os(FreeBSD) || os(OpenBSD)
 internal typealias system_DIRPtr = OpaquePointer
 #else
 internal typealias system_DIRPtr = UnsafeMutablePointer<DIR>


### PR DESCRIPTION
Two commits:

* straightforward platform conditional to typealias `system_DIRPtr` properly (it would be ideal if the `#else` case was an `#error` to guide new porters appropriately, but that's another show).
* `ManagedBuffer.capacity` is unavailable on OpenBSD, so must be handled specially. Thankfully the workaround is straightforward here, I think.