### PR TITLE
[Windows] Fix HRESULT_FACILITY

### DIFF
--- a/Sources/System/FilePath/FilePathWindows.swift
+++ b/Sources/System/FilePath/FilePathWindows.swift
@@ -517,7 +517,7 @@ fileprivate func HRESULT_CODE(_ hr: HRESULT) -> DWORD {
 
 @inline(__always)
 fileprivate func HRESULT_FACILITY(_ hr: HRESULT) -> DWORD {
-    DWORD(hr << 16) & 0x1fff
+    DWORD(hr >> 16) & 0x1fff
 }
 
 @inline(__always)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-system/pull/275 by @AZero13

`HRESULT_FACILITY` is `>> 16 & 0x1fff`, not `<<`