### PR TITLE
Install missing CSystem headers with CMake

### DIFF
--- a/Sources/CSystem/CMakeLists.txt
+++ b/Sources/CSystem/CMakeLists.txt
@@ -15,8 +15,10 @@ target_include_directories(CSystem PUBLIC
 install(FILES
   include/CSystemLinux.h
   include/CSystemShared.h
+  include/CSystemWASI.h
   include/CSystemWindows.h
   include/CSystemFreeBSD.h
+  include/io_uring.h
   include/module.modulemap
   DESTINATION include/CSystem)
 set_property(GLOBAL APPEND PROPERTY SWIFT_SYSTEM_EXPORTS CSystem)


### PR DESCRIPTION
## Summary

This updates the CSystem CMake install list to include the headers that installed consumers need:

- `CSystemWASI.h`, which is referenced by `module.modulemap`
- `io_uring.h`, which is included by `CSystemLinux.h`

## Why

The previous install list copied the module map and several platform headers, but left out two headers required by that installed module. That can break consumers that import `CSystem` from a CMake-installed package outside the source tree.

## Validation

- `cmake -S . -B .build/cmake-install-check-ninja -G Ninja -DCMAKE_INSTALL_PREFIX=.build/install-check-ninja`
- `cmake --build .build/cmake-install-check-ninja`
- `cmake --install .build/cmake-install-check-ninja`
- `printf '@import CSystem;\nint main(void) { return 0; }\n' | clang -fmodules -I .build/install-check-ninja/include/CSystem -x objective-c -c -o /dev/null -`