### PR TITLE
Preserve leading `..` for drive-relative paths during lexical normalization

### DIFF
--- a/Sources/System/FilePath/FilePathParsing.swift
+++ b/Sources/System/FilePath/FilePathParsing.swift
@@ -132,7 +132,11 @@ extension FilePath {
     defer { assert(isLexicallyNormal) }
 
     let relStart = _relativeStart
-    let hasRoot = relStart != _storage.startIndex
+
+    // Whether a leading `..` collapses against a fixed root. A traditional
+    // drive-relative root such as `C:` does not anchor leading `..`, so those
+    // are preserved exactly as for a rootless relative path.
+    let rootAnchorsLeadingParents = _rootAnchorsLeadingParents
 
     // TODO: all this logic might be nicer if _parseComponent considered
     // the null character index to be the next start...
@@ -153,8 +157,8 @@ extension FilePath {
       // otherwise parse-back a component to remove the parent (but stop at
       // root).
       if _isParentDirectory(component) {
-        // Skip over it if we're at the root
-        if hasRoot && writeIdx == relStart {
+        // Skip over it if it collapses against a fixed root
+        if rootAnchorsLeadingParents && writeIdx == relStart {
           readIdx = nextStart
           continue
         }
@@ -168,7 +172,7 @@ extension FilePath {
             readIdx = nextStart
             continue
           }
-          assert(self.root == nil && self.components.first!.kind == .parentDirectory)
+          assert(!rootAnchorsLeadingParents && self.components.first!.kind == .parentDirectory)
         }
       }
 
@@ -204,6 +208,16 @@ extension FilePath {
   }
   internal var _hasRoot: Bool {
     _relativeStart != _storage.startIndex
+  }
+
+  // Whether a leading `..` component refers to the parent of a fixed anchor
+  // (and therefore collapses during lexical normalization), as opposed to
+  // being preserved. This is true when the path has a root, unless that root
+  // is a traditional drive-relative root such as `C:`, which anchors to the
+  // drive's current directory rather than to a fixed location.
+  internal var _rootAnchorsLeadingParents: Bool {
+    guard let root = self.root else { return false }
+    return !root._isTraditionalDriveRelative
   }
 }
 
@@ -320,6 +334,21 @@ extension FilePath.Root {
       (slice.count == 1 && slice.first == .backslash) ||
         (slice.count == 2 && slice.last == .colon))
     return false
+  }
+
+  // Whether this is a traditional drive-relative root, i.e. `X:` with no
+  // trailing separator.
+  //
+  // Such a root anchors the path to the current working directory *on* the
+  // named drive rather than to a fixed directory, so a leading `..` is
+  // meaningful and must not be collapsed during lexical normalization
+  // (`C:..` is the parent of the drive's current directory). This is unlike
+  // `\` and `C:\`, where a leading `..` refers to the parent of a fixed root
+  // and collapses to the root itself.
+  internal var _isTraditionalDriveRelative: Bool {
+    guard _windowsPaths else { return false }
+    let slice = self._slice
+    return slice.count == 2 && slice.last == .colon
   }
 }
 

--- a/Sources/System/FilePath/FilePathSyntax.swift
+++ b/Sources/System/FilePath/FilePathSyntax.swift
@@ -360,13 +360,14 @@ extension FilePath {
   /// * `"../local/bin".isLexicallyNormal   == true`
   /// * `"local/bin/..".isLexicallyNormal   == false`
   public var isLexicallyNormal: Bool {
-    // `..` components are permitted at the front of a
-    // relative path, otherwise there should be no special directories
-    //
-    // FIXME: Windows `C:..\foo\bar` should probably be lexically normal, but
-    // `\..\foo\bar` should not.
-    components.drop(
-      while: { root == nil && $0.kind == .parentDirectory }
+    // `..` components are permitted at the front of a path that is not anchored
+    // to a fixed root, otherwise there should be no special directories. On
+    // Windows, a traditional drive-relative root such as `C:` does not anchor
+    // leading `..` (e.g. `C:..\foo\bar` is lexically normal), whereas a rooted
+    // path such as `\..\foo\bar` is not.
+    let preservesLeadingParents = !_rootAnchorsLeadingParents
+    return components.drop(
+      while: { preservesLeadingParents && $0.kind == .parentDirectory }
     ).allSatisfy { $0.kind == .regular }
   }
 

--- a/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
@@ -651,7 +651,86 @@ final class FilePathSyntaxTest: XCTestCase {
         root: #"C:"#, relative: #"foo\bar\..\..\.."#,
         dirname: #"C:foo\bar\..\.."#, basename: "..",
         components: ["foo", "bar", "..", "..", ".."],
-        lexicallyNormalized: "C:"
+        // `C:` is drive-relative, so the `..` that escapes the relative
+        // portion is preserved rather than collapsed against the root.
+        lexicallyNormalized: #"C:.."#
+      ),
+
+      // A `..` at the front of a drive-relative path refers to the parent of
+      // the drive's current directory, so it is preserved during lexical
+      // normalization (unlike a `..` at the front of a rooted `\` path).
+      .windows(
+        #"C:.."#,
+        absolute: false,
+        root: #"C:"#, relative: #".."#,
+        dirname: #"C:"#, basename: "..",
+        components: [".."],
+        lexicallyNormalized: #"C:.."#
+      ),
+
+      .windows(
+        #"C:..\foo\bar"#,
+        absolute: false,
+        root: #"C:"#, relative: #"..\foo\bar"#,
+        dirname: #"C:..\foo"#, basename: "bar",
+        components: ["..", "foo", "bar"],
+        lexicallyNormalized: #"C:..\foo\bar"#
+      ),
+
+      .windows(
+        #"C:..\..\foo"#,
+        absolute: false,
+        root: #"C:"#, relative: #"..\..\foo"#,
+        dirname: #"C:..\.."#, basename: "foo",
+        components: ["..", "..", "foo"],
+        lexicallyNormalized: #"C:..\..\foo"#
+      ),
+
+      .windows(
+        #"C:foo\..\..\bar"#,
+        absolute: false,
+        root: #"C:"#, relative: #"foo\..\..\bar"#,
+        dirname: #"C:foo\..\.."#, basename: "bar",
+        components: ["foo", "..", "..", "bar"],
+        lexicallyNormalized: #"C:..\bar"#
+      ),
+
+      .windows(
+        #"C:.\..\foo"#,
+        absolute: false,
+        root: #"C:"#, relative: #".\..\foo"#,
+        dirname: #"C:.\.."#, basename: "foo",
+        components: [".", "..", "foo"],
+        lexicallyNormalized: #"C:..\foo"#
+      ),
+
+      .windows(
+        #"C:..\.\..\bar"#,
+        absolute: false,
+        root: #"C:"#, relative: #"..\.\..\bar"#,
+        dirname: #"C:..\.\.."#, basename: "bar",
+        components: ["..", ".", "..", "bar"],
+        lexicallyNormalized: #"C:..\..\bar"#
+      ),
+
+      // In contrast, `\` anchors to the root of the current drive, so a
+      // leading `..` collapses against it rather than being preserved.
+      .windows(
+        #"\..\foo\bar"#,
+        absolute: false,
+        root: #"\"#, relative: #"..\foo\bar"#,
+        dirname: #"\..\foo"#, basename: "bar",
+        components: ["..", "foo", "bar"],
+        lexicallyNormalized: #"\foo\bar"#
+      ),
+
+      .windows(
+        #"\..\..\foo"#,
+        absolute: false,
+        root: #"\"#, relative: #"..\..\foo"#,
+        dirname: #"\..\.."#, basename: "foo",
+        components: ["..", "..", "foo"],
+        lexicallyNormalized: #"\foo"#
       ),
 
       .windows(


### PR DESCRIPTION
On Windows, a traditional drive-relative root like `C:` anchors a path to the current working directory *on* the named drive, not to a fixed location. That makes a leading `..` meaningful: `C:..` is the parent of the drive's current directory, which is generally not the root of the drive. `lexicallyNormalize()` was treating any root as a fixed anchor and collapsing leading `..` against it, so it silently changed the meaning of drive-relative paths:

```swift
FilePath(#"C:..\foo\bar"#).lexicallyNormalized()    // produced C:foo\bar
FilePath(#"C:..\..\foo"#).lexicallyNormalized()     // produced C:foo
FilePath(#"C:foo\..\..\bar"#).lexicallyNormalized() // produced C:bar
```

In each case a `..` that escapes the relative portion was dropped, which loses information.

The root cause is in `_normalizeSpecialDirectories`: the branch that skips a leading `..` fired whenever the path had a root (`hasRoot && writeIdx == relStart`). That is correct for fixed anchors (`/` on Unix, and `\`, `C:\`, UNC and device roots on Windows, where `..` at the front refers to the parent of the root and collapses to the root), but it is wrong for the drive-relative `C:` form, where the `..` has to be kept just like a leading `..` on a rootless relative path.

The fix distinguishes the two cases. A new internal `Root._isTraditionalDriveRelative` identifies the `X:` form (a two-character root ending in `:`, which the existing `isAbsolute` logic already treats as the only colon-terminated relative root). Normalization now preserves a leading `..` exactly when the root, if any, is drive-relative. `isLexicallyNormal` is updated to match, which resolves the FIXME that was sitting on it: `C:..\foo\bar` is now reported as lexically normal, while `\..\foo\bar` is not.

After the change:

```swift
FilePath(#"C:..\foo\bar"#).lexicallyNormalized()    // C:..\foo\bar
FilePath(#"C:..\..\foo"#).lexicallyNormalized()     // C:..\..\foo
FilePath(#"C:foo\..\..\bar"#).lexicallyNormalized() // C:..\bar
FilePath(#"\..\foo\bar"#).lexicallyNormalized()    // \foo\bar  (unchanged)
```

These match `ntpath.normpath` for the same inputs (CPython recently corrected its own drive-relative normalization for the same reason in python/cpython#126780). The rooted `\` and absolute cases, and all Unix behavior such as `/.. => /`, are unaffected.

Verification: reproduced the wrong output against the documented/reference behavior using the package's `withWindowsPaths` test harness on macOS, applied the fix, and confirmed the outputs match. Added regression cases in `FilePathSyntaxTest` covering leading and interior `..` for both drive-relative (`C:`) and rooted (`\`) Windows paths; they fail before the change and pass after. `swift test` passes in both debug and release (67 XCTest tests and 7 swift-testing tests, 0 failures), and one pre-existing case that encoded the old behavior (`C:foo\bar\..\..\.. => C:`) was corrected to `C:..`.

This is related to the drive-root discussion in #188 (the trapping/validation questions there are separate and not addressed here).

I have not yet completed the Swift project CLA; happy to sign it as part of the review process per CONTRIBUTING.