### PR TITLE
[CI] Enable Android SDK build in swift-system

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,7 +58,7 @@ jobs:
       enable_linux_checks: false
       enable_macos_checks: true
       enable_windows_checks: false
-      enable_android_sdk_build: true
+      enable_android_sdk_build: false
       # Only build
       macos_build_command: "xcrun swift build --build-tests"
       macos_exclude_xcode_versions: '[]'


### PR DESCRIPTION
Now that `swiftlang/github-workflows` supports building with the Swift SDK for Android in https://github.com/swiftlang/github-workflows/pull/172, we can enable the job in swift-system to prevent Android build regressions.

Other projects have recently added Android CI at https://github.com/swiftlang/swift-foundation/pull/1566, https://github.com/swiftlang/swift-testing/pull/1382, https://github.com/swiftlang/swift-subprocess/pull/202, and https://github.com/swiftlang/swift-toolchain-sqlite/pull/23.