### PR TITLE
Fix FreeBSD build

### DIFF
--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -692,9 +692,12 @@ internal var _S_IFLNK: mode_t { S_IFLNK }
 @_alwaysEmitIntoClient
 internal var _S_IFSOCK: mode_t { S_IFSOCK }
 
-#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
+#if SYSTEM_PACKAGE_DARWIN
 @_alwaysEmitIntoClient
 internal var _S_IFWHT: mode_t { S_IFWHT }
+#elseif os(FreeBSD)
+@_alwaysEmitIntoClient
+internal var _S_IFWHT: mode_t { .init(S_IFWHT) }
 #endif
 
 // MARK: - stat/chflags File Flags

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -692,10 +692,8 @@ internal var _S_IFLNK: mode_t { S_IFLNK }
 @_alwaysEmitIntoClient
 internal var _S_IFSOCK: mode_t { S_IFSOCK }
 
-#if SYSTEM_PACKAGE_DARWIN
-@_alwaysEmitIntoClient
-internal var _S_IFWHT: mode_t { S_IFWHT }
-#elseif os(FreeBSD)
+#if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
+// `S_IFWHT` is `Int32` on FreeBSD.
 @_alwaysEmitIntoClient
 internal var _S_IFWHT: mode_t { .init(S_IFWHT) }
 #endif

--- a/Tests/SystemTests/StatTests.swift
+++ b/Tests/SystemTests/StatTests.swift
@@ -381,13 +381,15 @@ private struct StatTests {
       #endif
 
       flags.insert(userSettableFlags)
-      try #require(fchflags(fd.rawValue, flags.rawValue) == 0, "\(Errno.current)")
+      // On FreeBSD, the second argument of `fchflags` requires `UInt` instead of`UInt32`.
+      try #require(fchflags(fd.rawValue, .init(flags.rawValue)) == 0, "\(Errno.current)")
 
       stat = try fd.stat()
       #expect(stat.flags == flags)
 
       flags.remove(userSettableFlags)
-      try #require(fchflags(fd.rawValue, flags.rawValue) == 0, "\(Errno.current)")
+      // On FreeBSD, the second argument of `fchflags` requires `UInt` instead of`UInt32`.
+      try #require(fchflags(fd.rawValue, .init(flags.rawValue)) == 0, "\(Errno.current)")
 
       stat = try fd.stat()
       #expect(stat.flags == flags)
@@ -413,12 +415,5 @@ private func > (lhs: timespec, rhs: timespec) -> Bool {
 private func == (lhs: timespec, rhs: timespec) -> Bool {
   lhs.tv_sec == rhs.tv_sec && lhs.tv_nsec == rhs.tv_nsec
 }
-
-#if os(FreeBSD)
-// Helper functions for FreeBSD
-private func fchflags(_ fd: CInt, _ flags: CInterop.FileFlags) -> CInt {
-  fchflags(fd, UInt(flags))
-}
-#endif
 
 #endif

--- a/Tests/SystemTests/StatTests.swift
+++ b/Tests/SystemTests/StatTests.swift
@@ -118,11 +118,7 @@ private struct StatTests {
       #expect(targetStat.type == .regular)
       #expect(symlinkStat.type == .symbolicLink)
       #expect(symlinkStat.size < targetStat.size)
-      #if os(FreeBSD)
       #expect(symlinkStat.sizeAllocated <= targetStat.sizeAllocated)
-      #else
-      #expect(symlinkStat.sizeAllocated < targetStat.sizeAllocated)
-      #endif
 
       // Set each .st_atim back to its original value for comparison
 

--- a/Tests/SystemTests/StatTests.swift
+++ b/Tests/SystemTests/StatTests.swift
@@ -385,13 +385,13 @@ private struct StatTests {
       #endif
 
       flags.insert(userSettableFlags)
-      try #require(fchflags(fd.rawValue, UInt(flags.rawValue)) == 0, "\(Errno.current)")
+      try #require(fchflags(fd.rawValue, flags.rawValue) == 0, "\(Errno.current)")
 
       stat = try fd.stat()
       #expect(stat.flags == flags)
 
       flags.remove(userSettableFlags)
-      try #require(fchflags(fd.rawValue, UInt(flags.rawValue)) == 0, "\(Errno.current)")
+      try #require(fchflags(fd.rawValue, flags.rawValue) == 0, "\(Errno.current)")
 
       stat = try fd.stat()
       #expect(stat.flags == flags)
@@ -417,5 +417,12 @@ private func > (lhs: timespec, rhs: timespec) -> Bool {
 private func == (lhs: timespec, rhs: timespec) -> Bool {
   lhs.tv_sec == rhs.tv_sec && lhs.tv_nsec == rhs.tv_nsec
 }
+
+#if os(FreeBSD)
+// Helper functions for FreeBSD
+private func fchflags(_ fd: CInt, _ flags: CInterop.FileFlags) -> CInt {
+  fchflags(fd, UInt(flags))
+}
+#endif
 
 #endif


### PR DESCRIPTION
fixes #294, fixes #295

This PR fixes `swift build` and `swift test` on FreeBSD.

```console
$ swift build
[1/1] Planning build
Building for debugging...
[1/1] Write swift-version-2B7A02F0DA2902A5.txt
Build complete! (0.14s)
$ swift test
Building for debugging...                                                                                                                                                              
[5/5] Compiling SystemTests StatTests.swift                                                                                                                                            
Build complete! (1.84s)                                                                                                                                                                
Test Suite 'All tests' started at 2026-01-28 00:02:35.756                                                                                                                              
Test Suite 'debug.xctest' started at 2026-01-28 00:02:35.758
...
Test Suite 'debug.xctest' passed at 2026-01-28 00:02:37.857
         Executed 52 tests, with 0 failures (0 unexpected) in 2.099 (2.099) seconds
Test Suite 'All tests' passed at 2026-01-28 00:02:37.857
         Executed 52 tests, with 0 failures (0 unexpected) in 2.099 (2.099) seconds
◇ Test run started.
↳ Testing Library Version: 6.3-dev (98430f2d6cb8d81)
↳ Target Platform: x86_64-unknown-freebsd
◇ Suite "Stat" started.
◇ Suite "FileMode" started.
◇ Test basics() started.
◇ Test times() started.
◇ Test permissions() started.
◇ Test followSymlinkInits() started.
◇ Test invalidInput() started.
◇ Test basics() started.
◇ Test flags() started.
✔ Test invalidInput() passed after 0.001 seconds.
✔ Test basics() passed after 0.001 seconds.
✔ Suite "FileMode" passed after 0.001 seconds.
✔ Test flags() passed after 0.003 seconds.
✔ Test basics() passed after 0.004 seconds.
✔ Test permissions() passed after 0.004 seconds.
✔ Test followSymlinkInits() passed after 0.004 seconds.
✔ Test times() passed after 0.043 seconds.
✔ Suite "Stat" passed after 0.044 seconds.
✔ Test run with 7 tests in 2 suites passed after 0.044 seconds.
```

Environment:

```console
$ uname -a
FreeBSD Coconut-rhinoceros-beetle 15.0-RELEASE-p1 FreeBSD 15.0-RELEASE-p1 releng/15.0-n280999-7bceec30b351 GENERIC amd64
$ swift --version
Swift version 6.3-dev (LLVM b58b2a34d509492, Swift cf535d8b998d09b)
Target: x86_64-unknown-freebsd14.3
Build config: +assertions
```

Swift toolchain is from [forums.swift.org/t/swift-on-freebsd-preview/83064](https://forums.swift.org/t/swift-on-freebsd-preview/83064).