### PR TITLE
Adjust toolchain support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,21 +9,39 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
-      linux_os_versions: '["noble", "jammy", "focal"]'
-      linux_exclude_swift_versions: '[{"os_version": "focal", "swift_version": "nightly-main"}, {"os_version": "focal", "swift_version": "nightly-6.2"}, {"os_version": "focal", "swift_version": "6.2"}, {"os_version": "noble", "swift_version": "5.9"}, {"os_version": "noble", "swift_version": "5.10"}]'
-      enable_macos_checks: true
-      # FIXME: https://github.com/swiftlang/github-workflows/pull/140
-      # Xcode 16.0 and 16.1 are not actually available
-      macos_exclude_xcode_versions: |
-        [
-          {"xcode_version": "16.0"},
-          {"xcode_version": "16.1"},
-        ]
       swift_flags: "-Xbuild-tools-swiftc -DSYSTEM_CI"
+      enable_linux_checks: true
+      linux_os_versions: '["noble", "jammy", "focal"]'
+      linux_exclude_swift_versions: |
+        [
+          {"swift_version": "5.9"},
+          {"swift_version": "5.10"},
+          {"os_version": "focal", "swift_version": "nightly-6.2"},
+          {"os_version": "focal", "swift_version": "6.2"},
+          {"os_version": "focal", "swift_version": "nightly-main"},
+        ]
+      enable_macos_checks: true
+      macos_exclude_xcode_versions: '[]'
+      enable_windows_checks: true
+      windows_exclude_swift_versions: |
+        [
+          {"swift_version": "5.9"},
+          {"swift_version": "5.10"}
+        ]
       enable_linux_static_sdk_build: true
-      linux_static_sdk_exclude_swift_versions: '[{"os_version": "focal", "swift_version": "nightly-main"}, {"os_version": "focal", "swift_version": "nightly-6.2"}, {"os_version": "focal", "swift_version": "6.2"}]'
+      linux_static_sdk_exclude_swift_versions: |
+        [
+          {"os_version": "focal", "swift_version": "nightly-6.2"},
+          {"os_version": "focal", "swift_version": "6.2"},
+          {"os_version": "focal", "swift_version": "nightly-main"},
+        ]
       enable_wasm_sdk_build: true
-      wasm_exclude_swift_versions: '[{"os_version": "focal", "swift_version": "nightly-main"}, {"os_version": "focal", "swift_version": "nightly-6.2"}, {"os_version": "focal", "swift_version": "6.2"}]'
+      wasm_exclude_swift_versions: |
+        [
+          {"os_version": "focal", "swift_version": "nightly-6.2"},
+          {"os_version": "focal", "swift_version": "6.2"},
+          {"os_version": "focal", "swift_version": "nightly-main"},
+        ]
 
   build-abi-stable:
     name: Build ABI Stable
@@ -34,13 +52,7 @@ jobs:
       enable_windows_checks: false
       # Only build
       macos_build_command: "xcrun swift build --build-tests"
-      # FIXME: https://github.com/swiftlang/github-workflows/pull/140
-      # Xcode 16.0 and 16.1 are not actually available
-      macos_exclude_xcode_versions: |
-        [
-          {"xcode_version": "16.0"},
-          {"xcode_version": "16.1"},
-        ]
+      macos_exclude_xcode_versions: '[]'
       # Enable availability to match ABI stable verion of system.
       swift_flags: "-Xbuild-tools-swiftc -DSYSTEM_CI -Xbuild-tools-swiftc -DSYSTEM_ABI_STABLE"
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift System open source project

--- a/Package.swift
+++ b/Package.swift
@@ -139,5 +139,6 @@ let package = Package(
       exclude: testsToExclude,
       cSettings: cSettings,
       swiftSettings: swiftSettings),
-  ])
-
+  ],
+  swiftLanguageVersions: [.v5]
+)

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -140,7 +140,7 @@ extension String {
     return
 
     #else
-    self.init(validatingUTF8: platformString)
+    self.init(validatingCString: platformString)
     #endif
   }
 

--- a/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathComponentsTest.swift
@@ -107,7 +107,7 @@ final class FilePathComponentsTest: XCTestCase {
 
     func expect(
       _ s: String,
-      _ file: StaticString = #file,
+      _ file: StaticString = #filePath,
       _ line: UInt = #line
     ) {
       if path == FilePath(s) { return }

--- a/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
@@ -850,7 +850,7 @@ final class FilePathSyntaxTest: XCTestCase {
 
     func expect(
       _ s: String,
-      _ file: StaticString = #file,
+      _ file: StaticString = #filePath,
       _ line: UInt = #line
     ) {
       if path == FilePath(s) { return }

--- a/Tests/SystemTests/TestingInfrastructure.swift
+++ b/Tests/SystemTests/TestingInfrastructure.swift
@@ -37,7 +37,7 @@ extension Trace.Entry {
 #endif // ENABLE_MOCKING
 
 // To aid debugging, force failures to fatal error
-internal var forceFatalFailures = false
+internal let forceFatalFailures = false
 
 internal protocol TestCase {
   // TODO: want a source location stack, more fidelity, kinds of stack entries, etc

--- a/Tests/SystemTests/UtilTests.swift
+++ b/Tests/SystemTests/UtilTests.swift
@@ -34,7 +34,7 @@ class UtilTests: XCTestCase {
   func testCStringArray() {
     func check(
       _ array: [String],
-      file: StaticString = #file,
+      file: StaticString = #filePath,
       line: UInt = #line
     ) {
       array._withCStringArray { carray in


### PR DESCRIPTION
The next minor release of SwiftSystem will require Swift 6.0, dropping support for Swift 5.9 and 5.10.