### PR TITLE
Require Swift 6.1

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,6 +19,7 @@ jobs:
         [
           {"swift_version": "5.9"},
           {"swift_version": "5.10"},
+          {"swift_version": "6.0"},
           {"os_version": "focal", "swift_version": "nightly-6.2"},
           {"os_version": "focal", "swift_version": "6.2"},
           {"os_version": "focal", "swift_version": "nightly-6.3"},
@@ -31,7 +32,8 @@ jobs:
       windows_exclude_swift_versions: |
         [
           {"swift_version": "5.9"},
-          {"swift_version": "5.10"}
+          {"swift_version": "5.10"},
+          {"swift_version": "6.0"},
         ]
       enable_linux_static_sdk_build: true
       linux_static_sdk_exclude_swift_versions: |

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift System open source project
@@ -142,5 +142,5 @@ let package = Package(
       cSettings: cSettings,
       swiftSettings: swiftSettings),
   ],
-  swiftLanguageVersions: [.v5]
+  swiftLanguageModes: [.v5]
 )


### PR DESCRIPTION
Whenever we determine that our next minor version will be cut after the release of Swift 6.3, then we should merge this.