### PR TITLE
Enable .closeOnExec for FileDescriptor.open on Windows

### DIFF
--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -301,7 +301,6 @@ extension FileDescriptor {
     public static var O_EVTONLY: OpenOptions { eventOnly }
 #endif
 
-#if !os(Windows)
     /// Indicates that executing a program closes the file.
     ///
     /// Normally, file descriptors remain open
@@ -319,6 +318,11 @@ extension FileDescriptor {
     @_alwaysEmitIntoClient
     @available(*, unavailable, renamed: "closeOnExec")
     public static var O_CLOEXEC: OpenOptions { closeOnExec }
+
+#if os(Windows)
+    @_alwaysEmitIntoClient
+    @available(*, unavailable, renamed: "closeOnExec")
+    public static var O_NOINHERIT: OpenOptions { closeOnExec }
 #endif
   }
 

--- a/Tests/SystemTests/FileOperationsTestWindows.swift
+++ b/Tests/SystemTests/FileOperationsTestWindows.swift
@@ -18,6 +18,7 @@ import XCTest
 #endif
 
 import WinSDK
+import ucrt
 
 private let FILE_APPEND_DATA = DWORD(WinSDK.FILE_APPEND_DATA)
 private let FILE_EXECUTE = DWORD(WinSDK.FILE_EXECUTE)
@@ -293,6 +294,38 @@ final class FileOperationsTestWindows: XCTestCase {
 
       // Verify that exactly DWORD.max works (if we had a buffer that large)
       // We can't easily test this without allocating 4GB, but the boundary is correct
+    }
+  }
+
+  func testCloseOnExecOpenOption() throws {
+    try withTemporaryFilePath(basename: "testCloseOnExec") { path in
+
+      func hasInheritFlag(of fd: FileDescriptor) throws -> Bool {
+        let osfHandle = _get_osfhandle(fd.rawValue)
+        let handle = try XCTUnwrap(HANDLE(bitPattern: osfHandle))
+        var flags: DWORD = 0
+        XCTAssertTrue(GetHandleInformation(handle, &flags))
+        return flags & DWORD(HANDLE_FLAG_INHERIT) == DWORD(HANDLE_FLAG_INHERIT)
+      }
+
+      var fd: FileDescriptor
+      fd = try FileDescriptor.open(
+        path.appending("wontinherit.txt"), .readWrite,
+        options: [.create, .truncate, .closeOnExec],
+        permissions: .ownerReadWrite
+      )
+      try fd.closeAfter {
+        XCTAssertEqual(try hasInheritFlag(of: fd), false)
+      }
+
+      fd = try FileDescriptor.open(
+        path.appending("inheritable.txt"), .readWrite,
+        options: [.create, .truncate],
+        permissions: .ownerReadWrite
+      )
+      try fd.closeAfter {
+        XCTAssertEqual(try hasInheritFlag(of: fd), true)
+      }
     }
   }
 }


### PR DESCRIPTION
Make OpenOptions.closeOnExec available on Windows, where it maps to _O_CLOEXEC (O_NOINHERIT). The Windows open adapter already decodes O_NOINHERIT into a non-inheritable handle, so this produces the expected close-on-exec semantics. Also add the deprecated O_NOINHERIT alias, matching the PipeOptions treatment from #312.