### PR TITLE
Don't define __BSD_VISIBLE on OpenBSD.

### DIFF
--- a/Sources/CSystem/shims.c
+++ b/Sources/CSystem/shims.c
@@ -7,10 +7,10 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #if defined(__FreeBSD__)
 #define __BSD_VISIBLE
 #endif
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <unistd.h>
 #endif
 

--- a/Sources/CSystem/shims.c
+++ b/Sources/CSystem/shims.c
@@ -8,7 +8,9 @@
 */
 
 #if defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__)
 #define __BSD_VISIBLE
+#endif
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
This causes a compilation error because OpenBSD headers that refer to this aren't `#ifdef` but `#if`, so the define must have a value.

This doesn't actually seem to be necessary on OpenBSD, so let's just remove it on OpenBSD.