### PR TITLE
Add overloads to cover dup3 and pipe2 POSIX APIs

### DIFF
--- a/Sources/CSystem/CMakeLists.txt
+++ b/Sources/CSystem/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(CSystem INTERFACE
 
 install(FILES
   include/CSystemLinux.h
+  include/CSystemShared.h
   include/CSystemWindows.h
   include/module.modulemap
   DESTINATION include/CSystem)

--- a/Sources/CSystem/CMakeLists.txt
+++ b/Sources/CSystem/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift System open source project
 
-Copyright (c) 2020 Apple Inc. and the Swift System project authors
+Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Sources/CSystem/include/CSystemShared.h
+++ b/Sources/CSystem/include/CSystemShared.h
@@ -1,0 +1,2 @@
+extern int csystem_posix_pipe2(int fildes[2], int flag);
+extern int csystem_posix_dup3(int fildes, int fildes2, int flag);

--- a/Sources/CSystem/include/CSystemShared.h
+++ b/Sources/CSystem/include/CSystemShared.h
@@ -1,2 +1,11 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
 extern int csystem_posix_pipe2(int fildes[2], int flag);
 extern int csystem_posix_dup3(int fildes, int fildes2, int flag);

--- a/Sources/CSystem/include/module.modulemap
+++ b/Sources/CSystem/include/module.modulemap
@@ -1,4 +1,5 @@
 module CSystem {
+  header "CSystemShared.h"
   header "CSystemLinux.h"
   header "CSystemWASI.h"
   header "CSystemWindows.h"

--- a/Sources/CSystem/shims.c
+++ b/Sources/CSystem/shims.c
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/CSystem/shims.c
+++ b/Sources/CSystem/shims.c
@@ -7,12 +7,40 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#define __BSD_VISIBLE
+#include <unistd.h>
+#endif
+
 #ifdef __linux__
-
+#define _GNU_SOURCE
 #include <CSystemLinux.h>
-
 #endif
 
 #if defined(_WIN32)
 #include <CSystemWindows.h>
 #endif
+
+#include <errno.h>
+
+#if !defined(_WIN32) && !defined(__wasi__) && !defined(__APPLE__)
+#define HAVE_PIPE2_DUP3
+#endif
+
+// Wrappers are required because _GNU_SOURCE causes a conflict with other imports when defined in CSystemLinux.h
+extern int csystem_posix_pipe2(int fildes[2], int flag) {
+    #ifdef HAVE_PIPE2_DUP3
+    return pipe2(fildes, flag);
+    #else
+    errno = ENOSYS;
+    return -1;
+    #endif
+}
+extern int csystem_posix_dup3(int fildes, int fildes2, int flag) {
+    #ifdef HAVE_PIPE2_DUP3
+    return dup3(fildes, fildes2, flag);
+    #else
+    errno = ENOSYS;
+    return -1;
+    #endif
+}

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -324,6 +324,141 @@ extension FileDescriptor {
 #endif
   }
 
+  /// Options that specify behavior for a newly-created pipe.
+  @frozen
+  @available(Windows, unavailable)
+  @available(macOS, unavailable)
+  @available(iOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  @available(visionOS, unavailable)
+  public struct PipeOptions: OptionSet, Sendable, Hashable, Codable {
+    /// The raw C options.
+    @_alwaysEmitIntoClient
+    public var rawValue: CInt
+
+    /// Create a strongly-typed options value from raw C options.
+    @_alwaysEmitIntoClient
+    public init(rawValue: CInt) { self.rawValue = rawValue }
+
+#if !os(Windows)
+    /// Indicates that all
+    /// subsequent input and output operations on the pipe's file descriptors will be nonblocking.
+    ///
+    /// The corresponding C constant is `O_NONBLOCK`.
+    @_alwaysEmitIntoClient
+    public static var nonBlocking: OpenOptions { .init(rawValue: _O_NONBLOCK) }
+
+    @_alwaysEmitIntoClient
+    @available(*, unavailable, renamed: "nonBlocking")
+    public static var O_NONBLOCK: OpenOptions { nonBlocking }
+
+    /// Indicates that executing a program closes the file.
+    ///
+    /// Normally, file descriptors remain open
+    /// across calls to the `exec(2)` family of functions.
+    /// If you specify this option,
+    /// the file descriptor is closed when replacing this process
+    /// with another process.
+    ///
+    /// The state of the file
+    /// descriptor flags can be inspected using `F_GETFD`,
+    /// as described in the `fcntl(2)` man page.
+    ///
+    /// The corresponding C constant is `O_CLOEXEC`.
+    @_alwaysEmitIntoClient
+    public static var closeOnExec: OpenOptions { .init(rawValue: _O_CLOEXEC) }
+
+    @_alwaysEmitIntoClient
+    @available(*, unavailable, renamed: "closeOnExec")
+    public static var O_CLOEXEC: OpenOptions { closeOnExec }
+
+#if !os(WASI) && !os(Linux) && !os(Android)
+    /// Indicates that forking a program closes the file.
+    ///
+    /// Normally, file descriptors remain open
+    /// across calls to the `fork(2)` function.
+    /// If you specify this option,
+    /// the file descriptor is closed when forking this process
+    /// into another process.
+    ///
+    /// The state of the file
+    /// descriptor flags can be inspected using `F_GETFD`,
+    /// as described in the `fcntl(2)` man page.
+    ///
+    /// The corresponding C constant is `O_CLOFORK`.
+    @_alwaysEmitIntoClient
+    public static var closeOnFork: OpenOptions { .init(rawValue: _O_CLOFORK) }
+
+    @_alwaysEmitIntoClient
+    @available(*, unavailable, renamed: "closeOnFork")
+    public static var O_CLOFORK: OpenOptions { closeOnFork }
+#endif
+#endif
+  }
+
+  /// Options that specify behavior for a duplicated file descriptor.
+  @frozen
+  @available(Windows, unavailable)
+  @available(macOS, unavailable)
+  @available(iOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  @available(visionOS, unavailable)
+  public struct DuplicateOptions: OptionSet, Sendable, Hashable, Codable {
+    /// The raw C options.
+    @_alwaysEmitIntoClient
+    public var rawValue: CInt
+
+    /// Create a strongly-typed options value from raw C options.
+    @_alwaysEmitIntoClient
+    public init(rawValue: CInt) { self.rawValue = rawValue }
+
+#if !os(Windows)
+    /// Indicates that executing a program closes the file.
+    ///
+    /// Normally, file descriptors remain open
+    /// across calls to the `exec(2)` family of functions.
+    /// If you specify this option,
+    /// the file descriptor is closed when replacing this process
+    /// with another process.
+    ///
+    /// The state of the file
+    /// descriptor flags can be inspected using `F_GETFD`,
+    /// as described in the `fcntl(2)` man page.
+    ///
+    /// The corresponding C constant is `O_CLOEXEC`.
+    @_alwaysEmitIntoClient
+    public static var closeOnExec: OpenOptions { .init(rawValue: _O_CLOEXEC) }
+
+    @_alwaysEmitIntoClient
+    @available(*, unavailable, renamed: "closeOnExec")
+    public static var O_CLOEXEC: OpenOptions { closeOnExec }
+
+#if !os(WASI) && !os(Linux) && !os(Android)
+    /// Indicates that forking a program closes the file.
+    ///
+    /// Normally, file descriptors remain open
+    /// across calls to the `fork(2)` function.
+    /// If you specify this option,
+    /// the file descriptor is closed when forking this process
+    /// into another process.
+    ///
+    /// The state of the file
+    /// descriptor flags can be inspected using `F_GETFD`,
+    /// as described in the `fcntl(2)` man page.
+    ///
+    /// The corresponding C constant is `O_CLOFORK`.
+    @_alwaysEmitIntoClient
+    public static var closeOnFork: OpenOptions { .init(rawValue: _O_CLOFORK) }
+
+    @_alwaysEmitIntoClient
+    @available(*, unavailable, renamed: "closeOnFork")
+    public static var O_CLOFORK: OpenOptions { closeOnFork }
+#endif
+#endif
+  }
+
   /// Options for specifying what a file descriptor's offset is relative to.
   @frozen
   @available(System 0.0.1, *)

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -306,12 +306,10 @@ extension FileDescriptor {
     ///
     /// Normally, file descriptors remain open
     /// across calls to the `exec(2)` family of functions.
-    /// If you specify this option,
-    /// the file descriptor is closed when replacing this process
-    /// with another process.
+    /// If you specify this option, the system closes the file
+    /// descriptor when replacing this process with another process.
     ///
-    /// The state of the file
-    /// descriptor flags can be inspected using `F_GETFD`,
+    /// You can inspect the file descriptor flag state using `F_GETFD`,
     /// as described in the `fcntl(2)` man page.
     ///
     /// The corresponding C constant is `O_CLOEXEC`.
@@ -342,8 +340,8 @@ extension FileDescriptor {
     public init(rawValue: CInt) { self.rawValue = rawValue }
 
 #if !os(Windows)
-    /// Indicates that all
-    /// subsequent input and output operations on the pipe's file descriptors will be nonblocking.
+    /// Indicates that all subsequent input and output operations
+    /// on the pipe's file descriptors will be nonblocking.
     ///
     /// The corresponding C constant is `O_NONBLOCK`.
     @_alwaysEmitIntoClient
@@ -357,12 +355,10 @@ extension FileDescriptor {
     ///
     /// Normally, file descriptors remain open
     /// across calls to the `exec(2)` family of functions.
-    /// If you specify this option,
-    /// the file descriptor is closed when replacing this process
-    /// with another process.
+    /// If you specify this option, the system closes the file
+    /// descriptor when replacing this process with another process.
     ///
-    /// The state of the file
-    /// descriptor flags can be inspected using `F_GETFD`,
+    /// You can inspect the file descriptor flag state using `F_GETFD`,
     /// as described in the `fcntl(2)` man page.
     ///
     /// The corresponding C constant is `O_CLOEXEC`.
@@ -378,12 +374,10 @@ extension FileDescriptor {
     ///
     /// Normally, file descriptors remain open
     /// across calls to the `fork(2)` function.
-    /// If you specify this option,
-    /// the file descriptor is closed when forking this process
-    /// into another process.
+    /// If you specify this option, the system closes the file
+    /// descriptor when forking this process into another process.
     ///
-    /// The state of the file
-    /// descriptor flags can be inspected using `F_GETFD`,
+    /// You can inspect the file descriptor flag state using `F_GETFD`,
     /// as described in the `fcntl(2)` man page.
     ///
     /// The corresponding C constant is `O_CLOFORK`.
@@ -419,12 +413,10 @@ extension FileDescriptor {
     ///
     /// Normally, file descriptors remain open
     /// across calls to the `exec(2)` family of functions.
-    /// If you specify this option,
-    /// the file descriptor is closed when replacing this process
-    /// with another process.
+    /// If you specify this option, the system closes the file
+    /// descriptor when replacing this process with another process.
     ///
-    /// The state of the file
-    /// descriptor flags can be inspected using `F_GETFD`,
+    /// You can inspect the file descriptor flag state using `F_GETFD`,
     /// as described in the `fcntl(2)` man page.
     ///
     /// The corresponding C constant is `O_CLOEXEC`.
@@ -440,12 +432,10 @@ extension FileDescriptor {
     ///
     /// Normally, file descriptors remain open
     /// across calls to the `fork(2)` function.
-    /// If you specify this option,
-    /// the file descriptor is closed when forking this process
-    /// into another process.
+    /// If you specify this option, the system closes the file
+    /// descriptor when forking this process into another process.
     ///
-    /// The state of the file
-    /// descriptor flags can be inspected using `F_GETFD`,
+    /// You can inspect the file descriptor flag state using `F_GETFD`,
     /// as described in the `fcntl(2)` man page.
     ///
     /// The corresponding C constant is `O_CLOFORK`.

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2021 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -347,11 +347,11 @@ extension FileDescriptor {
     ///
     /// The corresponding C constant is `O_NONBLOCK`.
     @_alwaysEmitIntoClient
-    public static var nonBlocking: OpenOptions { .init(rawValue: _O_NONBLOCK) }
+    public static var nonBlocking: PipeOptions { .init(rawValue: _O_NONBLOCK) }
 
     @_alwaysEmitIntoClient
     @available(*, unavailable, renamed: "nonBlocking")
-    public static var O_NONBLOCK: OpenOptions { nonBlocking }
+    public static var O_NONBLOCK: PipeOptions { nonBlocking }
 
     /// Indicates that executing a program closes the file.
     ///
@@ -367,11 +367,11 @@ extension FileDescriptor {
     ///
     /// The corresponding C constant is `O_CLOEXEC`.
     @_alwaysEmitIntoClient
-    public static var closeOnExec: OpenOptions { .init(rawValue: _O_CLOEXEC) }
+    public static var closeOnExec: PipeOptions { .init(rawValue: _O_CLOEXEC) }
 
     @_alwaysEmitIntoClient
     @available(*, unavailable, renamed: "closeOnExec")
-    public static var O_CLOEXEC: OpenOptions { closeOnExec }
+    public static var O_CLOEXEC: PipeOptions { closeOnExec }
 
 #if !os(WASI) && !os(Linux) && !os(Android)
     /// Indicates that forking a program closes the file.
@@ -388,11 +388,11 @@ extension FileDescriptor {
     ///
     /// The corresponding C constant is `O_CLOFORK`.
     @_alwaysEmitIntoClient
-    public static var closeOnFork: OpenOptions { .init(rawValue: _O_CLOFORK) }
+    public static var closeOnFork: PipeOptions { .init(rawValue: _O_CLOFORK) }
 
     @_alwaysEmitIntoClient
     @available(*, unavailable, renamed: "closeOnFork")
-    public static var O_CLOFORK: OpenOptions { closeOnFork }
+    public static var O_CLOFORK: PipeOptions { closeOnFork }
 #endif
 #endif
   }
@@ -429,11 +429,11 @@ extension FileDescriptor {
     ///
     /// The corresponding C constant is `O_CLOEXEC`.
     @_alwaysEmitIntoClient
-    public static var closeOnExec: OpenOptions { .init(rawValue: _O_CLOEXEC) }
+    public static var closeOnExec: DuplicateOptions { .init(rawValue: _O_CLOEXEC) }
 
     @_alwaysEmitIntoClient
     @available(*, unavailable, renamed: "closeOnExec")
-    public static var O_CLOEXEC: OpenOptions { closeOnExec }
+    public static var O_CLOEXEC: DuplicateOptions { closeOnExec }
 
 #if !os(WASI) && !os(Linux) && !os(Android)
     /// Indicates that forking a program closes the file.
@@ -450,11 +450,11 @@ extension FileDescriptor {
     ///
     /// The corresponding C constant is `O_CLOFORK`.
     @_alwaysEmitIntoClient
-    public static var closeOnFork: OpenOptions { .init(rawValue: _O_CLOFORK) }
+    public static var closeOnFork: DuplicateOptions { .init(rawValue: _O_CLOFORK) }
 
     @_alwaysEmitIntoClient
     @available(*, unavailable, renamed: "closeOnFork")
-    public static var O_CLOFORK: OpenOptions { closeOnFork }
+    public static var O_CLOFORK: DuplicateOptions { closeOnFork }
 #endif
 #endif
   }

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -432,6 +432,7 @@ extension FileDescriptor {
   ///
   ///
   /// The corresponding C function is `dup3`.
+  @discardableResult
   @_alwaysEmitIntoClient
   @available(Windows, unavailable)
   @available(macOS, unavailable)
@@ -443,7 +444,7 @@ extension FileDescriptor {
     as target: FileDescriptor,
     options: DuplicateOptions,
     retryOnInterrupt: Bool = true
-  ) throws -> FileDescriptor {
+  ) throws(Errno) -> FileDescriptor {
     try _duplicate(as: target, options: options.rawValue, retryOnInterrupt: retryOnInterrupt).get()
   }
 
@@ -514,7 +515,7 @@ extension FileDescriptor {
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   @available(visionOS, unavailable)
-  public static func pipe(options: PipeOptions) throws -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
+  public static func pipe(options: PipeOptions) throws(Errno) -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
     try _pipe(options: options.rawValue).get()
   }
 
@@ -535,7 +536,7 @@ extension FileDescriptor {
 
   @_alwaysEmitIntoClient
   @available(*, unavailable, renamed: "pipe")
-  public func pipe2() throws -> FileDescriptor {
+  public static func pipe2() throws -> FileDescriptor {
     fatalError("Not implemented")
   }
 }

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -403,17 +403,62 @@ extension FileDescriptor {
     as target: FileDescriptor? = nil,
     retryOnInterrupt: Bool = true
   ) throws -> FileDescriptor {
-    try _duplicate(as: target, retryOnInterrupt: retryOnInterrupt).get()
+    try _duplicate(as: target, options: 0, retryOnInterrupt: retryOnInterrupt).get()
+  }
+
+  /// Duplicates this file descriptor and return the newly created copy.
+  ///
+  /// - Parameters:
+  ///   - `target`: The desired target file descriptor.
+  ///   - `options`: The behavior for creating the target file descriptor.
+  ///   - retryOnInterrupt: Whether to retry the write operation
+  ///      if it throws ``Errno/interrupted``. The default is `true`.
+  ///      Pass `false` to try only once and throw an error upon interruption.
+  /// - Returns: The new file descriptor.
+  ///
+  /// If the `target` descriptor is already in use, then it is first
+  /// deallocated as if a close(2) call had been done first.
+  ///
+  /// File descriptors are merely references to some underlying system resource.
+  /// The system does not distinguish between the original and the new file
+  /// descriptor in any way. For example, read, write and seek operations on
+  /// one of them also affect the logical file position in the other, and
+  /// append mode, non-blocking I/O and asynchronous I/O options are shared
+  /// between the references. If a separate pointer into the file is desired,
+  /// a different object reference to the file must be obtained by issuing an
+  /// additional call to `open`.
+  ///
+  /// However, each file descriptor maintains its own close-on-exec flag.
+  ///
+  ///
+  /// The corresponding C function is `dup3`.
+  @_alwaysEmitIntoClient
+  @available(Windows, unavailable)
+  @available(macOS, unavailable)
+  @available(iOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  @available(visionOS, unavailable)
+  public func duplicate(
+    as target: FileDescriptor,
+    options: DuplicateOptions,
+    retryOnInterrupt: Bool = true
+  ) throws -> FileDescriptor {
+    try _duplicate(as: target, options: options.rawValue, retryOnInterrupt: retryOnInterrupt).get()
   }
 
   @available(System 0.0.2, *)
   @usableFromInline
   internal func _duplicate(
     as target: FileDescriptor?,
+    options: Int32,
     retryOnInterrupt: Bool
   ) throws -> Result<FileDescriptor, Errno> {
     valueOrErrno(retryOnInterrupt: retryOnInterrupt) {
       if let target = target {
+        if options != 0 {
+          return system_dup3(self.rawValue, target.rawValue, options)
+        }
         return system_dup2(self.rawValue, target.rawValue)
       }
       return system_dup(self.rawValue)
@@ -431,6 +476,12 @@ extension FileDescriptor {
   public func dup2() throws -> FileDescriptor {
     fatalError("Not implemented")
   }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "duplicate")
+  public func dup3() throws -> FileDescriptor {
+    fatalError("Not implemented")
+  }
 }
 #endif
 
@@ -445,20 +496,47 @@ extension FileDescriptor {
   @_alwaysEmitIntoClient
   @available(System 1.1.0, *)
   public static func pipe() throws -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
-    try _pipe().get()
+    try _pipe(options: 0).get()
   }
 
-  @available(System 1.1.0, *)
+  /// Creates a unidirectional data channel, which can be used for interprocess communication.
+  ///
+  /// - Parameters:
+  ///   - options: The behavior for creating the pipe.
+  ///
+  /// - Returns: The pair of file descriptors.
+  ///
+  /// The corresponding C function is `pipe2`.
+  @_alwaysEmitIntoClient
+  @available(Windows, unavailable)
+  @available(macOS, unavailable)
+  @available(iOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  @available(visionOS, unavailable)
+  public static func pipe(options: PipeOptions) throws -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
+    try _pipe(options: options.rawValue).get()
+  }
+
   @usableFromInline
-  internal static func _pipe() -> Result<(readEnd: FileDescriptor, writeEnd: FileDescriptor), Errno> {
+  internal static func _pipe(options: Int32) -> Result<(readEnd: FileDescriptor, writeEnd: FileDescriptor), Errno> {
     var fds: (Int32, Int32) = (-1, -1)
     return withUnsafeMutablePointer(to: &fds) { pointer in
       pointer.withMemoryRebound(to: Int32.self, capacity: 2) { fds in
         valueOrErrno(retryOnInterrupt: false) {
-          system_pipe(fds)
+          if options != 0 {
+            return system_pipe2(fds, options)
+          }
+          return system_pipe(fds)
         }.map { _ in (.init(rawValue: fds[0]), .init(rawValue: fds[1])) }
       }
     }
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "pipe")
+  public func pipe2() throws -> FileDescriptor {
+    fatalError("Not implemented")
   }
 }
 #endif

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2025 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -395,7 +395,6 @@ extension FileDescriptor {
   ///
   /// However, each file descriptor maintains its own close-on-exec flag.
   ///
-  ///
   /// The corresponding C functions are `dup` and `dup2`.
   @_alwaysEmitIntoClient
   @available(System 0.0.2, *)
@@ -403,7 +402,7 @@ extension FileDescriptor {
     as target: FileDescriptor? = nil,
     retryOnInterrupt: Bool = true
   ) throws -> FileDescriptor {
-    try _duplicate(as: target, options: 0, retryOnInterrupt: retryOnInterrupt).get()
+    try _duplicate(as: target, retryOnInterrupt: retryOnInterrupt).get()
   }
 
   /// Duplicate this file descriptor and return the newly created copy.
@@ -452,17 +451,31 @@ extension FileDescriptor {
   @usableFromInline
   internal func _duplicate(
     as target: FileDescriptor?,
+    retryOnInterrupt: Bool
+  ) -> Result<FileDescriptor, Errno> {
+    valueOrErrno(retryOnInterrupt: retryOnInterrupt) {
+      if let target {
+        system_dup2(self.rawValue, target.rawValue)
+      } else {
+        system_dup(self.rawValue)
+      }
+    }.map(FileDescriptor.init(rawValue:))
+  }
+
+  @available(Windows, unavailable)
+  @available(macOS, unavailable)
+  @available(iOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  @available(visionOS, unavailable)
+  @usableFromInline
+  internal func _duplicate(
+    as target: FileDescriptor,
     options: Int32,
     retryOnInterrupt: Bool
-  ) throws -> Result<FileDescriptor, Errno> {
+  ) -> Result<FileDescriptor, Errno> {
     valueOrErrno(retryOnInterrupt: retryOnInterrupt) {
-      if let target = target {
-        if options != 0 {
-          return system_dup3(self.rawValue, target.rawValue, options)
-        }
-        return system_dup2(self.rawValue, target.rawValue)
-      }
-      return system_dup(self.rawValue)
+      system_dup3(self.rawValue, target.rawValue, options)
     }.map(FileDescriptor.init(rawValue:))
   }
 
@@ -496,8 +509,9 @@ extension FileDescriptor {
   /// The corresponding C function is `pipe`.
   @_alwaysEmitIntoClient
   @available(System 1.1.0, *)
-  public static func pipe() throws -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
-    try _pipe(options: 0).get()
+  public static func pipe(
+  ) throws -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
+    try _pipe().get()
   }
 
   /// Creates a unidirectional data channel, which can be used for
@@ -516,20 +530,41 @@ extension FileDescriptor {
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   @available(visionOS, unavailable)
-  public static func pipe(options: PipeOptions) throws(Errno) -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
+  public static func pipe(
+    options: PipeOptions
+  ) throws(Errno) -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
     try _pipe(options: options.rawValue).get()
   }
 
+  @available(System 1.1.0, *)
   @usableFromInline
-  internal static func _pipe(options: Int32) -> Result<(readEnd: FileDescriptor, writeEnd: FileDescriptor), Errno> {
+  internal static func _pipe(
+  ) -> Result<(readEnd: FileDescriptor, writeEnd: FileDescriptor), Errno> {
     var fds: (Int32, Int32) = (-1, -1)
     return withUnsafeMutablePointer(to: &fds) { pointer in
       pointer.withMemoryRebound(to: Int32.self, capacity: 2) { fds in
         valueOrErrno(retryOnInterrupt: false) {
-          if options != 0 {
-            return system_pipe2(fds, options)
-          }
-          return system_pipe(fds)
+          system_pipe(fds)
+        }.map { _ in (.init(rawValue: fds[0]), .init(rawValue: fds[1])) }
+      }
+    }
+  }
+
+  @available(Windows, unavailable)
+  @available(macOS, unavailable)
+  @available(iOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  @available(visionOS, unavailable)
+  @usableFromInline
+  internal static func _pipe(
+    options: Int32,
+  ) -> Result<(readEnd: FileDescriptor, writeEnd: FileDescriptor), Errno> {
+    var fds: (Int32, Int32) = (-1, -1)
+    return withUnsafeMutablePointer(to: &fds) { pointer in
+      pointer.withMemoryRebound(to: Int32.self, capacity: 2) { fds in
+        valueOrErrno(retryOnInterrupt: false) {
+          system_pipe2(fds, options)
         }.map { _ in (.init(rawValue: fds[0]), .init(rawValue: fds[1])) }
       }
     }

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -406,12 +406,12 @@ extension FileDescriptor {
     try _duplicate(as: target, options: 0, retryOnInterrupt: retryOnInterrupt).get()
   }
 
-  /// Duplicates this file descriptor and return the newly created copy.
+  /// Duplicate this file descriptor and return the newly created copy.
   ///
   /// - Parameters:
-  ///   - `target`: The desired target file descriptor.
-  ///   - `options`: The behavior for creating the target file descriptor.
-  ///   - retryOnInterrupt: Whether to retry the write operation
+  ///   - target: The desired target file descriptor.
+  ///   - options: The behavior for creating the target file descriptor.
+  ///   - retryOnInterrupt: Whether to retry the operation
   ///      if it throws ``Errno/interrupted``. The default is `true`.
   ///      Pass `false` to try only once and throw an error upon interruption.
   /// - Returns: The new file descriptor.
@@ -428,8 +428,8 @@ extension FileDescriptor {
   /// a different object reference to the file must be obtained by issuing an
   /// additional call to `open`.
   ///
-  /// However, each file descriptor maintains its own close-on-exec flag.
-  ///
+  /// However, each file descriptor maintains its own close-on-exec and
+  /// close-on-fork flags.
   ///
   /// The corresponding C function is `dup3`.
   @discardableResult
@@ -500,7 +500,8 @@ extension FileDescriptor {
     try _pipe(options: 0).get()
   }
 
-  /// Creates a unidirectional data channel, which can be used for interprocess communication.
+  /// Creates a unidirectional data channel, which can be used for
+  /// interprocess communication.
   ///
   /// - Parameters:
   ///   - options: The behavior for creating the pipe.

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -622,6 +622,15 @@ internal var _O_SYMLINK: CInt { O_SYMLINK }
 #if !os(Windows)
 @_alwaysEmitIntoClient
 internal var _O_CLOEXEC: CInt { O_CLOEXEC }
+
+@_alwaysEmitIntoClient
+internal var _O_CLOFORK: CInt {
+  #if !os(WASI) && !os(Linux) && !os(Android) && !canImport(Darwin)
+  O_CLOFORK
+  #else
+  0
+  #endif
+}
 #endif
 
 @_alwaysEmitIntoClient

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2025 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
This follows the existing pattern of wrapping dup/dup2 and pipe with FileDescriptor.duplicate and FileDescriptor.pipe, with additional overloads for passing the O_CLOEXEC and similar flags.

Forums pitch: https://forums.swift.org/t/pitch-swiftsystem-dup3-and-pipe2-cover-apis/

Addresses: https://github.com/apple/swift-system/issues/228