### PR TITLE
Add `pipe(options:)` for Windows

### DIFF
--- a/Proposals/0007-FileDescriptor-dup3-pipe2.md
+++ b/Proposals/0007-FileDescriptor-dup3-pipe2.md
@@ -167,7 +167,7 @@ struct FileDescriptor {
 }
 ```
 
-These API additions are unavailable Darwin, as the underlying `dup3` and `pipe2` APIs do not exist.
+These API additions are unavailable on Darwin, as the underlying `dup3` and `pipe2` APIs do not exist.
 
 `pipe(options:)` is added for Windows with the option `.closeOnExec`, but `duplicate(as:options:)` is not added because the underlying API does not match `dup3`.
 

--- a/Proposals/0007-FileDescriptor-dup3-pipe2.md
+++ b/Proposals/0007-FileDescriptor-dup3-pipe2.md
@@ -9,6 +9,8 @@
 
 * **v1** Initial version
 
+- **v2** Add Windows version of `pipe(options:)`
+
 ## Introduction
 
 Swift System today provides `FileDescriptor.duplicate()`, `FileDescriptor.duplicate(as:)` and `FileDescriptor.pipe()` cover APIs for the POSIX `dup`, `dup2`, and `pipe` functions, respectively.
@@ -165,7 +167,9 @@ struct FileDescriptor {
 }
 ```
 
-These API additions are unavailable on Windows and Darwin, as the underlying `dup3` and `pipe2` APIs do not exist.
+These API additions are unavailable Darwin, as the underlying `dup3` and `pipe2` APIs do not exist.
+
+`pipe(options:)` is added for Windows with the option `.closeOnExec`, but `duplicate(as:options:)` is not added because the underlying API does not match `dup3`.
 
 `closeOnFork` is unavailable on Linux and Android, as the underlying `O_CLOFORK` constant does not exist.
 

--- a/Sources/CSystem/include/CSystemShared.h
+++ b/Sources/CSystem/include/CSystemShared.h
@@ -7,5 +7,8 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
+#if !defined(_WIN32)
 extern int csystem_posix_pipe2(int fildes[2], int flag);
+#endif
+
 extern int csystem_posix_dup3(int fildes, int fildes2, int flag);

--- a/Sources/CSystem/shims.c
+++ b/Sources/CSystem/shims.c
@@ -28,6 +28,8 @@
 #endif
 
 // Wrappers are required because _GNU_SOURCE causes a conflict with other imports when defined in CSystemLinux.h
+
+#if !defined(_WIN32)
 extern int csystem_posix_pipe2(int fildes[2], int flag) {
     #ifdef HAVE_PIPE2_DUP3
     return pipe2(fildes, flag);
@@ -36,6 +38,8 @@ extern int csystem_posix_pipe2(int fildes[2], int flag) {
     return -1;
     #endif
 }
+#endif // !defined(_WIN32)
+
 extern int csystem_posix_dup3(int fildes, int fildes2, int flag) {
     #ifdef HAVE_PIPE2_DUP3
     return dup3(fildes, fildes2, flag);

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -324,7 +324,6 @@ extension FileDescriptor {
 
   /// Options that specify behavior for a newly-created pipe.
   @frozen
-  @available(Windows, unavailable)
   @available(macOS, unavailable)
   @available(iOS, unavailable)
   @available(tvOS, unavailable)
@@ -350,6 +349,7 @@ extension FileDescriptor {
     @_alwaysEmitIntoClient
     @available(*, unavailable, renamed: "nonBlocking")
     public static var O_NONBLOCK: PipeOptions { nonBlocking }
+#endif // !os(Windows)
 
     /// Indicates that executing a program closes the file.
     ///
@@ -369,7 +369,13 @@ extension FileDescriptor {
     @available(*, unavailable, renamed: "closeOnExec")
     public static var O_CLOEXEC: PipeOptions { closeOnExec }
 
-#if !os(WASI) && !os(Linux) && !os(Android)
+#if os(Windows)
+    @_alwaysEmitIntoClient
+    @available(*, unavailable, renamed: "closeOnExec")
+    public static var O_NOINHERIT: PipeOptions { closeOnExec }
+#endif
+
+#if !os(Windows) && !os(WASI) && !os(Linux) && !os(Android)
     /// Indicates that forking a program closes the file.
     ///
     /// Normally, file descriptors remain open
@@ -387,7 +393,6 @@ extension FileDescriptor {
     @_alwaysEmitIntoClient
     @available(*, unavailable, renamed: "closeOnFork")
     public static var O_CLOFORK: PipeOptions { closeOnFork }
-#endif
 #endif
   }
 

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -524,7 +524,6 @@ extension FileDescriptor {
   ///
   /// The corresponding C function is `pipe2`.
   @_alwaysEmitIntoClient
-  @available(Windows, unavailable)
   @available(macOS, unavailable)
   @available(iOS, unavailable)
   @available(tvOS, unavailable)
@@ -550,7 +549,6 @@ extension FileDescriptor {
     }
   }
 
-  @available(Windows, unavailable)
   @available(macOS, unavailable)
   @available(iOS, unavailable)
   @available(tvOS, unavailable)

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -415,8 +415,13 @@ extension FileDescriptor {
   ///      Pass `false` to try only once and throw an error upon interruption.
   /// - Returns: The new file descriptor.
   ///
+  /// If the `target` descriptor the same as `self`, then EINVAL is thrown.
   /// If the `target` descriptor is already in use, then it is first
   /// deallocated as if a close(2) call had been done first.
+  ///
+  /// NOTE: This overload called with an empty option set is not necessarily
+  /// equivalent to calling the overload with no options, because `dup3` with
+  /// no set options is not required to behave identically to `dup2`.
   ///
   /// File descriptors are merely references to some underlying system resource.
   /// The system does not distinguish between the original and the new file
@@ -502,7 +507,8 @@ extension FileDescriptor {
 #if !os(WASI)
 @available(System 1.1.0, *)
 extension FileDescriptor {
-  /// Creates a unidirectional data channel, which can be used for interprocess communication.
+  /// Creates a unidirectional data channel, which can be used for
+  /// interprocess communication.
   ///
   /// - Returns: The pair of file descriptors.
   ///
@@ -516,6 +522,11 @@ extension FileDescriptor {
 
   /// Creates a unidirectional data channel, which can be used for
   /// interprocess communication.
+  ///
+  /// NOTE: This overload called with an empty option set is not necessarily
+  /// equivalent to calling the overload with no options. On Windows, this
+  /// overload with empty options disables the `closeOnExec` behaviour,
+  /// which is enabled by the overload without options.
   ///
   /// - Parameters:
   ///   - options: The behavior for creating the pipe.

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -619,10 +619,16 @@ internal var _O_DIRECTORY: CInt {
 internal var _O_SYMLINK: CInt { O_SYMLINK }
 #endif
 
-#if !os(Windows)
 @_alwaysEmitIntoClient
-internal var _O_CLOEXEC: CInt { O_CLOEXEC }
+internal var _O_CLOEXEC: CInt {
+  #if os(Windows)
+  O_NOINHERIT
+  #else
+  O_CLOEXEC
+  #endif
+}
 
+#if !os(Windows)
 @_alwaysEmitIntoClient
 internal var _O_CLOFORK: CInt {
   #if !os(WASI) && !os(Linux) && !os(Android) && !canImport(Darwin)

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -207,6 +207,13 @@ internal func pipe(
 }
 
 @inline(__always)
+internal func csystem_posix_pipe2(
+  _ fds: UnsafeMutablePointer<Int32>, bytesReserved: UInt32 = 0, _ oflag: Int32
+) -> CInt {
+  return _pipe(fds, bytesReserved, _O_BINARY | oflag)
+}
+
+@inline(__always)
 internal func ftruncate(_ fd: Int32, _ length: off_t) -> Int32 {
   let handle: intptr_t = _get_osfhandle(fd)
   if handle == /* INVALID_HANDLE_VALUE */ -1 { ucrt._set_errno(EBADF); return -1 }

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -201,7 +201,7 @@ internal func pwrite(
 
 @inline(__always)
 internal func pipe(
-  _ fds: UnsafeMutablePointer<Int32>, bytesReserved: UInt32 = 4096
+  _ fds: UnsafeMutablePointer<Int32>, bytesReserved: UInt32 = 0
 ) -> CInt {
   return _pipe(fds, bytesReserved, _O_BINARY | _O_NOINHERIT);
 }

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -176,7 +176,30 @@ final class FileOperationsTest: XCTestCase {
       }
     }
   }
-  #endif
+
+  #if !SYSTEM_PACKAGE_DARWIN
+  func testAdHocPipeWithOptions() throws {
+    // Ad-hoc test testing `Pipe` functionality.
+    // We cannot test `Pipe` using `MockTestCase` because it calls `pipe` with a pointer to an array local to the `Pipe`, the address of which we do not know prior to invoking `Pipe`.
+    let options: FileDescriptor.PipeOptions = [.closeOnExec]
+    let pipe: (readEnd: FileDescriptor, writeEnd: FileDescriptor)
+    pipe = try FileDescriptor.pipe(options: options)
+    try pipe.readEnd.closeAfter {
+      try pipe.writeEnd.closeAfter {
+        var abc = "abc"
+        try abc.withUTF8 {
+          _ = try pipe.writeEnd.write(UnsafeRawBufferPointer($0))
+        }
+        let readLen = 3
+        let readBytes = try Array<UInt8>(unsafeUninitializedCapacity: readLen) { buf, count in
+          count = try pipe.readEnd.read(into: UnsafeMutableRawBufferPointer(buf))
+        }
+        XCTAssertEqual(readBytes, Array(abc.utf8))
+      }
+    }
+  }
+  #endif // !SYSTEM_PACKAGE_DARWIN
+  #endif // !os(WASI)
 
   func testAdHocDuplicate2() throws {
     try withTemporaryFilePath(basename: "test") {

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -178,6 +178,79 @@ final class FileOperationsTest: XCTestCase {
   }
   #endif
 
+  func testAdHocDuplicate2() throws {
+    try withTemporaryFilePath(basename: "test") {
+      let path = $0.appending("foo2.txt")
+      let fd1 = try FileDescriptor.open(path, .readWrite,
+                                        options: [.create, .truncate],
+                                        permissions: .ownerReadWrite)
+
+      let fd2 = FileDescriptor(rawValue: 731)
+      let fd3 = try fd1.duplicate(as: fd2)
+      XCTAssertEqual(fd2, fd3)
+
+      try fd2.close()
+      do {
+        try fd3.close()
+        XCTFail("Should be unreachable")
+      } catch {
+        if let error = try? XCTUnwrap(error as? Errno) {
+          XCTAssertEqual(error, .badFileDescriptor)
+        }
+      }
+
+      // dup2() accepts two equal parameters.
+      let fd4 = try fd1.duplicate(as: fd1)
+      XCTAssertEqual(fd4, fd1)
+
+      try fd1.close()
+      do {
+        try fd4.close()
+        XCTFail("Should be unreachable")
+      } catch {
+        if let error = try? XCTUnwrap(error as? Errno) {
+          XCTAssertEqual(error, .badFileDescriptor)
+        }
+      }
+    }
+  }
+
+  #if !SYSTEM_PACKAGE_DARWIN && !os(Windows)
+  func testAdHocDuplicate3() throws {
+
+    try withTemporaryFilePath(basename: "test") {
+      let path = $0.appending("foo3.txt")
+
+      let fd1 = try FileDescriptor.open(path, .readWrite,
+                                        options: [.create, .truncate],
+                                        permissions: .ownerReadWrite)
+
+      let fd2 = FileDescriptor(rawValue: 731)
+      let fd3 = try fd1.duplicate(as: fd2, options: [.closeOnExec])
+      XCTAssertEqual(fd2, fd3)
+
+      try fd2.close()
+      do {
+        try fd3.close()
+      } catch {
+        if let error = try? XCTUnwrap(error as? Errno) {
+          XCTAssertEqual(error, .badFileDescriptor)
+        }
+      }
+
+      // dup3() does not accept two equal parameters.
+      do {
+        _ = try fd1.duplicate(as: fd1, options: [])
+        XCTFail("Should be unreachable")
+      } catch {
+        if let error = try? XCTUnwrap(error as? Errno) {
+          XCTAssertEqual(error, .invalidArgument)
+        }
+      }
+    }
+  }
+  #endif // !SYSTEM_PACKAGE_DARWIN && !os(Windows)
+
   func testAdHocOpen() {
     // Ad-hoc test touching a file system.
     do {

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -201,6 +201,7 @@ final class FileOperationsTest: XCTestCase {
   #endif // !SYSTEM_PACKAGE_DARWIN
   #endif // !os(WASI)
 
+  #if !os(Windows)
   func testAdHocDuplicate2() throws {
     try withTemporaryFilePath(basename: "test") {
       let path = $0.appending("foo2.txt")
@@ -237,6 +238,7 @@ final class FileOperationsTest: XCTestCase {
       }
     }
   }
+  #endif // !os(Windows)
 
   #if !SYSTEM_PACKAGE_DARWIN && !os(Windows)
   func testAdHocDuplicate3() throws {


### PR DESCRIPTION
This adds:
- `FileDescriptor.PipeOptions` for Windows, enabling the option `.closeOnExec`.
- `FileDescriptor.pipe(options:)` for Windows

...along with some extra tests.

The Windows-native implementation of pipes, using `CreatePipe()`, creates file handles that aren't inherited. Accordingly, the Windows `pipe()` in swift-system sets the no-inherit option. Adding a version of pipe() that accepts options gives us the opportunity to allow Windows users to not set the option when that is appropriate to their use case.