### PR TITLE
Enable Windows CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,8 +10,6 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}]'
-      # https://github.com/apple/swift-system/issues/223
-      enable_windows_checks: false
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main

--- a/Tests/SystemTests/FileOperationsTestWindows.swift
+++ b/Tests/SystemTests/FileOperationsTestWindows.swift
@@ -174,6 +174,9 @@ final class FileOperationsTestWindows: XCTestCase {
 
   /// Test that the umask works properly
   func testUmask() throws {
+    // See https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/persistent-storage#permissions
+    try XCTSkipIf(NSUserName() == "ContainerAdministrator", "containers use a different permission model")
+    
     // Default mask should be 0o022
     XCTAssertEqual(FilePermissions.creationMask, [.groupWrite, .otherWrite])
 
@@ -205,6 +208,9 @@ final class FileOperationsTestWindows: XCTestCase {
 
   /// Test that setting permissions on a file works as expected
   func testPermissions() throws {
+    // See https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/persistent-storage#permissions
+    try XCTSkipIf(NSUserName() == "ContainerAdministrator", "containers use a different permission model")
+
     try FilePermissions.withCreationMask([]) {
       try withTemporaryFilePath(basename: "testPermissions") { path in
         let tests = [


### PR DESCRIPTION
FileOperationsTestWindows.testPermissions fails on Windows in a container environment with Hyper-V isolated containers; see https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/persistent-storage#permissions for some potentially-relevant information.

Skip it if we detect we're in a container.

Closes #223