### PR TITLE
Gate 6.2 features by feature flag

### DIFF
--- a/Sources/System/IORing/IOCompletion.swift
+++ b/Sources/System/IORing/IOCompletion.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.2)
+#if compiler(>=6.2) && $Lifetimes
 #if os(Linux)
 
 import CSystem
@@ -67,5 +67,5 @@ public extension IORing.Completion {
         }
     }
 }
-#endif
-#endif
+#endif // os(Linux)
+#endif // compiler(>=6.2) && $Lifetimes

--- a/Sources/System/IORing/IORequest.swift
+++ b/Sources/System/IORing/IORequest.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.2)
+#if compiler(>=6.2) && $Lifetimes
 #if os(Linux)
 
 import CSystem
@@ -493,5 +493,5 @@ extension IORing.Request {
         return request
     }
 }
-#endif
-#endif
+#endif // os(Linux)
+#endif // compiler(>=6.2) && $Lifetimes

--- a/Sources/System/IORing/IORing.swift
+++ b/Sources/System/IORing/IORing.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.2)
+#if compiler(>=6.2) && $Lifetimes
 #if os(Linux)
 
 import CSystem
@@ -900,5 +900,5 @@ extension IORing.RegisteredBuffer {
         return unsafe _overrideLifetime(span, borrowing: self)
     }
 }
-#endif
-#endif
+#endif // os(Linux)
+#endif // compiler(>=6.2) && $Lifetimes

--- a/Sources/System/IORing/RawIORequest.swift
+++ b/Sources/System/IORing/RawIORequest.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.2)
+#if compiler(>=6.2) && $Lifetimes
 #if os(Linux)
 
 import CSystem
@@ -201,5 +201,5 @@ extension RawIORequest {
         }
     }
 }
-#endif
-#endif
+#endif // os(Linux)
+#endif // compiler(>=6.2) && $Lifetimes

--- a/Tests/SystemTests/IORequestTests.swift
+++ b/Tests/SystemTests/IORequestTests.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.2)
+#if compiler(>=6.2) && $Lifetimes
 #if os(Linux)
 
 import XCTest
@@ -30,5 +30,5 @@ final class IORequestTests: XCTestCase {
         XCTAssertEqual(sourceBytes, .init(repeating: 0, count: 64))
     }
 }
-#endif
-#endif
+#endif // os(Linux)
+#endif // compiler(>=6.2) && $Lifetimes

--- a/Tests/SystemTests/IORingTests.swift
+++ b/Tests/SystemTests/IORingTests.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.2)
+#if compiler(>=6.2) && $Lifetimes
 #if os(Linux)
 
 import XCTest
@@ -128,5 +128,5 @@ final class IORingTests: XCTestCase {
         rawBuffer.deallocate()
     }
 }
-#endif
-#endif
+#endif // os(Linux)
+#endif // compiler(>=6.2) && $Lifetimes


### PR DESCRIPTION
This is slightly finer-grained, so that users who have a pre-release, but not up-to-date compiler aren't confronted with a compilation error.