### PR TITLE
[Proposal] Stat for Swift System

### DIFF
--- a/Proposals/0006-system-stat.md
+++ b/Proposals/0006-system-stat.md
@@ -1,6 +1,6 @@
 # Stat for Swift System
 
-* Proposal: [SYS-0006](NNNN-system-stat.md)
+* Proposal: [SYS-0006](0006-system-stat.md)
 * Authors: [Jonathan Flat](https://github.com/jrflat), [Michael Ilseman](https://github.com/milseman), [Rauhul Varma](https://github.com/rauhul)
 * Review Manager: TBD
 * Status: **Awaiting review**


### PR DESCRIPTION
This proposal introduces a Swift-native `Stat` type to the System library, providing comprehensive access to file metadata on Unix-like platforms through type-safe, platform-aware APIs that wrap the C `stat` types and system calls.

[Read full proposal...](https://github.com/jrflat/swift-system/blob/stat-proposal/Proposals/0006-system-stat.md)