### PR TITLE
Implement the `dup3` and `pipe2` wrappers for Darwin

### DIFF
--- a/Sources/CSystem/CMakeLists.txt
+++ b/Sources/CSystem/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(CSystem PUBLIC
   $<INSTALL_INTERFACE:include/CSystem>)
 
 install(FILES
+  include/CSystemDarwin.h
   include/CSystemLinux.h
   include/CSystemShared.h
   include/CSystemWASI.h

--- a/Sources/CSystem/include/CSystemDarwin.h
+++ b/Sources/CSystem/include/CSystemDarwin.h
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-#if defined(__FreeBSD__)
+#if defined(__APPLE__)
 
 #include <fcntl.h>
 
@@ -17,4 +17,4 @@
 #define COMPATIBILITY_O_CLOFORK 0
 #endif
 
-#endif // defined(__FreeBSD__)
+#endif // defined(__APPLE__)

--- a/Sources/CSystem/include/module.modulemap
+++ b/Sources/CSystem/include/module.modulemap
@@ -1,5 +1,6 @@
 module CSystem {
   header "CSystemShared.h"
+  header "CSystemDarwin.h"
   header "CSystemLinux.h"
   header "CSystemWASI.h"
   header "CSystemWindows.h"

--- a/Sources/CSystem/shims.c
+++ b/Sources/CSystem/shims.c
@@ -31,24 +31,40 @@
 #define HAVE_PIPE2_DUP3
 #endif
 
+#if defined(__APPLE__)
+#include <Availability.h>
+#if defined(__MAC_27_0)
+#include <unistd.h>
+#define HAVE_PIPE2_DUP3
+#endif
+#endif // defined(__APPLE__)
+
 // Wrappers are required because _GNU_SOURCE causes a conflict with other imports when defined in CSystemLinux.h
 
 #if !defined(_WIN32)
 extern int csystem_posix_pipe2(int fildes[2], int flag) {
-    #ifdef HAVE_PIPE2_DUP3
+  #if defined(__APPLE__) && defined(HAVE_PIPE2_DUP3)
+  if (__builtin_available(macOS 27, iOS 27, tvOS 27, watchOS 27, visionOS 27, *))
     return pipe2(fildes, flag);
-    #else
-    errno = ENOSYS;
-    return -1;
-    #endif
+  __builtin_trap();
+  #elif defined(HAVE_PIPE2_DUP3)
+  return pipe2(fildes, flag);
+  #else
+  errno = ENOSYS;
+  return -1;
+  #endif
 }
 #endif // !defined(_WIN32)
 
 extern int csystem_posix_dup3(int fildes, int fildes2, int flag) {
-    #ifdef HAVE_PIPE2_DUP3
+  #if defined(__APPLE__) && defined(HAVE_PIPE2_DUP3)
+  if (__builtin_available(macOS 27, iOS 27, tvOS 27, watchOS 27, visionOS 27, *))
     return dup3(fildes, fildes2, flag);
-    #else
-    errno = ENOSYS;
-    return -1;
-    #endif
+  __builtin_trap();
+  #elif defined(HAVE_PIPE2_DUP3)
+  return dup3(fildes, fildes2, flag);
+  #else
+  errno = ENOSYS;
+  return -1;
+  #endif
 }

--- a/Sources/System/FileDescriptor.swift
+++ b/Sources/System/FileDescriptor.swift
@@ -328,11 +328,7 @@ extension FileDescriptor {
 
   /// Options that specify behavior for a newly-created pipe.
   @frozen
-  @available(macOS, unavailable)
-  @available(iOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  @available(visionOS, unavailable)
+  @available(macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0, *)
   public struct PipeOptions: OptionSet, Sendable, Hashable, Codable {
     /// The raw C options.
     @_alwaysEmitIntoClient
@@ -403,11 +399,7 @@ extension FileDescriptor {
   /// Options that specify behavior for a duplicated file descriptor.
   @frozen
   @available(Windows, unavailable)
-  @available(macOS, unavailable)
-  @available(iOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  @available(visionOS, unavailable)
+  @available(macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0, *)
   public struct DuplicateOptions: OptionSet, Sendable, Hashable, Codable {
     /// The raw C options.
     @_alwaysEmitIntoClient
@@ -532,7 +524,6 @@ extension FileDescriptor {
     @available(*, unavailable, renamed: "nextData")
     public static var SEEK_DATA: SeekOrigin { nextData }
 #endif
-
   }
 }
 

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -370,13 +370,13 @@ extension FileDescriptor {
 #if !os(WASI)
 @available(System 0.0.2, *)
 extension FileDescriptor {
-  /// Duplicates this file descriptor and return the newly created copy.
+  /// Duplicates this file descriptor and returns the newly created copy.
   ///
   /// - Parameters:
   ///   - `target`: The desired target file descriptor, or `nil`, in which case
   ///      the copy is assigned to the file descriptor with the lowest raw value
   ///      that is not currently in use by the process.
-  ///   - retryOnInterrupt: Whether to retry the write operation
+  ///   - retryOnInterrupt: Whether to retry the duplicate operation
   ///      if it throws ``Errno/interrupted``. The default is `true`.
   ///      Pass `false` to try only once and throw an error upon interruption.
   /// - Returns: The new file descriptor.
@@ -436,20 +436,19 @@ extension FileDescriptor {
   /// close-on-fork flags.
   ///
   /// The corresponding C function is `dup3`.
-  @discardableResult
-  @_alwaysEmitIntoClient
   @available(Windows, unavailable)
-  @available(macOS, unavailable)
-  @available(iOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  @available(visionOS, unavailable)
+  @available(macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0, *)
+  @_alwaysEmitIntoClient
+  @discardableResult
   public func duplicate(
     as target: FileDescriptor,
     options: DuplicateOptions,
     retryOnInterrupt: Bool = true
   ) throws(Errno) -> FileDescriptor {
-    try _duplicate(as: target, options: options.rawValue, retryOnInterrupt: retryOnInterrupt).get()
+    let result = _duplicate(
+      as: target, options: options.rawValue, retryOnInterrupt: retryOnInterrupt
+    )
+    return try result.get()
   }
 
   @available(System 0.0.2, *)
@@ -468,11 +467,7 @@ extension FileDescriptor {
   }
 
   @available(Windows, unavailable)
-  @available(macOS, unavailable)
-  @available(iOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  @available(visionOS, unavailable)
+  @available(macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0, *)
   @usableFromInline
   internal func _duplicate(
     as target: FileDescriptor,
@@ -502,7 +497,7 @@ extension FileDescriptor {
     fatalError("Not implemented")
   }
 }
-#endif
+#endif // !os(WASI)
 
 #if !os(WASI)
 @available(System 1.1.0, *)
@@ -535,11 +530,7 @@ extension FileDescriptor {
   ///
   /// The corresponding C function is `pipe2`.
   @_alwaysEmitIntoClient
-  @available(macOS, unavailable)
-  @available(iOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  @available(visionOS, unavailable)
+  @available(macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0, *)
   public static func pipe(
     options: PipeOptions
   ) throws(Errno) -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
@@ -560,11 +551,7 @@ extension FileDescriptor {
     }
   }
 
-  @available(macOS, unavailable)
-  @available(iOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  @available(visionOS, unavailable)
+  @available(macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0, *)
   @usableFromInline
   internal static func _pipe(
     options: Int32,
@@ -585,7 +572,7 @@ extension FileDescriptor {
     fatalError("Not implemented")
   }
 }
-#endif
+#endif // !os(WASI)
 
 @available(System 1.2.0, *)
 extension FileDescriptor {
@@ -674,4 +661,4 @@ extension FilePermissions {
     return system_umask(mode)
   }
 }
-#endif
+#endif // !os(WASI)

--- a/Sources/System/Internals/Constants.swift
+++ b/Sources/System/Internals/Constants.swift
@@ -14,22 +14,20 @@
 #if SYSTEM_PACKAGE_DARWIN
 import Darwin
 #elseif os(Windows)
-import CSystem
 import ucrt
 #elseif canImport(Glibc)
-import CSystem
 import Glibc
 #elseif canImport(Musl)
-import CSystem
 import Musl
 #elseif canImport(WASILibc)
-import CSystem
 import WASILibc
 #elseif canImport(Android)
 import Android
 #else
 #error("Unsupported Platform")
 #endif
+
+import CSystem
 
 // MARK: errno
 #if SYSTEM_PACKAGE_DARWIN
@@ -631,10 +629,10 @@ internal var _O_CLOEXEC: CInt {
 #if !os(Windows)
 @_alwaysEmitIntoClient
 internal var _O_CLOFORK: CInt {
-  #if !os(WASI) && !os(Linux) && !os(Android) && !canImport(Darwin) && !os(FreeBSD)
+  #if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
+  COMPATIBILITY_O_CLOFORK
+  #elseif !os(WASI) && !os(Linux) && !os(Android)
   O_CLOFORK
-  #elseif os(FreeBSD)
-  FREEBSD_O_CLOFORK
   #else
   0
   #endif

--- a/Sources/System/Internals/Syscalls.swift
+++ b/Sources/System/Internals/Syscalls.swift
@@ -141,13 +141,14 @@ internal func system_dup2(_ fd: Int32, _ fd2: Int32) -> Int32 {
   return dup2(fd, fd2)
 }
 
+@available(macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0, *)
 internal func system_dup3(_ fd: Int32, _ fd2: Int32, _ oflag: Int32) -> Int32 {
-  #if ENABLE_MOCKING
+#if ENABLE_MOCKING
   if mockingEnabled { return _mock(fd, fd2, oflag) }
-  #endif
+#endif
   return csystem_posix_dup3(fd, fd2, oflag)
 }
-#endif
+#endif // !os(WASI)
 
 #if !os(WASI)
 internal func system_pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
@@ -157,13 +158,14 @@ internal func system_pipe(_ fds: UnsafeMutablePointer<Int32>) -> CInt {
   return pipe(fds)
 }
 
+@available(macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0, *)
 internal func system_pipe2(_ fds: UnsafeMutablePointer<Int32>, _ oflag: Int32) -> CInt {
 #if ENABLE_MOCKING
   if mockingEnabled { return _mock(fds, oflag) }
 #endif
   return csystem_posix_pipe2(fds, oflag)
 }
-#endif
+#endif // !os(WASI)
 
 internal func system_ftruncate(_ fd: Int32, _ length: off_t) -> Int32 {
 #if ENABLE_MOCKING
@@ -201,7 +203,7 @@ internal func system_confstr(
 ) -> Int {
   return confstr(name, buf, len)
 }
-#endif
+#endif // SYSTEM_PACKAGE_DARWIN
 
 #if !os(Windows)
 internal let SYSTEM_AT_REMOVE_DIR = AT_REMOVEDIR
@@ -269,7 +271,7 @@ internal func system_openat(
 #endif
   return openat(fd, path, oflag)
 }
-#endif
+#endif // !os(Windows)
 
 #if !os(WASI) // WASI has no umask
 internal func system_umask(
@@ -277,7 +279,7 @@ internal func system_umask(
 ) -> CInterop.Mode {
   return umask(mode)
 }
-#endif
+#endif // !os(WASI)
 
 internal func system_getenv(
   _ name: UnsafePointer<CChar>

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2025 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -157,7 +157,8 @@ final class FileOperationsTest: XCTestCase {
     // TODO: Test writeAll, writeAll(toAbsoluteOffset), closeAfter
   }
 
-  #if !os(WASI) // WASI has no pipe
+#if !os(WASI) // WASI has no pipe
+  @available(System 1.1.0, *)
   func testAdHocPipe() throws {
     // Ad-hoc test testing `Pipe` functionality.
     // We cannot test `Pipe` using `MockTestCase` because it calls `pipe` with a pointer to an array local to the `Pipe`, the address of which we do not know prior to invoking `Pipe`.
@@ -177,8 +178,10 @@ final class FileOperationsTest: XCTestCase {
     }
   }
 
-  #if !SYSTEM_PACKAGE_DARWIN
   func testAdHocPipeWithOptions() throws {
+    guard #available(macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0, *) else {
+      throw XCTSkip("pipe2 and PipeOptions require Darwin 27 or newer")
+    }
     // Ad-hoc test testing `Pipe` functionality.
     // We cannot test `Pipe` using `MockTestCase` because it calls `pipe` with a pointer to an array local to the `Pipe`, the address of which we do not know prior to invoking `Pipe`.
     let options: FileDescriptor.PipeOptions = [.closeOnExec]
@@ -198,10 +201,9 @@ final class FileOperationsTest: XCTestCase {
       }
     }
   }
-  #endif // !SYSTEM_PACKAGE_DARWIN
-  #endif // !os(WASI)
+#endif // !os(WASI)
 
-  #if !os(Windows)
+#if !os(Windows)
   func testAdHocDuplicate2() throws {
     try withTemporaryFilePath(basename: "test") {
       let path = $0.appending("foo2.txt")
@@ -238,10 +240,11 @@ final class FileOperationsTest: XCTestCase {
       }
     }
   }
-  #endif // !os(Windows)
 
-  #if !SYSTEM_PACKAGE_DARWIN && !os(Windows)
   func testAdHocDuplicate3() throws {
+    guard #available(macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0, *) else {
+      throw XCTSkip("dup3 and DuplicateOptions require Darwin 27 or newer")
+    }
 
     try withTemporaryFilePath(basename: "test") {
       let path = $0.appending("foo3.txt")
@@ -274,7 +277,7 @@ final class FileOperationsTest: XCTestCase {
       }
     }
   }
-  #endif // !SYSTEM_PACKAGE_DARWIN && !os(Windows)
+#endif // !os(Windows)
 
   func testAdHocOpen() {
     // Ad-hoc test touching a file system.
@@ -334,6 +337,7 @@ final class FileOperationsTest: XCTestCase {
   }
   #endif // ENABLE_MOCKING
 
+  @available(System 1.2.0, *)
   func testResizeFile() throws {
     try withTemporaryFilePath(basename: "testResizeFile") { path in 
       let fd = try FileDescriptor.open(path.appending("\(UUID().uuidString).txt"), .readWrite, options: [.create, .truncate], permissions: .ownerReadWrite)


### PR DESCRIPTION
Implement the SYS-0007 amendment from https://github.com/apple/swift-system/pull/346.