### PR TITLE
Fix Windows path parsing when the package is built in release configuration

### DIFF
--- a/Sources/System/Internals/Mocking.swift
+++ b/Sources/System/Internals/Mocking.swift
@@ -130,7 +130,7 @@ internal var mockingEnabled: Bool {
 @inline(__always)
 internal var forceWindowsPaths: Bool? {
   #if !ENABLE_MOCKING
-  return false
+  return nil
   #else
   return MockingDriver.forceWindowsPaths
   #endif


### PR DESCRIPTION
forceWindowsPaths can be used to force Windows path parsing both on and off. Instead of defaulting it to false in release builds, we should not express any preference. This fixes path parsing on Windows in optimized builds