### PR TITLE
Fix IORing build for older Linux kernels

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,10 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
-      linux_exclude_swift_versions: '[{"swift_version": "5.8"}]'
+      linux_os_versions: '["jammy", "focal"]'
+      enable_macos_checks: false
+      macos_xcode_versions: '["16.3"]'
+
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main

--- a/Sources/System/IORing/IORing.swift
+++ b/Sources/System/IORing/IORing.swift
@@ -10,6 +10,10 @@ import Musl
 #endif
 import Synchronization
 
+private var ioringSupported: Bool {
+    __SWIFT_IORING_SUPPORTED != 0
+}
+
 //This was #defines in older headers, so we redeclare it to get a consistent import
 internal enum RegistrationOps: UInt32 {
 	case registerBuffers		= 0
@@ -366,7 +370,7 @@ public struct IORing: ~Copyable {
 
     /// Initializes an IORing with enough space for `queueDepth` prepared requests and completed operations
     public init(queueDepth: UInt32, flags: SetupFlags = []) throws(Errno) {
-        guard __SWIFT_IORING_SUPPORTED != 0 else {
+        guard ioringSupported else {
             throw Errno.notSupported
         }
 

--- a/Sources/System/IORing/RawIORequest.swift
+++ b/Sources/System/IORing/RawIORequest.swift
@@ -5,11 +5,13 @@ import CSystem
     
 @usableFromInline
 internal struct RawIORequest: ~Copyable {
-    @usableFromInline var rawValue: io_uring_sqe
+    // swift_io_uring_sqe is a typedef of io_uring_sqe on platforms where
+    // IORing is supported (currently requires kernel version >= 5.15).
+    @usableFromInline var rawValue: swift_io_uring_sqe
     @usableFromInline var path: FilePath? //buffer owner for the path pointer that the sqe may have
 
     @inlinable public init() {
-        self.rawValue = io_uring_sqe()
+        self.rawValue = swift_io_uring_sqe()
     }
 }
 
@@ -176,8 +178,8 @@ extension RawIORequest {
 
     @inlinable
     static func withTimeoutRequest<R>(
-        linkedTo opEntry: UnsafeMutablePointer<io_uring_sqe>,
-        in timeoutEntry: UnsafeMutablePointer<io_uring_sqe>,
+        linkedTo opEntry: UnsafeMutablePointer<swift_io_uring_sqe>,
+        in timeoutEntry: UnsafeMutablePointer<swift_io_uring_sqe>,
         duration: Duration, 
         flags: TimeOutFlags, 
         work: () throws -> R) rethrows -> R {


### PR DESCRIPTION
System currently fails to build on Ubuntu 20.04 (Linux kernel v5.4) as shown in https://github.com/apple/swift-system/pull/243, but those same tests should now pass with this PR. I verified locally that System now builds on a Swift 6.2 Ubuntu 20.04 image.

The issue is that `struct io_uring_sqe` has added new properties in later kernel versions, and the Swift implementation is expecting these properties to be available on the struct.

Specifically, `struct io_uring_sqe` added:
- `cancel_flags` in v5.5
- `open_flags` in v5.6
- `file_index` in v5.15

In the future, we could do something tricky to guard the availability of these features, but for now, let's just define a fallback struct for kernel versions < 5.15 so that we can build, but otherwise not support `IORing` initialization at runtime (such as by throwing `ENOTSUP`).

This PR defines a `struct swift_io_uring_sqe` that is just a typedef of `struct io_uring_sqe` on kernel versions that `IORing` supports. Otherwise, we use the same fallback struct that's defined when the `<linux/io_uring.h>` header isn't available.

We also replace the use of `IORING_FEAT_NODROP` with `IORing.Features.nonDroppingCompletions.rawValue`, which hard-codes the value for now.