### PR TITLE
[1.4.x] Support for FreeBSD and OpenBSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 /.swiftpm
 /.build
 /Packages
-swift-system.xcodeproj
+/*.xcodeproj
 xcuserdata/
 .*.sw?
+/.swiftpm
 .docc-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ cmake_minimum_required(VERSION 3.16.0)
 project(SwiftSystem
   LANGUAGES C Swift)
 
+include(GNUInstallDirs)
+
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/Sources/CSystem/CMakeLists.txt
+++ b/Sources/CSystem/CMakeLists.txt
@@ -9,8 +9,8 @@ See https://swift.org/LICENSE.txt for license information
 
 add_library(CSystem INTERFACE)
 target_include_directories(CSystem INTERFACE
-  include)
-
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  $<INSTALL_INTERFACE:include/CSystem>)
 
 install(FILES
   include/CSystemLinux.h

--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -1067,7 +1067,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   public static var ENOSYS: Errno { noFunction }
 
 // BSD
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
   /// Inappropriate file type or format.
   ///
   /// The file was the wrong type for the operation,
@@ -1082,7 +1082,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   public static var EFTYPE: Errno { badFileTypeOrFormat }
 #endif
 
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
   /// Authentication error.
   ///
   /// The authentication ticket used to mount an NFS file system was invalid.
@@ -1253,7 +1253,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "illegalByteSequence")
   public static var EILSEQ: Errno { illegalByteSequence }
 
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
   /// Attribute not found.
   ///
   /// The specified extended attribute doesn't exist.
@@ -1294,7 +1294,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "multiHop")
   public static var EMULTIHOP: Errno { multiHop }
 
-#if !os(WASI)
+#if !os(WASI) && !os(FreeBSD)
   /// No message available.
   ///
   /// No message was available to be received by the requested operation.
@@ -1320,7 +1320,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "noLink")
   public static var ENOLINK: Errno { noLink }
 
-#if !os(WASI)
+#if !os(WASI) && !os(FreeBSD)
   /// Reserved.
   ///
   /// This error is reserved for future use.
@@ -1361,7 +1361,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   @available(*, unavailable, renamed: "protocolError")
   public static var EPROTO: Errno { protocolError }
 
-#if !os(OpenBSD) && !os(WASI)
+#if !os(OpenBSD) && !os(WASI) && !os(FreeBSD)
   /// Reserved.
   ///
   /// This error is reserved for future use.
@@ -1459,6 +1459,38 @@ extension Errno {
   public static var EOWNERDEAD: Errno { previousOwnerDied }
 #endif
 
+#if os(FreeBSD)
+  /// Capabilities insufficient.
+  ///
+  /// The corresponding C error is `ENOTCAPABLE`.
+  @_alwaysEmitIntoClient
+  public static var notCapable: Errno { .init(rawValue: _ENOTCAPABLE) }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "notCapable")
+  public static var ENOTCAPABLE: Errno { notCapable }
+
+  /// Not permitted in capability mode.
+  ///
+  /// The corresponding C error is `ECAPMODE`.
+  @_alwaysEmitIntoClient
+  public static var capabilityMode: Errno { .init(rawValue: _ECAPMODE) }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "capabilityMode")
+  public static var ECAPMODE: Errno { capabilityMode }
+
+  /// Integrity check failed.
+  ///
+  /// The corresponding C error is `EINTEGRITY`.
+  @_alwaysEmitIntoClient
+  public static var integrityCheckFailed: Errno { .init(rawValue: _EINTEGRITY) }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "integrityCheckFailed")
+  public static var EINTEGRITY: Errno { integrityCheckFailed }
+#endif
+
 #if SYSTEM_PACKAGE_DARWIN
   /// Interface output queue is full.
   ///
@@ -1469,7 +1501,9 @@ extension Errno {
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "outputQueueFull")
   public static var EQFULL: Errno { outputQueueFull }
+#endif
 
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
   /// The largest valid error.
   ///
   /// This value is the largest valid value

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -182,7 +182,7 @@ extension FileDescriptor {
     @available(*, unavailable, renamed: "exclusiveCreate")
     public static var O_EXCL: OpenOptions { exclusiveCreate }
 
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
     /// Indicates that opening the file
     /// atomically obtains a shared lock on the file.
     ///
@@ -248,6 +248,22 @@ extension FileDescriptor {
     @_alwaysEmitIntoClient
     @available(*, unavailable, renamed: "directory")
     public static var O_DIRECTORY: OpenOptions { directory }
+#endif
+
+#if os(FreeBSD)
+    /// Indicates that each write operation is synchronous.
+    ///
+    /// If this option is specified,
+    /// each time you write to the file,
+    /// the new data is written immediately and synchronously to the disk.
+    ///
+    /// The corresponding C constant is `O_SYNC`.
+    @_alwaysEmitIntoClient
+    public static var sync: OpenOptions { .init(rawValue: _O_SYNC) }
+
+    @_alwaysEmitIntoClient
+    @available(*, unavailable, renamed: "sync")
+    public static var O_SYNC: OpenOptions { sync }
 #endif
 
 #if SYSTEM_PACKAGE_DARWIN
@@ -354,7 +370,7 @@ extension FileDescriptor {
 
 // TODO: These are available on some versions of Linux with appropriate
 // macro defines.
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
     /// Indicates that the offset should be set
     /// to the next hole after the specified number of bytes.
     ///
@@ -455,6 +471,19 @@ extension FileDescriptor.OpenOptions
       (.create, ".create"),
       (.truncate, ".truncate"),
       (.exclusiveCreate, ".exclusiveCreate"),
+    ]
+#elseif os(FreeBSD)
+    let descriptions: [(Element, StaticString)] = [
+      (.nonBlocking, ".nonBlocking"),
+      (.append, ".append"),
+      (.create, ".create"),
+      (.truncate, ".truncate"),
+      (.exclusiveCreate, ".exclusiveCreate"),
+      (.sharedLock, ".sharedLock"),
+      (.exclusiveLock, ".exclusiveLock"),
+      (.sync, ".sync"),
+      (.noFollow, ".noFollow"),
+      (.closeOnExec, ".closeOnExec")
     ]
 #else
     let descriptions: [(Element, StaticString)] = [

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -359,7 +359,7 @@ internal var _ENOLCK: CInt { ENOLCK }
 @_alwaysEmitIntoClient
 internal var _ENOSYS: CInt { ENOSYS }
 
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
 @_alwaysEmitIntoClient
 internal var _EFTYPE: CInt { EFTYPE }
 
@@ -368,7 +368,9 @@ internal var _EAUTH: CInt { EAUTH }
 
 @_alwaysEmitIntoClient
 internal var _ENEEDAUTH: CInt { ENEEDAUTH }
+#endif
 
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _EPWROFF: CInt { EPWROFF }
 
@@ -409,7 +411,7 @@ internal var _ENOMSG: CInt { ENOMSG }
 @_alwaysEmitIntoClient
 internal var _EILSEQ: CInt { EILSEQ }
 
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
 @_alwaysEmitIntoClient
 internal var _ENOATTR: CInt { ENOATTR }
 #endif
@@ -422,7 +424,7 @@ internal var _EBADMSG: CInt { EBADMSG }
 @_alwaysEmitIntoClient
 internal var _EMULTIHOP: CInt { EMULTIHOP }
 
-#if !os(WASI)
+#if !os(WASI) && !os(FreeBSD)
 @_alwaysEmitIntoClient
 internal var _ENODATA: CInt { ENODATA }
 #endif
@@ -430,7 +432,7 @@ internal var _ENODATA: CInt { ENODATA }
 @_alwaysEmitIntoClient
 internal var _ENOLINK: CInt { ENOLINK }
 
-#if !os(WASI)
+#if !os(WASI) && !os(FreeBSD)
 @_alwaysEmitIntoClient
 internal var _ENOSR: CInt { ENOSR }
 
@@ -442,7 +444,7 @@ internal var _ENOSTR: CInt { ENOSTR }
 @_alwaysEmitIntoClient
 internal var _EPROTO: CInt { EPROTO }
 
-#if !os(OpenBSD) && !os(WASI)
+#if !os(OpenBSD) && !os(WASI) && !os(FreeBSD)
 @_alwaysEmitIntoClient
 internal var _ETIME: CInt { ETIME }
 #endif
@@ -471,10 +473,23 @@ internal var _ENOTRECOVERABLE: CInt { ENOTRECOVERABLE }
 internal var _EOWNERDEAD: CInt { EOWNERDEAD }
 #endif
 
+#if os(FreeBSD)
+@_alwaysEmitIntoClient
+internal var _ENOTCAPABLE: CInt { ENOTCAPABLE }
+
+@_alwaysEmitIntoClient
+internal var _ECAPMODE: CInt { ECAPMODE }
+
+@_alwaysEmitIntoClient
+internal var _EINTEGRITY: CInt { EINTEGRITY }
+#endif
+
 #if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _EQFULL: CInt { EQFULL }
+#endif
 
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
 @_alwaysEmitIntoClient
 internal var _ELAST: CInt { ELAST }
 #endif
@@ -524,7 +539,7 @@ internal var _O_APPEND: CInt {
 #endif
 }
 
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
 @_alwaysEmitIntoClient
 internal var _O_SHLOCK: CInt { O_SHLOCK }
 
@@ -541,6 +556,14 @@ internal var _O_ASYNC: CInt { O_ASYNC }
 
 @_alwaysEmitIntoClient
 internal var _O_NOFOLLOW: CInt { O_NOFOLLOW }
+#endif
+
+#if os(FreeBSD)
+@_alwaysEmitIntoClient
+internal var _O_FSYNC: CInt { O_FSYNC }
+
+@_alwaysEmitIntoClient
+internal var _O_SYNC: CInt { O_SYNC }
 #endif
 
 @_alwaysEmitIntoClient
@@ -609,7 +632,7 @@ internal var _SEEK_CUR: CInt { SEEK_CUR }
 @_alwaysEmitIntoClient
 internal var _SEEK_END: CInt { SEEK_END }
 
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
 @_alwaysEmitIntoClient
 internal var _SEEK_HOLE: CInt { SEEK_HOLE }
 

--- a/Sources/System/Internals/RawBuffer.swift
+++ b/Sources/System/Internals/RawBuffer.swift
@@ -80,7 +80,13 @@ extension _RawBuffer {
     internal static func create(minimumCapacity: Int) -> Storage {
       Storage.create(
         minimumCapacity: minimumCapacity,
-        makingHeaderWith: { $0.capacity }
+        makingHeaderWith: {
+#if os(OpenBSD)
+          minimumCapacity
+#else
+          $0.capacity
+#endif
+        }
       ) as! Storage
     }
   }

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -191,7 +191,7 @@ internal func system_confstr(
 internal let SYSTEM_AT_REMOVE_DIR = AT_REMOVEDIR
 internal let SYSTEM_DT_DIR = DT_DIR
 internal typealias system_dirent = dirent
-#if os(Linux) || os(Android)
+#if os(Linux) || os(Android) || os(FreeBSD) || os(OpenBSD)
 internal typealias system_DIRPtr = OpaquePointer
 #else
 internal typealias system_DIRPtr = UnsafeMutablePointer<DIR>

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -187,7 +187,7 @@ internal func pwrite(
 internal func pipe(
   _ fds: UnsafeMutablePointer<Int32>, bytesReserved: UInt32 = 4096
 ) -> CInt {
-  return _pipe(fds, bytesReserved, _O_BINARY | _O_NOINHERIT);
+  return _pipe(fds, bytesReserved, _O_BINARY | _O_NOINHERIT);
 }
 
 @inline(__always)

--- a/Tests/SystemTests/ErrnoTest.swift
+++ b/Tests/SystemTests/ErrnoTest.swift
@@ -131,10 +131,13 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(ENOLCK == Errno.noLocks.rawValue)
     XCTAssert(ENOSYS == Errno.noFunction.rawValue)
 
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
     XCTAssert(EFTYPE == Errno.badFileTypeOrFormat.rawValue)
     XCTAssert(EAUTH == Errno.authenticationError.rawValue)
     XCTAssert(ENEEDAUTH == Errno.needAuthenticator.rawValue)
+#endif
+
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssert(EPWROFF == Errno.devicePowerIsOff.rawValue)
     XCTAssert(EDEVERR == Errno.deviceError.rawValue)
 #endif
@@ -164,13 +167,17 @@ final class ErrnoTest: XCTestCase {
 #if !os(Windows)
     XCTAssert(EBADMSG == Errno.badMessage.rawValue)
     XCTAssert(EMULTIHOP == Errno.multiHop.rawValue)
-    XCTAssert(ENODATA == Errno.noData.rawValue)
     XCTAssert(ENOLINK == Errno.noLink.rawValue)
+    XCTAssert(EPROTO == Errno.protocolError.rawValue)
+#endif
+
+#if !os(Windows) && !os(FreeBSD)
+    XCTAssert(ENODATA == Errno.noData.rawValue)
     XCTAssert(ENOSR == Errno.noStreamResources.rawValue)
     XCTAssert(ENOSTR == Errno.notStream.rawValue)
-    XCTAssert(EPROTO == Errno.protocolError.rawValue)
     XCTAssert(ETIME == Errno.timeout.rawValue)
 #endif
+
     XCTAssert(EOPNOTSUPP == Errno.notSupportedOnSocket.rawValue)
 
     // From headers but not man page
@@ -190,6 +197,12 @@ final class ErrnoTest: XCTestCase {
 #if !os(Windows)
     XCTAssert(ENOTRECOVERABLE == Errno.notRecoverable.rawValue)
     XCTAssert(EOWNERDEAD == Errno.previousOwnerDied.rawValue)
+#endif
+
+#if os(FreeBSD)
+    XCTAssert(ENOTCAPABLE == Errno.notCapable.rawValue)
+    XCTAssert(ECAPMODE == Errno.capabilityMode.rawValue)
+    XCTAssert(EINTEGRITY == Errno.integrityCheckFailed.rawValue)
 #endif
 
 #if SYSTEM_PACKAGE_DARWIN

--- a/Tests/SystemTests/FileTypesTest.swift
+++ b/Tests/SystemTests/FileTypesTest.swift
@@ -42,18 +42,25 @@ final class FileDescriptorTest: XCTestCase {
 #endif
 
     // BSD only
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
     XCTAssertEqual(O_SHLOCK, FileDescriptor.OpenOptions.sharedLock.rawValue)
     XCTAssertEqual(O_EXLOCK, FileDescriptor.OpenOptions.exclusiveLock.rawValue)
+#endif
+
+#if SYSTEM_PACKAGE_DARWIN
     XCTAssertEqual(O_SYMLINK, FileDescriptor.OpenOptions.symlink.rawValue)
     XCTAssertEqual(O_EVTONLY, FileDescriptor.OpenOptions.eventOnly.rawValue)
+#endif
+
+#if os(FreeBSD)
+    XCTAssertEqual(O_SYNC, FileDescriptor.OpenOptions.sync.rawValue)
 #endif
 
     XCTAssertEqual(SEEK_SET, FileDescriptor.SeekOrigin.start.rawValue)
     XCTAssertEqual(SEEK_CUR, FileDescriptor.SeekOrigin.current.rawValue)
     XCTAssertEqual(SEEK_END, FileDescriptor.SeekOrigin.end.rawValue)
 
-#if SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
     XCTAssertEqual(SEEK_HOLE, FileDescriptor.SeekOrigin.nextHole.rawValue)
     XCTAssertEqual(SEEK_DATA, FileDescriptor.SeekOrigin.nextData.rawValue)
 #endif

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -36,7 +36,7 @@ function(get_swift_host_arch result_var_name)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
     set("${result_var_name}" "armv7" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "amd64")
-    set("${result_var_name}" "amd64" PARENT_SCOPE)
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
     set("${result_var_name}" "x86_64" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
@@ -45,6 +45,8 @@ function(get_swift_host_arch result_var_name)
     set("${result_var_name}" "i686" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
     set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "riscv64")
+    set("${result_var_name}" "riscv64" PARENT_SCOPE)
   else()
     message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
   endif()
@@ -67,6 +69,28 @@ function(get_swift_host_os result_var_name)
   endif()
 endfunction()
 
+if(NOT Swift_MODULE_TRIPLE)
+  # Attempt to get the module triple from the Swift compiler.
+  set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+  if(CMAKE_Swift_COMPILER_TARGET)
+    list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
+  endif()
+  execute_process(COMMAND ${module_triple_command}
+    OUTPUT_VARIABLE target_info_json)
+  string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+
+  # Exit now if we failed to infer the triple.
+  if(NOT module_triple)
+    message(FATAL_ERROR
+      "Failed to get module triple from Swift compiler. "
+      "Compiler output: ${target_info_json}")
+  endif()
+
+  # Cache the module triple for future use.
+  set(Swift_MODULE_TRIPLE "${module_triple}" CACHE STRING "swift module triple used for installed swiftmodule and swiftinterface files")
+  mark_as_advanced(Swift_MODULE_TRIPLE)
+endif()
+
 function(_install_target module)
   get_swift_host_os(swift_os)
   get_target_property(type ${module} TYPE)
@@ -77,24 +101,20 @@ function(_install_target module)
     set(swift swift)
   endif()
 
-  install(TARGETS ${module}
-    ARCHIVE DESTINATION lib/${swift}/${swift_os}
-    LIBRARY DESTINATION lib/${swift}/${swift_os}
-    RUNTIME DESTINATION bin)
+  install(TARGETS ${module})
   if(type STREQUAL EXECUTABLE)
     return()
   endif()
 
-  get_swift_host_arch(swift_arch)
   get_target_property(module_name ${module} Swift_MODULE_NAME)
   if(NOT module_name)
     set(module_name ${module})
   endif()
 
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
-    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
-    RENAME ${swift_arch}.swiftdoc)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${Swift_MODULE_TRIPLE}.swiftdoc)
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
-    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
-    RENAME ${swift_arch}.swiftmodule)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${Swift_MODULE_TRIPLE}.swiftmodule)
 endfunction()


### PR DESCRIPTION
The 1.4.0 branch has gotten so close to main that I decided to just merge main into 1.4.0 for this tag.

The changes are mostly in support of FreeBSD and OpenBSD, along with some cmake configuration improvements, and some typo fixes.

The list of commits vastly overstates the number of actual differences.