### PR TITLE
Fix typedef errors on platforms with _ASM_GENERIC_INT headers

### DIFF
--- a/Sources/CSystem/include/io_uring.h
+++ b/Sources/CSystem/include/io_uring.h
@@ -134,11 +134,13 @@ typedef struct __SWIFT_IORING_SQE_FALLBACK_STRUCT swift_io_uring_sqe;
 #define IORING_FEAT_RW_ATTR             (1U << 16)
 #define IORING_FEAT_NO_IOWAIT           (1U << 17)
 
+#if !defined(_ASM_GENERIC_INT_LL64_H) && !defined(_ASM_GENERIC_INT_L64_H) && !defined(_UAPI_ASM_GENERIC_INT_LL64_H) && !defined(_UAPI_ASM_GENERIC_INT_L64_H)
 typedef uint8_t  __u8;
 typedef uint16_t __u16;
 typedef uint32_t __u32;
 typedef uint64_t __u64;
 typedef int32_t  __s32;
+#endif
 
 #ifndef __kernel_rwf_t
 typedef int __kernel_rwf_t;


### PR DESCRIPTION
System fails to build on Amazon Linux 2 with the error:

```
/Swift/swift-system/Sources/CSystem/include/io_uring.h:141:18: error: typedef redefinition with different types ('uint64_t' (aka 'unsigned long') vs 'unsigned long long')
  141 | typedef uint64_t __u64;
      |                  ^
/usr/include/asm-generic/int-ll64.h:31:42: note: previous definition is here
   31 | __extension__ typedef unsigned long long __u64;
      |                                          ^
```

We can guard the `__u64`, `__u32`, etc. typedefs with `#if !defined` for the various `_ASM_GENERIC_INT` headers where these types are already defined.

Verified System builds successfully on Amazon Linux 2 with this change.