### PR TITLE
Set -package-name in CMake build

### DIFF
--- a/Sources/System/CMakeLists.txt
+++ b/Sources/System/CMakeLists.txt
@@ -24,7 +24,8 @@ add_library(SystemPackage
 set_target_properties(SystemPackage PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_compile_options(SystemPackage PRIVATE
-  -enable-experimental-feature Lifetimes)
+  -enable-experimental-feature Lifetimes
+  "SHELL:-package-name swift-system")
 target_sources(SystemPackage PRIVATE
   FilePath/FilePath.swift
   FilePath/FilePathComponents.swift


### PR DESCRIPTION
Currently the CMake build of main fails on Windows because it recently started using the package access level for the first time, but doesn't set a package name. Update CMakeLists.txt to set one.