### PR TITLE
Fix API documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ try fd.closeAfter {
 }
 ```
 
-[API documentation](https://swiftpackageindex.com/apple/swift-system/main/documentation/SystemPackage)
+[API documentation](https://swiftpackageindex.com/apple/swift-system/documentation/SystemPackage)
 
 ## Adding `SystemPackage` as a Dependency
 


### PR DESCRIPTION
Point API docs URL to the latest stable version instead of the unstable main branch.

**Motivation:**
For most of developers this README.md is the main entry point when searching online or installing the library, so pointing them to API docs for the latest stable release makes more sense then the main branch, which may contain not-yet-released API or breaking changes.

**Modifications:**
This PR removes main branch name from API docs URLs, making them always point to the latest stable release instead of the main branch.