### PR TITLE
[Implementation] Back-deploy CInterop.stat for Migration Compatibility

### DIFF
--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -81,9 +81,33 @@ public enum CInterop {
 }
 
 #if !os(Windows)
+@available(System 0.0.2, *) // Original availability of CInterop
+extension CInterop {
+  /// The C `stat` struct.
+  public typealias Stat = stat
+
+  /// Calls the C `stat()` function.
+  ///
+  /// This is a direct wrapper around the C `stat()` system call.
+  /// For a more ergonomic Swift API, use `Stat` instead.
+  ///
+  /// - Warning: This API is primarily intended for migration purposes when
+  ///   supporting older deployment targets. If your deployment target supports
+  ///   it, prefer using the `Stat` API introduced in SYS-0006, which provides
+  ///   type-safe, ergonomic access to file metadata in Swift.
+  ///
+  /// - Parameters:
+  ///   - path: A null-terminated C string representing the file path.
+  ///   - s: An `inout` reference to a `CInterop.Stat` struct to populate.
+  /// - Returns: 0 on success, -1 on error (check `Errno.current`).
+  @_alwaysEmitIntoClient
+  public static func stat(_ path: UnsafePointer<CChar>, _ s: inout CInterop.Stat) -> Int32 {
+    system_stat(path, &s)
+  }
+}
+
 @available(System 99, *)
 extension CInterop {
-  public typealias Stat = stat
   public typealias DeviceID = dev_t
   public typealias Inode = ino_t
   public typealias UserID = uid_t

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -91,7 +91,8 @@ internal func system_strlen(_ s: UnsafeMutablePointer<CChar>) -> Int {
 }
 
 #if !os(Windows)
-@available(System 99, *)
+@available(System 0.0.2, *)
+@_alwaysEmitIntoClient
 internal func system_stat(_ p: UnsafePointer<CChar>, _ s: inout CInterop.Stat) -> Int32 {
   stat(p, &s)
 }


### PR DESCRIPTION
This PR back-deploys `CInterop.stat(_:_:)` and `CInterop.Stat` to the original `CInterop` availability to help developer migration in rare cases where `FilePath.stat()` and `FileDescriptor.stat()` conflict with existing usage of unqualified `stat()` in extensions of those types.

See the pitch at: https://forums.swift.org/t/pitch-back-deploy-system-cinterop-stat-for-migration-compatibility/84930
See the full proposal in #298