### PR TITLE
Fix typo: remove extra space after comma

### DIFF
--- a/Proposals/0006-system-stat.md
+++ b/Proposals/0006-system-stat.md
@@ -417,7 +417,7 @@ public struct FileFlags: OptionSet, Sendable, Hashable, Codable {
 
 ### Stat
 
-`Stat` can be initialized from a `FilePath`, `UnsafePointer<CChar>`,  or `FileDescriptor`. This proposal also includes functions on `FileDescriptor` and `FilePath` for creating a `Stat` object, seen in the section below.
+`Stat` can be initialized from a `FilePath`, `UnsafePointer<CChar>`, or `FileDescriptor`. This proposal also includes functions on `FileDescriptor` and `FilePath` for creating a `Stat` object, seen in the section below.
 
 The initializer accepting a `FileDescriptor` corresponds to `fstat()`. If the file descriptor points to a symlink, this will return information about the symlink itself.
 


### PR DESCRIPTION
Cherry-picked from commit 9ddcf9a0515a557f2efd6d7be77124127e94615f
Originally in https://github.com/apple/swift-system/pull/300