### PR TITLE
Add missing System sources to CMake build

### DIFF
--- a/Sources/System/CMakeLists.txt
+++ b/Sources/System/CMakeLists.txt
@@ -9,6 +9,7 @@ See https://swift.org/LICENSE.txt for license information
 
 add_library(SystemPackage
   Errno.swift
+  ErrnoWindows.swift
   FileDescriptor.swift
   FileHelpers.swift
   FileOperations.swift
@@ -18,9 +19,12 @@ add_library(SystemPackage
   SystemString.swift
   Util.swift
   Util+StringArray.swift
-  UtilConsumers.swift)
+  UtilConsumers.swift
+  WinSDK+Overlay.swift)
 set_target_properties(SystemPackage PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_compile_options(SystemPackage PRIVATE
+  -enable-experimental-feature Lifetimes)
 target_sources(SystemPackage PRIVATE
   FilePath/FilePath.swift
   FilePath/FilePathComponents.swift
@@ -28,7 +32,23 @@ target_sources(SystemPackage PRIVATE
   FilePath/FilePathParsing.swift
   FilePath/FilePathString.swift
   FilePath/FilePathSyntax.swift
+  FilePath/FilePathTemp.swift
+  FilePath/FilePathTempPosix.swift
+  FilePath/FilePathTempWindows.swift
   FilePath/FilePathWindows.swift)
+target_sources(SystemPackage PRIVATE
+  FileSystem/FileFlags.swift
+  FileSystem/FileMode.swift
+  FileSystem/FileType.swift
+  FileSystem/Identifiers.swift
+  FileSystem/Stat.swift)
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  target_sources(SystemPackage PRIVATE
+    IORing/IOCompletion.swift
+    IORing/IORequest.swift
+    IORing/IORing.swift
+    IORing/RawIORequest.swift)
+endif()
 target_sources(SystemPackage PRIVATE
   Internals/Backcompat.swift
   Internals/CInterop.swift


### PR DESCRIPTION
## Summary

This updates the CMake source list for SystemPackage so it matches the Swift sources in the SwiftPM target.

The CMake build now includes the previously omitted source groups:

- Windows support files
- temporary-path implementation files
- FileSystem APIs, including Stat, FileType, FileMode, and FileFlags
- Linux-only IORing files

It also enables the Swift Lifetimes feature for the CMake target, matching SwiftPM, so the Linux IORing sources are not compiled away when they are included.

## Why

The CMake target had drifted from the SwiftPM target. CMake consumers could get a successful build while the produced module was missing newer API areas.

## Validation

- cmake configure with Ninja and CMAKE_INSTALL_PREFIX=.build/install-system-sources-check
- cmake --build .build/cmake-system-sources-check
- cmake --install .build/cmake-system-sources-check
- Installed-module Swift typecheck that imports SystemPackage and uses FilePath.stat() / Stat.type
- Source-list audit: CMake now names 40/40 Swift sources from the SwiftPM target