### PR TITLE
Forward io_uring_enter2 size argument

### DIFF
--- a/Sources/CSystem/include/io_uring.h
+++ b/Sources/CSystem/include/io_uring.h
@@ -235,7 +235,7 @@ static inline int io_uring_enter2(int fd, unsigned int to_submit, unsigned int m
 		   unsigned int flags, void *args, size_t sz)
 {
 	return syscall(__NR_io_uring_enter, fd, to_submit, min_complete,
-			flags, args, _NSIG / 8);
+			flags, args, sz);
 }
 
 static inline int io_uring_enter(int fd, unsigned int to_submit, unsigned int min_complete,


### PR DESCRIPTION
## Summary

This updates the io_uring_enter2 shim to pass its size argument through to the io_uring_enter syscall.

## Why

The wrapper accepted a size argument, but always passed the sigset size instead. Extended-argument callers compute the size they need, so the wrapper should not discard it.

The older io_uring_enter helper still passes the sigset size when it calls io_uring_enter2, which keeps that path unchanged.

## Validation

- cmake configure with Ninja and CMAKE_INSTALL_PREFIX=.build/install-io-uring-enter2-check
- cmake --build .build/cmake-io-uring-enter2-check
- cmake --install .build/cmake-io-uring-enter2-check
- Confirmed the installed CSystem io_uring.h forwards the sz argument