### PR TITLE
Update Android followSymlinkInits to handle sizeAllocated

### DIFF
--- a/Tests/SystemTests/StatTests.swift
+++ b/Tests/SystemTests/StatTests.swift
@@ -118,7 +118,12 @@ private struct StatTests {
       #expect(targetStat.type == .regular)
       #expect(symlinkStat.type == .symbolicLink)
       #expect(symlinkStat.size < targetStat.size)
+
+      #if os(Android)
+      #expect(symlinkStat.sizeAllocated <= targetStat.sizeAllocated)
+      #else
       #expect(symlinkStat.sizeAllocated < targetStat.sizeAllocated)
+      #endif
 
       // Set each .st_atim back to its original value for comparison
 


### PR DESCRIPTION
`followSymlinkInits` is failing on an Android emulator (API 28 and 35). See https://github.com/swift-android-sdk/swift-android-sdk-workflow-demo/actions/runs/20010192707/job/57378485958#step:22:1657 :

```
Test followSymlinkInits() recorded an issue at StatTests.swift:121:7: Expectation failed: (symlinkStat.sizeAllocated → 8192) < (targetStat.sizeAllocated → 8192)
```

I can also reproduce it locally with `skip android test`.

I *believe* this is a known limitation of symbolic links on Android.

Note that the Android CI in https://github.com/swiftlang/github-workflows only builds and doesn't (yet) test, so this wasn't caught in the checks that were added in https://github.com/apple/swift-system/pull/270.

