### PR TITLE
Fix WASI build (dirent, umask, errno and open flag tests)

### DIFF
--- a/Sources/CSystem/include/CSystemWASI.h
+++ b/Sources/CSystem/include/CSystemWASI.h
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift System project authors
+ Copyright (c) 2024 - 2025 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,8 +11,10 @@
 
 #if __wasi__
 
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h> // For NAME_MAX
 
 // wasi-libc defines the following constants in a way that Clang Importer can't
 // understand, so we need to expose them manually.
@@ -27,5 +29,38 @@ static inline int32_t _getConst_O_WRONLY(void) { return O_WRONLY; }
 
 static inline int32_t _getConst_EWOULDBLOCK(void) { return EWOULDBLOCK; }
 static inline int32_t _getConst_EOPNOTSUPP(void) { return EOPNOTSUPP; }
+
+static inline uint8_t _getConst_DT_DIR(void) { return DT_DIR; }
+
+// Modified dirent struct that can be imported to Swift
+struct _system_dirent {
+  ino_t d_ino;
+  unsigned char d_type;
+  // char d_name[] cannot be imported to Swift
+  char d_name[NAME_MAX + 1];
+};
+
+// Convert WASI dirent with d_name[] to _system_dirent
+static inline
+struct _system_dirent *
+_system_dirent_from_wasi_dirent(const struct dirent *wasi_dirent) {
+
+  // Match readdir behavior and use thread-local storage for the converted dirent
+  static __thread struct _system_dirent _converted_dirent;
+
+  if (wasi_dirent == NULL) {
+    return NULL;
+  }
+
+  memset(&_converted_dirent, 0, sizeof(struct _system_dirent));
+
+  _converted_dirent.d_ino = wasi_dirent->d_ino;
+  _converted_dirent.d_type = wasi_dirent->d_type;
+
+  strncpy(_converted_dirent.d_name, wasi_dirent->d_name, NAME_MAX);
+  _converted_dirent.d_name[NAME_MAX] = '\0';
+
+  return &_converted_dirent;
+}
 
 #endif

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2025 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -509,6 +509,7 @@ extension FileDescriptor {
   }
 }
 
+#if !os(WASI) // WASI has no umask
 extension FilePermissions {
   /// The file creation permission mask (aka "umask").
   ///
@@ -549,3 +550,4 @@ extension FilePermissions {
     return system_umask(mode)
   }
 }
+#endif

--- a/Tests/SystemTests/ErrnoTest.swift
+++ b/Tests/SystemTests/ErrnoTest.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2025 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -36,7 +36,7 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(ENOMEM == Errno.noMemory.rawValue)
     XCTAssert(EACCES == Errno.permissionDenied.rawValue)
     XCTAssert(EFAULT == Errno.badAddress.rawValue)
-#if !os(Windows)
+#if !os(Windows) && !os(WASI)
     XCTAssert(ENOTBLK == Errno.notBlockDevice.rawValue)
 #endif
     XCTAssert(EBUSY == Errno.resourceBusy.rawValue)
@@ -74,9 +74,11 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(WSAEOPNOTSUPP == Errno.notSupported.rawValue)
     XCTAssert(WSAEPFNOSUPPORT == Errno.protocolFamilyNotSupported.rawValue)
 #else
-    XCTAssert(ESOCKTNOSUPPORT == Errno.socketTypeNotSupported.rawValue)
     XCTAssert(ENOTSUP == Errno.notSupported.rawValue)
+#if !os(WASI)
+    XCTAssert(ESOCKTNOSUPPORT == Errno.socketTypeNotSupported.rawValue)
     XCTAssert(EPFNOSUPPORT == Errno.protocolFamilyNotSupported.rawValue)
+#endif
 #endif
     XCTAssert(EAFNOSUPPORT == Errno.addressFamilyNotSupported.rawValue)
     XCTAssert(EADDRINUSE == Errno.addressInUse.rawValue)
@@ -91,7 +93,7 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(ENOTCONN == Errno.socketNotConnected.rawValue)
 #if os(Windows)
     XCTAssert(WSAESHUTDOWN == Errno.socketShutdown.rawValue)
-#else
+#elseif !os(WASI)
     XCTAssert(ESHUTDOWN == Errno.socketShutdown.rawValue)
 #endif
     XCTAssert(ETIMEDOUT == Errno.timedOut.rawValue)
@@ -100,7 +102,7 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(ENAMETOOLONG == Errno.fileNameTooLong.rawValue)
 #if os(Windows)
     XCTAssert(WSAEHOSTDOWN == Errno.hostIsDown.rawValue)
-#else
+#elseif !os(WASI)
     XCTAssert(EHOSTDOWN == Errno.hostIsDown.rawValue)
 #endif
     XCTAssert(EHOSTUNREACH == Errno.noRouteToHost.rawValue)
@@ -115,7 +117,9 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(WSAEDQUOT == Errno.diskQuotaExceeded.rawValue)
     XCTAssert(WSAESTALE == Errno.staleNFSFileHandle.rawValue)
 #else
+#if !os(WASI)
     XCTAssert(EUSERS == Errno.tooManyUsers.rawValue)
+#endif
     XCTAssert(EDQUOT == Errno.diskQuotaExceeded.rawValue)
     XCTAssert(ESTALE == Errno.staleNFSFileHandle.rawValue)
 #endif
@@ -171,7 +175,7 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(EPROTO == Errno.protocolError.rawValue)
 #endif
 
-#if !os(Windows) && !os(FreeBSD)
+#if !os(Windows) && !os(FreeBSD) && !os(WASI)
     XCTAssert(ENODATA == Errno.noData.rawValue)
     XCTAssert(ENOSR == Errno.noStreamResources.rawValue)
     XCTAssert(ENOSTR == Errno.notStream.rawValue)
@@ -181,11 +185,13 @@ final class ErrnoTest: XCTestCase {
     XCTAssert(EOPNOTSUPP == Errno.notSupportedOnSocket.rawValue)
 
     // From headers but not man page
+#if !os(WASI) // Would need to use _getConst func from CSystem
     XCTAssert(EWOULDBLOCK == Errno.wouldBlock.rawValue)
+#endif
 #if os(Windows)
     XCTAssert(WSAETOOMANYREFS == Errno.tooManyReferences.rawValue)
     XCTAssert(WSAEREMOTE == Errno.tooManyRemoteLevels.rawValue)
-#else
+#elseif !os(WASI)
     XCTAssert(ETOOMANYREFS == Errno.tooManyReferences.rawValue)
     XCTAssert(EREMOTE == Errno.tooManyRemoteLevels.rawValue)
 #endif

--- a/Tests/SystemTests/FileTypesTest.swift
+++ b/Tests/SystemTests/FileTypesTest.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2025 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -32,6 +32,7 @@ final class FileDescriptorTest: XCTestCase {
     XCTAssertEqual(O_WRONLY, FileDescriptor.AccessMode.writeOnly.rawValue)
     XCTAssertEqual(O_RDWR, FileDescriptor.AccessMode.readWrite.rawValue)
 
+#if !os(WASI) // Would need to use _getConst funcs from CSystem
 #if !os(Windows)
     XCTAssertEqual(O_NONBLOCK, FileDescriptor.OpenOptions.nonBlocking.rawValue)
 #endif
@@ -39,6 +40,7 @@ final class FileDescriptorTest: XCTestCase {
     XCTAssertEqual(O_CREAT, FileDescriptor.OpenOptions.create.rawValue)
     XCTAssertEqual(O_TRUNC, FileDescriptor.OpenOptions.truncate.rawValue)
     XCTAssertEqual(O_EXCL, FileDescriptor.OpenOptions.exclusiveCreate.rawValue)
+#endif // !os(WASI
 #if !os(Windows)
     XCTAssertEqual(O_NOFOLLOW, FileDescriptor.OpenOptions.noFollow.rawValue)
     XCTAssertEqual(O_CLOEXEC, FileDescriptor.OpenOptions.closeOnExec.rawValue)


### PR DESCRIPTION
Builds successfully with `swift-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm`. Tests also build but do not run (same symptom as https://forums.swift.org/t/swiftpm-fails-to-build-swift-testing-targeting-wasm/81085).

- `_getConst_DT_DIR()` for `DT_DIR`
- Modified `_system_dirent` struct that can be imported to Swift (WASI's `dirent` has variable length `char d_name[]` which can't be imported, so this uses `NAME_MAX + 1` instead)
- `#if !os(WASI)` unavailable functions like `umask()` and `pipe()`, as well as unavailable `Errno` and open flag constants that are used directly in tests