### PR TITLE
Use fatalError instead of precondition for missing permissions on .create

### DIFF
--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -16,6 +16,8 @@ extension FileDescriptor {
   ///   - mode: The read and write access to use.
   ///   - options: The behavior for opening the file.
   ///   - permissions: The file permissions to use for created files.
+  ///     This value must not be `nil` when `options` contains `.create`;
+  ///     passing `nil` in that case is a programmer error and traps at runtime.
   ///   - retryOnInterrupt: Whether to retry the open operation
   ///     if it throws ``Errno/interrupted``.
   ///     The default is `true`.
@@ -55,6 +57,8 @@ extension FileDescriptor {
   ///   - mode: The read and write access to use.
   ///   - options: The behavior for opening the file.
   ///   - permissions: The file permissions to use for created files.
+  ///     This value must not be `nil` when `options` contains `.create`;
+  ///     passing `nil` in that case is a programmer error and traps at runtime.
   ///   - retryOnInterrupt: Whether to retry the open operation
   ///     if it throws ``Errno/interrupted``.
   ///     The default is `true`.
@@ -88,8 +92,10 @@ extension FileDescriptor {
       if let permissions = permissions {
         return system_open(path, oFlag, permissions.rawValue)
       }
-      precondition(!options.contains(.create),
-        "Create must be given permissions")
+      if options.contains(.create) {
+        fatalError(
+          "FileDescriptor.open: 'permissions' must not be nil when 'options' contains '.create'")
+      }
       return system_open(path, oFlag)
     }
     return descOrError.map { FileDescriptor(rawValue: $0) }
@@ -102,6 +108,8 @@ extension FileDescriptor {
   ///   - mode: The read and write access to use.
   ///   - options: The behavior for opening the file.
   ///   - permissions: The file permissions to use for created files.
+  ///     This value must not be `nil` when `options` contains `.create`;
+  ///     passing `nil` in that case is a programmer error and traps at runtime.
   ///   - retryOnInterrupt: Whether to retry the open operation
   ///     if it throws ``Errno/interrupted``.
   ///     The default is `true`.


### PR DESCRIPTION
## Problem

`FileDescriptor.open(_:_:options:permissions:retryOnInterrupt:)` traps when
`options` contains `.create` but `permissions` is `nil`. As reported in #78,
this trap was raised with `precondition`, whose failure message can be elided
in optimized builds. When that happens the program aborts without any
indication of *why*, forcing users to dig through the source to discover that
`.create` requires a non-`nil` `permissions` value.

The reporter concluded this is a programmer error (so `throws` is not
appropriate), but that the crash should still carry a clear message in the
crash dump.

## Change

- Replace the `precondition(!options.contains(.create), ...)` check in the
  internal `_open` implementation with an explicit
  `if options.contains(.create) { fatalError(...) }`. Unlike `precondition`,
  `fatalError` always fires and always prints its message regardless of
  optimization level, so the diagnostic is guaranteed to appear in the crash
  dump.
- Use a descriptive message:
  `"FileDescriptor.open: 'permissions' must not be nil when 'options' contains '.create'"`.
- Document the trapping behavior in the `permissions:` parameter docs of the
  three public `open` overloads, so the requirement is discoverable from the
  API reference.

The change is confined to the existing trapping code path; no public API,
signatures, or non-trapping behavior change.

## Verification

- `swift build` succeeds (forced recompile of `FileOperations.swift`).
- `swift test --filter FileOperationsTest` passes: 8/8 tests.
- Full suite passes except `TemporaryPathTest.testNotInSlashTmp`, which is an
  environmental failure unrelated to this change (it asserts the temp dir is
  not under `/tmp`, and fails identically on an unmodified checkout when the
  test process runs from `/tmp`).

Fixes #78
