### PR TITLE
Circumvent FreeBSD’s closeOnFork definition issue

### DIFF
--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -631,8 +631,10 @@ internal var _O_CLOEXEC: CInt {
 #if !os(Windows)
 @_alwaysEmitIntoClient
 internal var _O_CLOFORK: CInt {
-  #if !os(WASI) && !os(Linux) && !os(Android) && !canImport(Darwin)
+  #if !os(WASI) && !os(Linux) && !os(Android) && !canImport(Darwin) && !os(FreeBSD)
   O_CLOFORK
+  #elseif os(FreeBSD)
+  0x08000000 // according to sys/sys/fcntl.h#L155
   #else
   0
   #endif


### PR DESCRIPTION
Potential solution for https://github.com/apple/swift-system/issues/316

FreeBSD defined `O_CLOFORK` in version 15.0, but we test on FreeBSD 14.3.
This hard-codes the value from the header when the compilation target is FreeBSD.