### PR TITLE
IORing throwing tweaks

### DIFF
--- a/Sources/System/IORing/IORing.swift
+++ b/Sources/System/IORing/IORing.swift
@@ -715,7 +715,7 @@ public struct IORing: ~Copyable {
     }
 
     /// Removes registered files from the ring
-    public func unregisterFiles() throws {
+    public func unregisterFiles() throws(Errno) {
         _ = try _ioUringRegister(
             ringDescriptor: ringDescriptor,
             opcode: RegistrationOps.unregisterFiles.rawValue,
@@ -781,7 +781,7 @@ public struct IORing: ~Copyable {
         RegisteredResources(resources: _registeredBuffers)
     }
 
-    public func unregisterBuffers() throws {
+    public func unregisterBuffers() throws(Errno) {
         _ = try _ioUringRegister(
             ringDescriptor: self.ringDescriptor,
             opcode: RegistrationOps.unregisterBuffers.rawValue,

--- a/Sources/System/IORing/RawIORequest.swift
+++ b/Sources/System/IORing/RawIORequest.swift
@@ -176,20 +176,20 @@ extension RawIORequest {
     }
 
     @inlinable
-    static func withTimeoutRequest<R>(
+    static func withTimeoutRequest<R, E: Error>(
         linkedTo opEntry: UnsafeMutablePointer<swift_io_uring_sqe>,
         in timeoutEntry: UnsafeMutablePointer<swift_io_uring_sqe>,
-        duration: Duration, 
-        flags: TimeOutFlags, 
-        work: () throws -> R) rethrows -> R {
+        duration: Duration,
+        flags: TimeOutFlags,
+        work: () throws(E) -> R) throws(E) -> R {
 
         opEntry.pointee.flags |= Flags.linkRequest.rawValue
         opEntry.pointee.off = 1
         var ts = timespec(
-            tv_sec: Int(duration.components.seconds), 
+            tv_sec: Int(duration.components.seconds),
             tv_nsec: Int(duration.components.attoseconds / 1_000_000_000)
         )
-        return try withUnsafePointer(to: &ts) { tsPtr in
+        return try withUnsafePointer(to: &ts) { tsPtr throws(E) -> R in
             var req: RawIORequest = RawIORequest()
             req.operation = .link_timeout
             req.rawValue.timeout_flags = flags.rawValue


### PR DESCRIPTION
This tweaks two public IORing functions to specify error types.
One internal helper function is changed to have a generic typed error instead of having a `rethrows` annotation.