### PR TITLE
Fix IORing static Linux SDK

### DIFF
--- a/Sources/CSystem/include/io_uring.h
+++ b/Sources/CSystem/include/io_uring.h
@@ -1,9 +1,164 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <sys/uio.h>
-
 #include <signal.h>
+
+#if __has_include(<linux/io_uring.h>)
 #include <linux/io_uring.h>
+#else
+// Minimal fallback definitions when linux/io_uring.h is not available (e.g. static SDK)
+#include <stdint.h>
+
+#define IORING_OFF_SQ_RING      0ULL
+#define IORING_OFF_CQ_RING      0x8000000ULL
+#define IORING_OFF_SQES         0x10000000ULL
+
+#define IORING_ENTER_GETEVENTS  (1U << 0)
+
+#define IORING_FEAT_SINGLE_MMAP         (1U << 0)
+#define IORING_FEAT_NODROP              (1U << 1)
+#define IORING_FEAT_SUBMIT_STABLE       (1U << 2)
+#define IORING_FEAT_RW_CUR_POS          (1U << 3)
+#define IORING_FEAT_CUR_PERSONALITY     (1U << 4)
+#define IORING_FEAT_FAST_POLL           (1U << 5)
+#define IORING_FEAT_POLL_32BITS         (1U << 6)
+#define IORING_FEAT_SQPOLL_NONFIXED     (1U << 7)
+#define IORING_FEAT_EXT_ARG             (1U << 8)
+#define IORING_FEAT_NATIVE_WORKERS      (1U << 9)
+#define IORING_FEAT_RSRC_TAGS           (1U << 10)
+#define IORING_FEAT_CQE_SKIP            (1U << 11)
+#define IORING_FEAT_LINKED_FILE         (1U << 12)
+#define IORING_FEAT_REG_REG_RING        (1U << 13)
+#define IORING_FEAT_RECVSEND_BUNDLE     (1U << 14)
+#define IORING_FEAT_MIN_TIMEOUT         (1U << 15)
+#define IORING_FEAT_RW_ATTR             (1U << 16)
+#define IORING_FEAT_NO_IOWAIT           (1U << 17)
+
+typedef uint8_t  __u8;
+typedef uint16_t __u16;
+typedef uint32_t __u32;
+typedef uint64_t __u64;
+typedef int32_t  __s32;
+
+#ifndef __kernel_rwf_t
+typedef int __kernel_rwf_t;
+#endif
+
+struct io_uring_sqe {
+    __u8    opcode;
+    __u8    flags;
+    __u16   ioprio;
+    __s32   fd;
+    union {
+        __u64   off;
+        __u64   addr2;
+        struct {
+            __u32   cmd_op;
+            __u32   __pad1;
+        };
+    };
+    union {
+        __u64   addr;
+        __u64   splice_off_in;
+        struct {
+            __u32   level;
+            __u32   optname;
+        };
+    };
+    __u32   len;
+    union {
+        __kernel_rwf_t  rw_flags;
+        __u32           fsync_flags;
+        __u16           poll_events;
+        __u32           poll32_events;
+        __u32           sync_range_flags;
+        __u32           msg_flags;
+        __u32           timeout_flags;
+        __u32           accept_flags;
+        __u32           cancel_flags;
+        __u32           open_flags;
+        __u32           statx_flags;
+        __u32           fadvise_advice;
+        __u32           splice_flags;
+        __u32           rename_flags;
+        __u32           unlink_flags;
+        __u32           hardlink_flags;
+        __u32           xattr_flags;
+        __u32           msg_ring_flags;
+        __u32           uring_cmd_flags;
+        __u32           waitid_flags;
+        __u32           futex_flags;
+        __u32           install_fd_flags;
+        __u32           nop_flags;
+    };
+    __u64   user_data;
+    union {
+        __u16   buf_index;
+        __u16   buf_group;
+    } __attribute__((packed));
+    __u16   personality;
+    union {
+        __s32   splice_fd_in;
+        __u32   file_index;
+        __u32   optlen;
+        struct {
+            __u16   addr_len;
+            __u16   __pad3[1];
+        };
+    };
+    union {
+        struct {
+            __u64   addr3;
+            __u64   __pad2[1];
+        };
+        __u64   optval;
+        __u8    cmd[0];
+    };
+};
+
+struct io_uring_cqe {
+    __u64   user_data;
+    __s32   res;
+    __u32   flags;
+};
+
+struct io_sqring_offsets {
+    __u32 head;
+    __u32 tail;
+    __u32 ring_mask;
+    __u32 ring_entries;
+    __u32 flags;
+    __u32 dropped;
+    __u32 array;
+    __u32 resv1;
+    __u64 user_addr;
+};
+
+struct io_cqring_offsets {
+    __u32 head;
+    __u32 tail;
+    __u32 ring_mask;
+    __u32 ring_entries;
+    __u32 overflow;
+    __u32 cqes;
+    __u32 flags;
+    __u32 resv1;
+    __u64 user_addr;
+};
+
+struct io_uring_params {
+    __u32 sq_entries;
+    __u32 cq_entries;
+    __u32 flags;
+    __u32 sq_thread_cpu;
+    __u32 sq_thread_idle;
+    __u32 features;
+    __u32 wq_fd;
+    __u32 resv[3];
+    struct io_sqring_offsets sq_off;
+    struct io_cqring_offsets cq_off;
+};
+#endif // __has_include(<linux/io_uring.h>)
 
 #ifndef SWIFT_IORING_C_WRAPPER
 #define SWIFT_IORING_C_WRAPPER

--- a/Sources/System/IORing/IORing.swift
+++ b/Sources/System/IORing/IORing.swift
@@ -223,7 +223,7 @@ private func setUpRing(
             /* prot: */ PROT_READ | PROT_WRITE,
             /* flags: */ MAP_SHARED | MAP_POPULATE,
             /* fd: */ ringDescriptor,
-            /* offset: */ __off_t(IORING_OFF_SQ_RING)
+            /* offset: */ off_t(IORING_OFF_SQ_RING)
         )
 
         if ringPtr == MAP_FAILED {
@@ -238,7 +238,7 @@ private func setUpRing(
             /* prot: */ PROT_READ | PROT_WRITE,
             /* flags: */ MAP_SHARED | MAP_POPULATE,
             /* fd: */ ringDescriptor,
-            /* offset: */ __off_t(IORING_OFF_SQ_RING)
+            /* offset: */ off_t(IORING_OFF_SQ_RING)
         )
 
         if sqPtr == MAP_FAILED {
@@ -253,7 +253,7 @@ private func setUpRing(
             /* prot: */ PROT_READ | PROT_WRITE,
             /* flags: */ MAP_SHARED | MAP_POPULATE,
             /* fd: */ ringDescriptor,
-            /* offset: */ __off_t(IORING_OFF_CQ_RING)
+            /* offset: */ off_t(IORING_OFF_CQ_RING)
         )
 
         if cqPtr == MAP_FAILED {
@@ -270,7 +270,7 @@ private func setUpRing(
         /* prot: */ PROT_READ | PROT_WRITE,
         /* flags: */ MAP_SHARED | MAP_POPULATE,
         /* fd: */ ringDescriptor,
-        /* offset: */ __off_t(IORING_OFF_SQES)
+        /* offset: */ off_t(IORING_OFF_SQES)
     )
 
     if sqes == MAP_FAILED {


### PR DESCRIPTION
Check `#if __has_include(<linux/io_uring.h>)` and if not (such as when building with the static Linux SDK), provide the missing definitions.

Verified on a Swift 6.2 Ubuntu 22.04 image that System now builds with `--swift-sdk swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-26-a_static-linux-0.0.1` (previously failed with the `'linux/io_uring.h' file not found` error shown in the issue).

Resolves #240 