### PR TITLE
Support testing in release mode

### DIFF
--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -22,7 +22,7 @@ import CSystem
 
 @available(/*System 0.0.1: macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0*/iOS 8, *)
 final class FileOperationsTest: XCTestCase {
-  #if !os(WASI) // Would need to use _getConst funcs from CSystem
+  #if ENABLE_MOCKING && !os(WASI) // Would need to use _getConst funcs from CSystem
   func testSyscalls() {
     let fd = FileDescriptor(rawValue: 1)
 
@@ -91,7 +91,7 @@ final class FileOperationsTest: XCTestCase {
 
     for test in syscallTestCases { test.runAllTests() }
   }
-  #endif // !os(WASI)
+  #endif // ENABLE_MOCKING && !os(WASI)
 
   func testWriteFromEmptyBuffer() throws {
     #if os(Windows)
@@ -215,6 +215,7 @@ final class FileOperationsTest: XCTestCase {
     }
   }
 
+  #if ENABLE_MOCKING
   func testGithubIssues() {
     // https://github.com/apple/swift-system/issues/26
     #if os(WASI)
@@ -233,6 +234,7 @@ final class FileOperationsTest: XCTestCase {
     }
     issue26.runAllTests()
   }
+  #endif // ENABLE_MOCKING
 
   func testResizeFile() throws {
     try withTemporaryFilePath(basename: "testResizeFile") { path in 

--- a/Tests/SystemTests/FilePathTests/FilePathParsingTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathParsingTest.swift
@@ -7,6 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
+#if ENABLE_MOCKING
 import XCTest
 
 #if SYSTEM_PACKAGE
@@ -105,3 +106,4 @@ final class FilePathParsingTest: XCTestCase {
     }
   }
 }
+#endif // ENABLE_MOCKING

--- a/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
@@ -7,6 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
+#if ENABLE_MOCKING
 import XCTest
 
 #if SYSTEM_PACKAGE
@@ -1238,3 +1239,4 @@ final class FilePathSyntaxTest: XCTestCase {
   }
 
 }
+#endif // ENABLE_MOCKING

--- a/Tests/SystemTests/MockingTest.swift
+++ b/Tests/SystemTests/MockingTest.swift
@@ -7,6 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
+#if ENABLE_MOCKING
 import XCTest
 
 #if SYSTEM_PACKAGE
@@ -48,3 +49,4 @@ final class MockingTest: XCTestCase {
     XCTAssertFalse(mockingEnabled)
   }
 }
+#endif // ENABLE_MOCKING

--- a/Tests/SystemTests/TestingInfrastructure.swift
+++ b/Tests/SystemTests/TestingInfrastructure.swift
@@ -17,6 +17,7 @@ import XCTest
 
 internal struct Wildcard: Hashable {}
 
+#if ENABLE_MOCKING
 extension Trace.Entry {
   /// This implements `==` with wildcard matching.
   /// (`Entry` cannot conform to `Equatable`/`Hashable` this way because
@@ -33,6 +34,7 @@ extension Trace.Entry {
     return true
   }
 }
+#endif // ENABLE_MOCKING
 
 // To aid debugging, force failures to fatal error
 internal var forceFatalFailures = false
@@ -81,6 +83,7 @@ extension TestCase {
       fail(message)
     }
   }
+  #if ENABLE_MOCKING
   func expectMatch(
     _ expected: Trace.Entry?, _ actual: Trace.Entry?,
     _ message: String? = nil
@@ -102,6 +105,7 @@ extension TestCase {
       fail(message)
     }
   }
+  #endif // ENABLE_MOCKING
   func expectNil<T>(
     _ actual: T?,
     _ message: String? = nil
@@ -142,6 +146,7 @@ extension TestCase {
 
 }
 
+#if ENABLE_MOCKING
 internal struct MockTestCase: TestCase {
   var file: StaticString
   var line: UInt
@@ -241,6 +246,7 @@ internal struct MockTestCase: TestCase {
     }
   }
 }
+#endif // ENABLE_MOCKING
 
 internal func withWindowsPaths(enabled: Bool, _ body: () -> ()) {
   _withWindowsPaths(enabled: enabled, body)


### PR DESCRIPTION
Some tests used internal types/functions that are guarded by `#if ENABLE_MOCKING` (defined in debug builds), but their code wasn't guarded by `#if ENABLE_MOCKING`. This made the tests fail to build in release mode.

This PR guards the respective tests/types in `#if ENABLE_MOCKING` so we can run `swift test -c release --enable-testable-imports` as suggested in https://github.com/swiftlang/github-workflows/pull/134.