### PR TITLE
[gardening] Swift 5.9 is required

### DIFF
--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if swift(>=5.9) && SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN
 
 import Darwin.Mach
 

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift System project authors
+ Copyright (c) 2022 - 2025 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift System project authors
+ Copyright (c) 2022 - 2025 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SystemTests/MachPortTests.swift
+++ b/Tests/SystemTests/MachPortTests.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if swift(>=5.9) && SYSTEM_PACKAGE_DARWIN
+#if SYSTEM_PACKAGE_DARWIN
 
 import XCTest
 import Darwin.Mach


### PR DESCRIPTION
Remove conditional compilation based on requiring Swift 5.9, since it is now a prerequisite.