### PR TITLE
[1.6] Fix: FileDescriptor.duplicate(as:) returns an invalid file descriptor on Windows

### DIFF
--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -135,7 +135,11 @@ internal func dup(_ fd: Int32) -> Int32 {
 
 @inline(__always)
 internal func dup2(_ fd: Int32, _ fd2: Int32) -> Int32 {
-  _dup2(fd, fd2)
+  // _dup2 returns 0 to indicate success. 
+  if _dup2(fd, fd2) == 0 {
+    return fd2
+  }
+  return -1
 }
 
 @inline(__always)


### PR DESCRIPTION
FileDescriptor.duplicate(as:) is backed by dup2 on Unix, and _dup2 on Windows. On Unix, dup2 returns its second argument. On Windows, _dup2 instead returns 0 on success and -1 on error. This results in the newly returned FileDescriptor object always containing a '0' file descriptor rather than the newly created file descriptor, in violation of the documented behavior.

Account for the platform difference in the syscall wrapper to fix this.

Closes #192

(cherry picked from commit b2711a872a8f5ae979cc326f75d7548175376663)