### PR TITLE
[CI] Enable Linux static SDK and Wasm SDK builds

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,6 +19,8 @@ jobs:
           {"xcode_version": "16.1"},
         ]
       swift_flags: "-Xbuild-tools-swiftc -DSYSTEM_CI"
+      enable_linux_static_sdk_build: true
+      enable_wasm_sdk_build: true
 
   build-abi-stable:
     name: Build ABI Stable


### PR DESCRIPTION
Enables Linux static SDK and Wasm SDK builds, which are now implemented upstream via https://github.com/swiftlang/github-workflows/pull/142