### PR TITLE
Adjust availability macro for System 1.7.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,13 +59,9 @@ let availability: [Available] = [
   Available("1.3.2", "macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.0"),
   Available("1.4.0", "macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.0"),
 
-  Available("1.4.1", "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999"),
-  Available("1.4.2", "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999"),
-  Available("1.5.0", "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999"),
-  Available("1.6.0", "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999"),
-  Available("1.6.1", "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999"),
+  Available("1.7.0", "macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0"),
 
-  Available("99", "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999"),
+  Available("199", "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999"),
 ]
 
 let swiftSettingsAvailability = availability.map(\.swiftSetting)

--- a/Sources/System/FileSystem/FileFlags.swift
+++ b/Sources/System/FileSystem/FileFlags.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift System open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift System project authors
+// Copyright (c) 2025 - 2026 Apple Inc. and the Swift System project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -45,7 +45,7 @@
 ///
 /// - Note: Only available on Darwin, FreeBSD, and OpenBSD.
 @frozen
-@available(System 99, *)
+@available(System 1.7.0, *)
 public struct FileFlags: OptionSet, Sendable, Hashable, Codable {
   
   /// The raw C flags.

--- a/Sources/System/FileSystem/FileMode.swift
+++ b/Sources/System/FileSystem/FileMode.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift System open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift System project authors
+// Copyright (c) 2025 - 2026 Apple Inc. and the Swift System project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -14,7 +14,7 @@
 ///
 /// - Note: Only available on Unix-like platforms.
 @frozen
-@available(System 99, *)
+@available(System 1.7.0, *)
 public struct FileMode: RawRepresentable, Sendable, Hashable, Codable {
   
   /// The raw C mode.

--- a/Sources/System/FileSystem/FileType.swift
+++ b/Sources/System/FileSystem/FileType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift System open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift System project authors
+// Copyright (c) 2025 - 2026 Apple Inc. and the Swift System project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -34,7 +34,7 @@
 ///
 /// - Note: Only available on Unix-like platforms.
 @frozen
-@available(System 99, *)
+@available(System 1.7.0, *)
 public struct FileType: RawRepresentable, Sendable, Hashable, Codable {
 
   /// The raw file-type bits from the C mode.

--- a/Sources/System/FileSystem/Identifiers.swift
+++ b/Sources/System/FileSystem/Identifiers.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift System open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift System project authors
+// Copyright (c) 2025 - 2026 Apple Inc. and the Swift System project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,7 +12,7 @@
 #if !os(Windows)
 /// A Swift wrapper of the C `uid_t` type.
 @frozen
-@available(System 99, *)
+@available(System 1.7.0, *)
 public struct UserID: RawRepresentable, Sendable, Hashable, Codable {
 
   /// The raw C `uid_t`.
@@ -30,7 +30,7 @@ public struct UserID: RawRepresentable, Sendable, Hashable, Codable {
 
 /// A Swift wrapper of the C `gid_t` type.
 @frozen
-@available(System 99, *)
+@available(System 1.7.0, *)
 public struct GroupID: RawRepresentable, Sendable, Hashable, Codable {
 
   /// The raw C `gid_t`.
@@ -48,7 +48,7 @@ public struct GroupID: RawRepresentable, Sendable, Hashable, Codable {
 
 /// A Swift wrapper of the C `dev_t` type.
 @frozen
-@available(System 99, *)
+@available(System 1.7.0, *)
 public struct DeviceID: RawRepresentable, Sendable, Hashable, Codable {
 
   /// The raw C `dev_t`.
@@ -66,7 +66,7 @@ public struct DeviceID: RawRepresentable, Sendable, Hashable, Codable {
 
 /// A Swift wrapper of the C `ino_t` type.
 @frozen
-@available(System 99, *)
+@available(System 1.7.0, *)
 public struct Inode: RawRepresentable, Sendable, Hashable, Codable {
 
   /// The raw C `ino_t`.

--- a/Sources/System/FileSystem/Stat.swift
+++ b/Sources/System/FileSystem/Stat.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift System open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift System project authors
+// Copyright (c) 2025 - 2026 Apple Inc. and the Swift System project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -35,7 +35,7 @@ import Android
 ///
 /// - Note: Only available on Unix-like platforms.
 @frozen
-@available(System 99, *)
+@available(System 1.7.0, *)
 public struct Stat: RawRepresentable, Sendable {
 
   /// The raw C `stat` struct.
@@ -536,7 +536,7 @@ public struct Stat: RawRepresentable, Sendable {
 
 // MARK: - Equatable and Hashable
 
-@available(System 99, *)
+@available(System 1.7.0, *)
 extension Stat: Equatable {
   @_alwaysEmitIntoClient
   /// Compares the raw bytes of two `Stat` structs for equality.
@@ -549,7 +549,7 @@ extension Stat: Equatable {
   }
 }
 
-@available(System 99, *)
+@available(System 1.7.0, *)
 extension Stat: Hashable {
   @_alwaysEmitIntoClient
   /// Hashes the raw bytes of this `Stat` struct.
@@ -564,7 +564,7 @@ extension Stat: Hashable {
 
 // MARK: - FileDescriptor Extensions
 
-@available(System 99, *)
+@available(System 1.7.0, *)
 extension FileDescriptor {
 
   /// Creates a `Stat` struct for the file referenced by this `FileDescriptor`.
@@ -580,7 +580,7 @@ extension FileDescriptor {
 
 // MARK: - FilePath Extensions
 
-@available(System 99, *)
+@available(System 1.7.0, *)
 extension FilePath {
 
   /// Creates a `Stat` struct for the file referenced by this `FilePath`.

--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -106,7 +106,7 @@ extension CInterop {
   }
 }
 
-@available(System 99, *)
+@available(System 1.7.0, *)
 extension CInterop {
   public typealias DeviceID = dev_t
   public typealias Inode = ino_t

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -96,15 +96,15 @@ internal func system_strlen(_ s: UnsafeMutablePointer<CChar>) -> Int {
 internal func system_stat(_ p: UnsafePointer<CChar>, _ s: inout CInterop.Stat) -> Int32 {
   stat(p, &s)
 }
-@available(System 99, *)
+@available(System 1.7.0, *)
 internal func system_lstat(_ p: UnsafePointer<CChar>, _ s: inout CInterop.Stat) -> Int32 {
   lstat(p, &s)
 }
-@available(System 99, *)
+@available(System 1.7.0, *)
 internal func system_fstat(_ fd: CInt, _ s: inout CInterop.Stat) -> Int32 {
   fstat(fd, &s)
 }
-@available(System 99, *)
+@available(System 1.7.0, *)
 internal func system_fstatat(_ fd: CInt, _ p: UnsafePointer<CChar>, _ s: inout CInterop.Stat, _ flags: CInt) -> Int32 {
   fstatat(fd, p, &s, flags)
 }

--- a/Tests/SystemTests/FileModeTests.swift
+++ b/Tests/SystemTests/FileModeTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift System open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift System project authors
+// Copyright (c) 2025 - 2026 Apple Inc. and the Swift System project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -36,7 +36,7 @@ import Android
 @Suite("FileMode")
 private struct FileModeTests {
 
-  @available(System 99, *)
+  @available(System 1.7.0, *)
   @Test func basics() async throws {
     var mode = FileMode(rawValue: S_IFREG | 0o644) // Regular file, rw-r--r--
     #expect(mode.type == .regular)
@@ -67,7 +67,7 @@ private struct FileModeTests {
     #expect(mode.type == mode2.type)
   }
 
-  @available(System 99, *)
+  @available(System 1.7.0, *)
   @Test func invalidInput() async throws {
     // No permissions, all other bits set
     var invalidMode = FileMode(rawValue: ~0o7777)

--- a/Tests/SystemTests/StatTests.swift
+++ b/Tests/SystemTests/StatTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift System open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift System project authors
+// Copyright (c) 2025 - 2026 Apple Inc. and the Swift System project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -39,7 +39,7 @@ import Android
 @Suite("Stat")
 private struct StatTests {
 
-  @available(System 99, *)
+  @available(System 1.7.0, *)
   @Test func basics() async throws {
     try withTemporaryFilePath(basename: "Stat_basics") { tempDir in
       let dirStatFromFilePath = try tempDir.stat()
@@ -81,7 +81,7 @@ private struct StatTests {
     }
   }
 
-  @available(System 99, *)
+  @available(System 1.7.0, *)
   @Test func followSymlinkInits() async throws {
     try withTemporaryFilePath(basename: "Stat_followSymlinkInits") { tempDir in
       let targetFilePath = tempDir.appending("target.txt")
@@ -190,7 +190,7 @@ private struct StatTests {
     }
   }
 
-  @available(System 99, *)
+  @available(System 1.7.0, *)
   @Test func permissions() async throws {
     try withTemporaryFilePath(basename: "Stat_permissions") { tempDir in
       let testFile = tempDir.appending("test.txt")
@@ -220,7 +220,7 @@ private struct StatTests {
     }
   }
 
-  @available(System 99, *)
+  @available(System 1.7.0, *)
   @Test func times() async throws {
     var start = timespec()
     try #require(clock_gettime(CLOCK_REALTIME, &start) == 0, "\(Errno.current)")
@@ -349,7 +349,7 @@ private struct StatTests {
   }
 
   #if SYSTEM_PACKAGE_DARWIN || os(FreeBSD) || os(OpenBSD)
-  @available(System 99, *)
+  @available(System 1.7.0, *)
   @Test func flags() async throws {
     try withTemporaryFilePath(basename: "Stat_flags") { tempDir in
       let filePath = tempDir.appending("test.txt")


### PR DESCRIPTION
Changes the placeholder availability of `Stat` to use the versions aligned with macOS 27.0