### PR TITLE
Add Android imports to tests

### DIFF
--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -14,6 +14,9 @@ import XCTest
 #else
 @testable import System
 #endif
+#if canImport(Android)
+import Android
+#endif
 
 @available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 final class FileOperationsTest: XCTestCase {

--- a/Tests/SystemTests/FileTypesTest.swift
+++ b/Tests/SystemTests/FileTypesTest.swift
@@ -14,6 +14,9 @@ import SystemPackage
 #else
 import System
 #endif
+#if canImport(Android)
+import Android
+#endif
 
 @available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 final class FileDescriptorTest: XCTestCase {


### PR DESCRIPTION
This is needed for constants like `O_RDWR`, completing the work in https://github.com/apple/swift-system/pull/187 and eliminating the need for @finagolfin's [swift-system-tests.patch](https://github.com/finagolfin/swift-android-sdk/blob/main/swift-system-tests.patch)