### PR TITLE
[Windows] fix pread/pwrite truncation

### DIFF
--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -160,7 +160,7 @@ public struct Errno: RawRepresentable, Error, Hashable, Codable {
   /// No child processes.
   ///
   /// A `wait(2)` or `waitpid(2)` function was executed
-  /// by a process that dosn't have any existing child processes
+  /// by a process that doesn't have any existing child processes
   /// or whose child processes are all already being waited for.
   ///
   /// The corresponding C error is `ECHILD`.

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -149,6 +149,12 @@ internal func pread(
   let handle: intptr_t = _get_osfhandle(fd)
   if handle == /* INVALID_HANDLE_VALUE */ -1 { ucrt._set_errno(EBADF); return -1 }
 
+  // Windows ReadFile accepts DWORD (32-bit) for buffer size, so validate nbyte doesn't exceed it
+  if nbyte > Int(DWORD.max) {
+    ucrt._set_errno(EINVAL)
+    return -1
+  }
+
   // NOTE: this is a non-owning handle, do *not* call CloseHandle on it
   let hFile: HANDLE = HANDLE(bitPattern: handle)!
 
@@ -170,6 +176,12 @@ internal func pwrite(
 ) -> Int {
   let handle: intptr_t = _get_osfhandle(fd)
   if handle == /* INVALID_HANDLE_VALUE */ -1 { ucrt._set_errno(EBADF); return -1 }
+
+  // Windows WriteFile accepts DWORD (32-bit) for buffer size, so validate nbyte doesn't exceed it
+  if nbyte > Int(DWORD.max) {
+    ucrt._set_errno(EINVAL)
+    return -1
+  }
 
   // NOTE: this is a non-owning handle, do *not* call CloseHandle on it
   let hFile: HANDLE = HANDLE(bitPattern: handle)!


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-system/pull/279 by [**@mairinkdev**](https://github.com/mairinkdev).

Validate buffer length inputs to avoid silent truncation in the `pread` and `pwrite` adaptors for Windows.