### PR TITLE
Fix missing `O_CLOFORK` on older FreeBSD

### DIFF
--- a/Sources/CSystem/CMakeLists.txt
+++ b/Sources/CSystem/CMakeLists.txt
@@ -16,6 +16,7 @@ install(FILES
   include/CSystemLinux.h
   include/CSystemShared.h
   include/CSystemWindows.h
+  include/CSystemFreeBSD.h
   include/module.modulemap
   DESTINATION include/CSystem)
 set_property(GLOBAL APPEND PROPERTY SWIFT_SYSTEM_EXPORTS CSystem)

--- a/Sources/CSystem/include/CSystemFreeBSD.h
+++ b/Sources/CSystem/include/CSystemFreeBSD.h
@@ -1,0 +1,21 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+#if defined(__FreeBSD__)
+
+#include <fcntl.h>
+
+#ifdef O_CLOFORK
+#define FREEBSD_O_CLOFORK O_CLOFORK
+#else
+#define FREEBSD_O_CLOFORK 0
+#endif
+
+#endif
+

--- a/Sources/CSystem/include/module.modulemap
+++ b/Sources/CSystem/include/module.modulemap
@@ -3,5 +3,6 @@ module CSystem {
   header "CSystemLinux.h"
   header "CSystemWASI.h"
   header "CSystemWindows.h"
+  header "CSystemFreeBSD.h"
   export *
 }

--- a/Sources/CSystem/shims.c
+++ b/Sources/CSystem/shims.c
@@ -12,6 +12,10 @@
 #include <unistd.h>
 #endif
 
+#if defined(__FreeBSD__)
+#include <CSystemFreeBSD.h>
+#endif
+
 #ifdef __linux__
 #define _GNU_SOURCE
 #include <CSystemLinux.h>

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -631,8 +631,10 @@ internal var _O_CLOEXEC: CInt {
 #if !os(Windows)
 @_alwaysEmitIntoClient
 internal var _O_CLOFORK: CInt {
-  #if !os(WASI) && !os(Linux) && !os(Android) && !canImport(Darwin)
+  #if !os(WASI) && !os(Linux) && !os(Android) && !canImport(Darwin) && !os(FreeBSD)
   O_CLOFORK
+  #elseif os(FreeBSD)
+  FREEBSD_O_CLOFORK
   #else
   0
   #endif


### PR DESCRIPTION
fixes #316 

closes #317 

In FreeBSD, `O_CLOFORK` has been added in https://github.com/freebsd/freebsd-src/pull/1698. This change hasn't ported to FreeBSD 14.x, so FreeBSD 14.x CI is currently failing.

This PR added a new variable `FREEBSD_O_CLOFORK`, which wraps `O_CLOFORK` on newer FreeBSD and `0` on older FreeBSD, and resolved #316 by using it.