### PR TITLE
Remove Ubuntu `focal` for `nightly-main` Swift version in GHA

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,6 @@ jobs:
           {"os_version": "focal", "swift_version": "6.2"},
           {"os_version": "focal", "swift_version": "nightly-6.3"},
           {"os_version": "focal", "swift_version": "6.3"},
-          {"os_version": "focal", "swift_version": "nightly-main"},
         ]
       enable_macos_checks: true
       macos_exclude_xcode_versions: '[]'
@@ -40,7 +39,6 @@ jobs:
           {"os_version": "focal", "swift_version": "6.2"},
           {"os_version": "focal", "swift_version": "nightly-6.3"},
           {"os_version": "focal", "swift_version": "6.3"},
-          {"os_version": "focal", "swift_version": "nightly-main"},
         ]
       enable_wasm_sdk_build: true
       wasm_exclude_swift_versions: |
@@ -49,7 +47,6 @@ jobs:
           {"os_version": "focal", "swift_version": "6.2"},
           {"os_version": "focal", "swift_version": "nightly-6.3"},
           {"os_version": "focal", "swift_version": "6.3"},
-          {"os_version": "focal", "swift_version": "nightly-main"},
         ]
       enable_android_sdk_build: true
       enable_android_sdk_checks: true


### PR DESCRIPTION
Ubuntu Focal (20.04) is no longer supported by `main` snapshots of Swift.