### PR TITLE
[1.7.0] Fix Stat MemberImportVisibility regression and add test

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -141,6 +141,12 @@ let package = Package(
       exclude: testsToExclude,
       cSettings: cSettings,
       swiftSettings: swiftSettings),
+    // Builds a SystemPackage consumer with MemberImportVisibility enabled.
+    // Fails if a C member of a vended type is attributed to the CSystem module.
+    .testTarget(
+      name: "MemberImportVisibility",
+      dependencies: ["SystemPackage"],
+      swiftSettings: [.enableUpcomingFeature("MemberImportVisibility")]),
   ],
   swiftLanguageModes: [.v5]
 )

--- a/Sources/CSystem/include/CSystemLinux.h
+++ b/Sources/CSystem/include/CSystemLinux.h
@@ -11,13 +11,11 @@
 
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
-#include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/sysinfo.h>
 #include <sys/timerfd.h>
 #include <sys/types.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <pthread.h>
 #include <sched.h>
 #include <unistd.h>

--- a/Tests/MemberImportVisibility/Probe.swift
+++ b/Tests/MemberImportVisibility/Probe.swift
@@ -1,0 +1,47 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// Compile-only canary for MemberImportVisibility regressions: this file fails
+// to build if a C member of a type SystemPackage vends is attributed to the
+// private CSystem module.
+//
+// For new type wrappers introduced to System, access their C members here:
+//  - Import the platform overlay (Glibc/Musl/Bionic), as consumers do.
+//  - Access raw C members of vended types (e.g. CInterop.Stat) as a downstream
+//    consumer would. Don't go through the Swift (e.g. Stat) wrapper since its
+//    accesses happen inside System, where importing CSystem is fine.
+//  - Touch every direct member the public API exposes. One field is not always
+//    a safe proxy for the rest.
+
+#if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Bionic)
+import Bionic
+#endif
+import SystemPackage
+
+func _mivProbe(_ s: CInterop.Stat) {
+  _ = s.st_dev
+  _ = s.st_ino
+  _ = s.st_mode
+  _ = s.st_nlink
+  _ = s.st_uid
+  _ = s.st_gid
+  _ = s.st_rdev
+  _ = s.st_size
+  _ = s.st_blksize
+  _ = s.st_blocks
+  _ = s.st_atim
+  _ = s.st_mtim
+  _ = s.st_ctim
+}
+#endif

--- a/Tests/MemberImportVisibility/Probe.swift
+++ b/Tests/MemberImportVisibility/Probe.swift
@@ -12,20 +12,18 @@
 // private CSystem module.
 //
 // For new type wrappers introduced to System, access their C members here:
-//  - Import the platform overlay (Glibc/Musl/Bionic), as consumers do.
+//  - Import the platform overlay (Glibc/Musl), as consumers do.
 //  - Access raw C members of vended types (e.g. CInterop.Stat) as a downstream
 //    consumer would. Don't go through the Swift (e.g. Stat) wrapper since its
 //    accesses happen inside System, where importing CSystem is fine.
 //  - Touch every direct member the public API exposes. One field is not always
 //    a safe proxy for the rest.
 
-#if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+#if canImport(Glibc) || canImport(Musl)
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Bionic)
-import Bionic
 #endif
 import SystemPackage
 


### PR DESCRIPTION
With `MemberImportVisibility` enabled, consumers of `SystemPackage` that read C `stat` fields fail to build due to the public `CInterop.Stat = stat` typealias (such as reported in https://github.com/apple/swift-nio/issues/3622):

```
- error: property 'st_mode' is not available due to missing import of defining module 'CSystem' [#MemberImportVisibility]
``` 

`CSystem` re-exported `<sys/stat.h>` and `<fcntl.h>`, so `struct stat`'s members were attributed to the private `CSystem` module rather than the platform overlay. `CSystem` uses neither header, so we can remove both includes from `CSystemLinux.h`, and `struct stat` will now resolve through Glibc/Musl/Bionic, which consumers already import.

To prevent this sort of regression in the future, this PR also adds a compile-only `MemberImportVisibility` test target that touches all `CInterop.Stat` members, so `swift test` should catch any issues in CI. Future wrapper types introduced to System can be added there, too.