### PR TITLE
[ci] re-allow 5.9 and 5.10 for 1.6.x

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,8 +17,8 @@ jobs:
       linux_os_versions: '["noble", "jammy", "focal"]'
       linux_exclude_swift_versions: |
         [
-          {"swift_version": "5.9"},
-          {"swift_version": "5.10"},
+          {"os_version": "noble", "swift_version": "5.9"},
+          {"os_version": "noble", "swift_version": "5.10"},
           {"os_version": "focal", "swift_version": "nightly-6.2"},
           {"os_version": "focal", "swift_version": "6.2"},
           {"os_version": "focal", "swift_version": "nightly-6.3"},


### PR DESCRIPTION
Allow 5.9 and 5.10 tests for distributions where they work. They were excluded in error.