### PR TITLE
Cherry-pick: remove unnecessary type casting

### DIFF
--- a/Sources/System/FilePath/FilePathTempWindows.swift
+++ b/Sources/System/FilePath/FilePathTempWindows.swift
@@ -73,7 +73,7 @@ internal func _recursiveRemove(
 ) throws {
   // First, deal with subdirectories
   try forEachFile(at: path) { findData in
-    if (findData.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY)) != 0 {
+    if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0 {
       let name = withUnsafeBytes(of: findData.cFileName) {
         return SystemString(platformString: $0.assumingMemoryBound(
                               to: CInterop.PlatformChar.self).baseAddress!)
@@ -94,7 +94,7 @@ internal func _recursiveRemove(
     let component = FilePath.Component(name)!
     let subpath = path.appending(component)
 
-    if (findData.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY)) == 0 {
+    if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0 {
       try subpath.withPlatformString { subpath in
         if try !subpath.withCanonicalPathRepresentation({ DeleteFileW($0) }) {
           throw Errno(windowsError: GetLastError())

--- a/Sources/System/FilePath/FilePathWindows.swift
+++ b/Sources/System/FilePath/FilePathWindows.swift
@@ -529,7 +529,7 @@ fileprivate func SUCCEEDED(_ hr: HRESULT) -> Bool {
 // an HRESULT to a Win32 error code.
 @inline(__always)
 fileprivate func WIN32_FROM_HRESULT(_ hr: HRESULT) -> DWORD {
-    if SUCCEEDED(hr) { return DWORD(ERROR_SUCCESS) }
+    if SUCCEEDED(hr) { return ERROR_SUCCESS }
     if HRESULT_FACILITY(hr) == FACILITY_WIN32 {
         return HRESULT_CODE(hr)
     }

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -38,9 +38,9 @@ internal func open(
   guard let hFile = try? path.withCanonicalPathRepresentation({ path in
     CreateFileW(path,
                 decodedFlags.dwDesiredAccess,
-                DWORD(FILE_SHARE_DELETE
-                      | FILE_SHARE_READ
-                      | FILE_SHARE_WRITE),
+                FILE_SHARE_DELETE
+                  | FILE_SHARE_READ
+                  | FILE_SHARE_WRITE,
                 &saAttrs,
                 decodedFlags.dwCreationDisposition,
                 decodedFlags.dwFlagsAndAttributes,
@@ -80,9 +80,9 @@ internal func open(
   guard let hFile = try? path.withCanonicalPathRepresentation({ path in
     CreateFileW(path,
                 decodedFlags.dwDesiredAccess,
-                DWORD(FILE_SHARE_DELETE
-                      | FILE_SHARE_READ
-                      | FILE_SHARE_WRITE),
+                FILE_SHARE_DELETE
+                  | FILE_SHARE_READ
+                  | FILE_SHARE_WRITE,
                 &saAttrs,
                 decodedFlags.dwCreationDisposition,
                 decodedFlags.dwFlagsAndAttributes,
@@ -202,16 +202,16 @@ internal func ftruncate(_ fd: Int32, _ length: off_t) -> Int32 {
 
   // Save the current position and restore it when we're done
   if !SetFilePointerEx(hFile, liCurrentOffset, &liCurrentOffset,
-                       DWORD(FILE_CURRENT)) {
+                       FILE_CURRENT) {
     ucrt._set_errno(_mapWindowsErrorToErrno(GetLastError()))
     return -1
   }
   defer {
-    _ = SetFilePointerEx(hFile, liCurrentOffset, nil, DWORD(FILE_BEGIN));
+    _ = SetFilePointerEx(hFile, liCurrentOffset, nil, FILE_BEGIN);
   }
 
   // Truncate (or extend) the file
-  if !SetFilePointerEx(hFile, liDesiredLength, nil, DWORD(FILE_BEGIN))
+  if !SetFilePointerEx(hFile, liDesiredLength, nil, FILE_BEGIN)
        || !SetEndOfFile(hFile) {
     ucrt._set_errno(_mapWindowsErrorToErrno(GetLastError()))
     return -1
@@ -263,7 +263,7 @@ internal func rmdir(
 }
 
 internal func _mapWindowsErrorToErrno(_ errorCode: DWORD) -> CInt {
-  switch Int32(errorCode) {
+  switch errorCode {
   case ERROR_SUCCESS:
     return 0
   case ERROR_INVALID_FUNCTION,
@@ -342,28 +342,28 @@ fileprivate func rightsFromModeBits(
   var rights: DWORD = 0
 
   if (bits & 0o4) != 0 {
-    rights |= DWORD(FILE_READ_ATTRIBUTES
-                      | FILE_READ_DATA
-                      | FILE_READ_EA
-                      | STANDARD_RIGHTS_READ
-                      | SYNCHRONIZE)
+    rights |= (FILE_READ_ATTRIBUTES
+      | FILE_READ_DATA
+      | FILE_READ_EA
+      | STANDARD_RIGHTS_READ
+      | SYNCHRONIZE)
   }
   if (bits & 0o2) != 0 {
-    rights |= DWORD(FILE_APPEND_DATA
-                      | FILE_WRITE_ATTRIBUTES
-                      | FILE_WRITE_DATA
-                      | FILE_WRITE_EA
-                      | STANDARD_RIGHTS_WRITE
-                      | SYNCHRONIZE)
+    rights |= (FILE_APPEND_DATA
+      | FILE_WRITE_ATTRIBUTES
+      | FILE_WRITE_DATA
+      | FILE_WRITE_EA
+      | STANDARD_RIGHTS_WRITE
+      | SYNCHRONIZE)
     if fileOrDirectory == .directory && !sticky {
-      rights |= DWORD(FILE_DELETE_CHILD)
+      rights |= FILE_DELETE_CHILD
     }
   }
   if (bits & 0o1) != 0 {
-    rights |= DWORD(FILE_EXECUTE
-                      | FILE_READ_ATTRIBUTES
-                      | STANDARD_RIGHTS_EXECUTE
-                      | SYNCHRONIZE)
+    rights |= (FILE_EXECUTE
+      | FILE_READ_ATTRIBUTES
+      | STANDARD_RIGHTS_EXECUTE
+      | SYNCHRONIZE)
   }
 
   return rights
@@ -431,7 +431,7 @@ internal func _createSecurityDescriptor(from mode: CInterop.Mode,
   var everyone: PSID? = nil
 
   guard AllocateAndInitializeSid(&SIDAuthWorld, 1,
-                                 DWORD(SECURITY_WORLD_RID),
+                                 SECURITY_WORLD_RID,
                                  0, 0, 0, 0, 0, 0, 0,
                                  &everyone) else {
     return nil
@@ -472,7 +472,7 @@ internal func _createSecurityDescriptor(from mode: CInterop.Mode,
     EXPLICIT_ACCESS_W(
       grfAccessPermissions: ownerRights,
       grfAccessMode: GRANT_ACCESS,
-      grfInheritance: DWORD(NO_INHERITANCE),
+      grfInheritance: NO_INHERITANCE,
       Trustee: TRUSTEE_W(
         pMultipleTrustee: nil,
         MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
@@ -485,7 +485,7 @@ internal func _createSecurityDescriptor(from mode: CInterop.Mode,
     EXPLICIT_ACCESS_W(
       grfAccessPermissions: groupRights,
       grfAccessMode: GRANT_ACCESS,
-      grfInheritance: DWORD(NO_INHERITANCE),
+      grfInheritance: NO_INHERITANCE,
       Trustee: TRUSTEE_W(
         pMultipleTrustee: nil,
         MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
@@ -498,7 +498,7 @@ internal func _createSecurityDescriptor(from mode: CInterop.Mode,
     EXPLICIT_ACCESS_W(
       grfAccessPermissions: otherRights,
       grfAccessMode: GRANT_ACCESS,
-      grfInheritance: DWORD(NO_INHERITANCE),
+      grfInheritance: NO_INHERITANCE,
       Trustee: TRUSTEE_W(
         pMultipleTrustee: nil,
         MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
@@ -515,7 +515,7 @@ internal func _createSecurityDescriptor(from mode: CInterop.Mode,
       EXPLICIT_ACCESS_W(
         grfAccessPermissions: ownerDenyRights,
         grfAccessMode: DENY_ACCESS,
-        grfInheritance: DWORD(NO_INHERITANCE),
+        grfInheritance: NO_INHERITANCE,
         Trustee: TRUSTEE_W(
           pMultipleTrustee: nil,
           MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
@@ -533,7 +533,7 @@ internal func _createSecurityDescriptor(from mode: CInterop.Mode,
       EXPLICIT_ACCESS_W(
         grfAccessPermissions: groupDenyRights,
         grfAccessMode: DENY_ACCESS,
-        grfInheritance: DWORD(NO_INHERITANCE),
+        grfInheritance: NO_INHERITANCE,
         Trustee: TRUSTEE_W(
           pMultipleTrustee: nil,
           MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
@@ -562,13 +562,13 @@ internal func _createSecurityDescriptor(from mode: CInterop.Mode,
   var descriptor = SECURITY_DESCRIPTOR()
 
   guard InitializeSecurityDescriptor(&descriptor,
-                                     DWORD(SECURITY_DESCRIPTOR_REVISION)) else {
+                                     SECURITY_DESCRIPTOR_REVISION) else {
     return nil
   }
 
   guard SetSecurityDescriptorControl(&descriptor,
-                                     SECURITY_DESCRIPTOR_CONTROL(SE_DACL_PROTECTED),
-                                     SECURITY_DESCRIPTOR_CONTROL(SE_DACL_PROTECTED))
+                                     SE_DACL_PROTECTED,
+                                     SE_DACL_PROTECTED)
           && SetSecurityDescriptorOwner(&descriptor, user, false)
           && SetSecurityDescriptorGroup(&descriptor, group, false)
           && SetSecurityDescriptorDacl(&descriptor,
@@ -608,15 +608,15 @@ fileprivate struct DecodedOpenFlags {
   init(_ oflag: Int32) {
     switch oflag & (_O_CREAT | _O_EXCL | _O_TRUNC) {
     case _O_CREAT | _O_EXCL, _O_CREAT | _O_EXCL | _O_TRUNC:
-      dwCreationDisposition = DWORD(CREATE_NEW)
+      dwCreationDisposition = CREATE_NEW
     case _O_CREAT:
-      dwCreationDisposition = DWORD(OPEN_ALWAYS)
+      dwCreationDisposition = OPEN_ALWAYS
     case _O_CREAT | _O_TRUNC:
-      dwCreationDisposition = DWORD(CREATE_ALWAYS)
+      dwCreationDisposition = CREATE_ALWAYS
     case _O_TRUNC:
-      dwCreationDisposition = DWORD(TRUNCATE_EXISTING)
+      dwCreationDisposition = TRUNCATE_EXISTING
     default:
-      dwCreationDisposition = DWORD(OPEN_EXISTING)
+      dwCreationDisposition = OPEN_EXISTING
     }
 
     // The _O_RDONLY, _O_WRONLY and _O_RDWR flags are non-overlapping
@@ -625,11 +625,11 @@ fileprivate struct DecodedOpenFlags {
     dwDesiredAccess = 0
     switch (oflag & (_O_RDONLY|_O_WRONLY|_O_RDWR)) {
     case _O_RDONLY:
-      dwDesiredAccess |= DWORD(GENERIC_READ)
+      dwDesiredAccess |= GENERIC_READ
     case _O_WRONLY:
-      dwDesiredAccess |= DWORD(GENERIC_WRITE)
+      dwDesiredAccess |= GENERIC_WRITE
     case _O_RDWR:
-      dwDesiredAccess |= DWORD(GENERIC_READ) | DWORD(GENERIC_WRITE)
+      dwDesiredAccess |= GENERIC_READ | GENERIC_WRITE
     default:
       break
     }
@@ -638,19 +638,19 @@ fileprivate struct DecodedOpenFlags {
 
     dwFlagsAndAttributes = 0
     if (oflag & _O_SEQUENTIAL) != 0 {
-      dwFlagsAndAttributes |= DWORD(FILE_FLAG_SEQUENTIAL_SCAN)
+      dwFlagsAndAttributes |= FILE_FLAG_SEQUENTIAL_SCAN
     }
     if (oflag & _O_RANDOM) != 0 {
-      dwFlagsAndAttributes |= DWORD(FILE_FLAG_RANDOM_ACCESS)
+      dwFlagsAndAttributes |= FILE_FLAG_RANDOM_ACCESS
     }
     if (oflag & _O_TEMPORARY) != 0 {
-      dwFlagsAndAttributes |= DWORD(FILE_FLAG_DELETE_ON_CLOSE)
+      dwFlagsAndAttributes |= FILE_FLAG_DELETE_ON_CLOSE
     }
 
     if (oflag & _O_SHORT_LIVED) != 0 {
-      dwFlagsAndAttributes |= DWORD(FILE_ATTRIBUTE_TEMPORARY)
+      dwFlagsAndAttributes |= FILE_ATTRIBUTE_TEMPORARY
     } else {
-      dwFlagsAndAttributes |= DWORD(FILE_ATTRIBUTE_NORMAL)
+      dwFlagsAndAttributes |= FILE_ATTRIBUTE_NORMAL
     }
   }
 }

--- a/Sources/System/WinSDK+Overlay.swift
+++ b/Sources/System/WinSDK+Overlay.swift
@@ -1,0 +1,439 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+#if os(Windows)
+
+import WinSDK
+
+@_transparent
+internal var CREATE_ALWAYS: DWORD {
+  DWORD(WinSDK.CREATE_ALWAYS)
+}
+
+@_transparent
+internal var CREATE_NEW: DWORD {
+  DWORD(WinSDK.CREATE_NEW)
+}
+
+@_transparent
+internal var ERROR_ACCESS_DENIED: DWORD {
+  DWORD(WinSDK.ERROR_ACCESS_DENIED)
+}
+
+@_transparent
+internal var ERROR_ALREADY_EXISTS: DWORD {
+  DWORD(WinSDK.ERROR_ALREADY_EXISTS)
+}
+
+@_transparent
+internal var ERROR_ARENA_TRASHED: DWORD {
+  DWORD(WinSDK.ERROR_ARENA_TRASHED)
+}
+
+@_transparent
+internal var ERROR_BAD_ENVIRONMENT: DWORD {
+  DWORD(WinSDK.ERROR_BAD_ENVIRONMENT)
+}
+
+@_transparent
+internal var ERROR_BAD_FORMAT: DWORD {
+  DWORD(WinSDK.ERROR_BAD_FORMAT)
+}
+
+@_transparent
+internal var ERROR_BAD_NET_NAME: DWORD {
+  DWORD(WinSDK.ERROR_BAD_NET_NAME)
+}
+
+@_transparent
+internal var ERROR_BAD_NETPATH: DWORD {
+  DWORD(WinSDK.ERROR_BAD_NETPATH)
+}
+
+@_transparent
+internal var ERROR_BAD_PATHNAME: DWORD {
+  DWORD(WinSDK.ERROR_BAD_PATHNAME)
+}
+
+@_transparent
+internal var ERROR_BROKEN_PIPE: DWORD {
+  DWORD(WinSDK.ERROR_BROKEN_PIPE)
+}
+
+@_transparent
+internal var ERROR_CANNOT_MAKE: DWORD {
+  DWORD(WinSDK.ERROR_CANNOT_MAKE)
+}
+
+@_transparent
+internal var ERROR_CHILD_NOT_COMPLETE: DWORD {
+  DWORD(WinSDK.ERROR_CHILD_NOT_COMPLETE)
+}
+
+@_transparent
+internal var ERROR_CURRENT_DIRECTORY: DWORD {
+  DWORD(WinSDK.ERROR_CURRENT_DIRECTORY)
+}
+
+@_transparent
+internal var ERROR_DIR_NOT_EMPTY: DWORD {
+  DWORD(WinSDK.ERROR_DIR_NOT_EMPTY)
+}
+
+@_transparent
+internal var ERROR_DISK_FULL: DWORD {
+  DWORD(WinSDK.ERROR_DISK_FULL)
+}
+
+@_transparent
+internal var ERROR_DRIVE_LOCKED: DWORD {
+  DWORD(WinSDK.ERROR_DRIVE_LOCKED)
+}
+
+@_transparent
+internal var ERROR_DIRECT_ACCESS_HANDLE: DWORD {
+  DWORD(WinSDK.ERROR_DIRECT_ACCESS_HANDLE)
+}
+
+@_transparent
+internal var ERROR_FILE_EXISTS: DWORD {
+  DWORD(WinSDK.ERROR_FILE_EXISTS)
+}
+
+@_transparent
+internal var ERROR_FILE_NOT_FOUND: DWORD {
+  DWORD(WinSDK.ERROR_FILE_NOT_FOUND)
+}
+
+@_transparent
+internal var ERROR_FAIL_I24: DWORD {
+  DWORD(WinSDK.ERROR_FAIL_I24)
+}
+
+@_transparent
+internal var ERROR_FILENAME_EXCED_RANGE: DWORD {
+  DWORD(WinSDK.ERROR_FILENAME_EXCED_RANGE)
+}
+
+@_transparent
+internal var ERROR_NEGATIVE_SEEK: DWORD {
+  DWORD(WinSDK.ERROR_NEGATIVE_SEEK)
+}
+
+@_transparent
+internal var ERROR_NO_MORE_FILES: DWORD {
+  DWORD(WinSDK.ERROR_NO_MORE_FILES)
+}
+
+@_transparent
+internal var ERROR_NO_UNICODE_TRANSLATION: DWORD {
+  DWORD(WinSDK.ERROR_NO_UNICODE_TRANSLATION)
+}
+
+@_transparent
+internal var ERROR_NOT_ENOUGH_MEMORY: DWORD {
+  DWORD(WinSDK.ERROR_NOT_ENOUGH_MEMORY)
+}
+
+@_transparent
+internal var ERROR_INVALID_ACCESS: DWORD {
+  DWORD(WinSDK.ERROR_INVALID_ACCESS)
+}
+
+@_transparent
+internal var ERROR_INVALID_BLOCK: DWORD {
+  DWORD(WinSDK.ERROR_INVALID_BLOCK)
+}
+
+@_transparent
+internal var ERROR_INVALID_DATA: DWORD {
+  DWORD(WinSDK.ERROR_INVALID_DATA)
+}
+
+@_transparent
+internal var ERROR_INVALID_DRIVE: DWORD {
+  DWORD(WinSDK.ERROR_INVALID_DRIVE)
+}
+
+@_transparent
+internal var ERROR_INVALID_FUNCTION: DWORD {
+  DWORD(WinSDK.ERROR_INVALID_FUNCTION)
+}
+
+@_transparent
+internal var ERROR_INVALID_HANDLE: DWORD {
+  DWORD(WinSDK.ERROR_INVALID_HANDLE)
+}
+
+@_transparent
+internal var ERROR_INFLOOP_IN_RELOC_CHAIN: DWORD {
+  DWORD(WinSDK.ERROR_INFLOOP_IN_RELOC_CHAIN)
+}
+
+@_transparent
+internal var ERROR_INVALID_PARAMETER: DWORD {
+  DWORD(WinSDK.ERROR_INVALID_PARAMETER)
+}
+
+@_transparent
+internal var ERROR_INVALID_STARTING_CODESEG: DWORD {
+  DWORD(WinSDK.ERROR_INVALID_STARTING_CODESEG)
+}
+
+@_transparent
+internal var ERROR_INVALID_TARGET_HANDLE: DWORD {
+  DWORD(WinSDK.ERROR_INVALID_TARGET_HANDLE)
+}
+
+@_transparent
+internal var ERROR_LOCK_FAILED: DWORD {
+  DWORD(WinSDK.ERROR_LOCK_FAILED)
+}
+
+@_transparent
+internal var ERROR_LOCK_VIOLATION: DWORD {
+  DWORD(WinSDK.ERROR_LOCK_VIOLATION)
+}
+
+@_transparent
+internal var ERROR_MAX_THRDS_REACHED: DWORD {
+  DWORD(WinSDK.ERROR_MAX_THRDS_REACHED)
+}
+
+@_transparent
+internal var ERROR_NESTING_NOT_ALLOWED: DWORD {
+  DWORD(WinSDK.ERROR_NESTING_NOT_ALLOWED)
+}
+
+@_transparent
+internal var ERROR_NETWORK_ACCESS_DENIED: DWORD {
+  DWORD(WinSDK.ERROR_NETWORK_ACCESS_DENIED)
+}
+
+@_transparent
+internal var ERROR_NO_PROC_SLOTS: DWORD {
+  DWORD(WinSDK.ERROR_NO_PROC_SLOTS)
+}
+
+@_transparent
+internal var ERROR_NOT_ENOUGH_QUOTA: DWORD {
+  DWORD(WinSDK.ERROR_NOT_ENOUGH_QUOTA)
+}
+
+@_transparent
+internal var ERROR_NOT_LOCKED: DWORD {
+  DWORD(WinSDK.ERROR_NOT_LOCKED)
+}
+
+@_transparent
+internal var ERROR_NOT_SAME_DEVICE: DWORD {
+  DWORD(WinSDK.ERROR_NOT_SAME_DEVICE)
+}
+
+@_transparent
+internal var ERROR_PATH_NOT_FOUND: DWORD {
+  DWORD(WinSDK.ERROR_PATH_NOT_FOUND)
+}
+
+@_transparent
+internal var ERROR_SEEK_ON_DEVICE: DWORD {
+  DWORD(WinSDK.ERROR_SEEK_ON_DEVICE)
+}
+
+@_transparent
+internal var ERROR_SHARING_BUFFER_EXCEEDED: DWORD {
+  DWORD(WinSDK.ERROR_SHARING_BUFFER_EXCEEDED)
+}
+
+@_transparent
+internal var ERROR_SUCCESS: DWORD {
+  DWORD(WinSDK.ERROR_SUCCESS)
+}
+
+@_transparent
+internal var ERROR_WAIT_NO_CHILDREN: DWORD {
+  DWORD(WinSDK.ERROR_WAIT_NO_CHILDREN)
+}
+
+@_transparent
+internal var ERROR_WRITE_PROTECT: DWORD {
+  DWORD(WinSDK.ERROR_WRITE_PROTECT)
+}
+
+@_transparent
+internal var ERROR_TOO_MANY_OPEN_FILES: DWORD {
+  DWORD(WinSDK.ERROR_TOO_MANY_OPEN_FILES)
+}
+
+@_transparent
+internal var FILE_APPEND_DATA: DWORD {
+  DWORD(WinSDK.FILE_APPEND_DATA)
+}
+
+@_transparent
+internal var FILE_ATTRIBUTE_DIRECTORY: DWORD {
+  DWORD(WinSDK.FILE_ATTRIBUTE_DIRECTORY)
+}
+
+@_transparent
+internal var FILE_ATTRIBUTE_NORMAL: DWORD {
+  DWORD(WinSDK.FILE_ATTRIBUTE_NORMAL)
+}
+
+@_transparent
+internal var FILE_ATTRIBUTE_TEMPORARY: DWORD {
+  DWORD(WinSDK.FILE_ATTRIBUTE_TEMPORARY)
+}
+
+@_transparent
+internal var FILE_BEGIN: DWORD {
+  DWORD(WinSDK.FILE_BEGIN)
+}
+
+@_transparent
+internal var FILE_CURRENT: DWORD {
+  DWORD(WinSDK.FILE_CURRENT)
+}
+
+@_transparent
+internal var FILE_DELETE_CHILD: DWORD {
+  DWORD(WinSDK.FILE_DELETE_CHILD)
+}
+
+@_transparent
+package var FILE_EXECUTE: DWORD {
+  DWORD(WinSDK.FILE_EXECUTE)
+}
+
+@_transparent
+internal var FILE_FLAG_DELETE_ON_CLOSE: DWORD {
+  DWORD(WinSDK.FILE_FLAG_DELETE_ON_CLOSE)
+}
+
+@_transparent
+internal var FILE_FLAG_RANDOM_ACCESS: DWORD {
+  DWORD(WinSDK.FILE_FLAG_RANDOM_ACCESS)
+}
+
+@_transparent
+internal var FILE_FLAG_SEQUENTIAL_SCAN: DWORD {
+  DWORD(WinSDK.FILE_FLAG_SEQUENTIAL_SCAN)
+}
+
+@_transparent
+package var FILE_READ_ATTRIBUTES: DWORD {
+  DWORD(WinSDK.FILE_READ_ATTRIBUTES)
+}
+
+@_transparent
+internal var FILE_READ_DATA: DWORD {
+  DWORD(WinSDK.FILE_READ_DATA)
+}
+
+@_transparent
+internal var FILE_READ_EA: DWORD {
+  DWORD(WinSDK.FILE_READ_EA)
+}
+
+@_transparent
+internal var FILE_SHARE_DELETE: DWORD {
+  DWORD(WinSDK.FILE_SHARE_DELETE)
+}
+
+@_transparent
+internal var FILE_SHARE_READ: DWORD {
+  DWORD(WinSDK.FILE_SHARE_READ)
+}
+
+@_transparent
+internal var FILE_SHARE_WRITE: DWORD {
+  DWORD(WinSDK.FILE_SHARE_WRITE)
+}
+
+@_transparent
+package var FILE_WRITE_ATTRIBUTES: DWORD {
+  DWORD(WinSDK.FILE_WRITE_ATTRIBUTES)
+}
+
+@_transparent
+internal var FILE_WRITE_DATA: DWORD {
+  DWORD(WinSDK.FILE_WRITE_DATA)
+}
+
+@_transparent
+internal var FILE_WRITE_EA: DWORD {
+  DWORD(WinSDK.FILE_WRITE_EA)
+}
+
+@_transparent
+internal var GENERIC_READ: DWORD {
+  DWORD(WinSDK.GENERIC_READ)
+}
+
+@_transparent
+internal var GENERIC_WRITE: DWORD {
+  DWORD(WinSDK.GENERIC_WRITE)
+}
+
+@_transparent
+internal var NO_INHERITANCE: DWORD {
+  DWORD(WinSDK.NO_INHERITANCE)
+}
+
+@_transparent
+internal var OPEN_ALWAYS: DWORD {
+  DWORD(WinSDK.OPEN_ALWAYS)
+}
+
+@_transparent
+internal var OPEN_EXISTING: DWORD {
+  DWORD(WinSDK.OPEN_EXISTING)
+}
+
+@_transparent
+internal var SE_DACL_PROTECTED: SECURITY_DESCRIPTOR_CONTROL {
+  SECURITY_DESCRIPTOR_CONTROL(WinSDK.SE_DACL_PROTECTED)
+}
+
+@_transparent
+internal var SECURITY_DESCRIPTOR_REVISION: DWORD {
+  DWORD(WinSDK.SECURITY_DESCRIPTOR_REVISION)
+}
+
+@_transparent
+internal var SECURITY_WORLD_RID: DWORD {
+  DWORD(WinSDK.SECURITY_WORLD_RID)
+}
+
+@_transparent
+internal var STANDARD_RIGHTS_READ: DWORD {
+  DWORD(WinSDK.STANDARD_RIGHTS_READ)
+}
+
+@_transparent
+internal var STANDARD_RIGHTS_EXECUTE: DWORD {
+  DWORD(WinSDK.STANDARD_RIGHTS_EXECUTE)
+}
+
+@_transparent
+internal var STANDARD_RIGHTS_WRITE: DWORD {
+  DWORD(WinSDK.STANDARD_RIGHTS_WRITE)
+}
+
+@_transparent
+internal var SYNCHRONIZE: DWORD {
+  DWORD(WinSDK.SYNCHRONIZE)
+}
+
+@_transparent
+internal var TRUNCATE_EXISTING: DWORD {
+  DWORD(WinSDK.TRUNCATE_EXISTING)
+}
+
+#endif

--- a/Tests/SystemTests/FileOperationsTestWindows.swift
+++ b/Tests/SystemTests/FileOperationsTestWindows.swift
@@ -19,6 +19,10 @@ import XCTest
 
 import WinSDK
 
+private let FILE_APPEND_DATA = DWORD(WinSDK.FILE_APPEND_DATA)
+private let FILE_EXECUTE = DWORD(WinSDK.FILE_EXECUTE)
+private let FILE_READ_ATTRIBUTES = DWORD(WinSDK.FILE_READ_ATTRIBUTES)
+
 @available(iOS 8, *)
 final class FileOperationsTestWindows: XCTestCase {
   private let r = ACCESS_MASK(
@@ -42,6 +46,8 @@ final class FileOperationsTestWindows: XCTestCase {
       | STANDARD_RIGHTS_EXECUTE
       | SYNCHRONIZE
   )
+
+  private let none = ACCESS_MASK(0)
 
   private struct Test {
     var permissions: CModeT
@@ -72,7 +78,7 @@ final class FileOperationsTestWindows: XCTestCase {
     var psidEveryone: PSID? = nil
 
     XCTAssert(AllocateAndInitializeSid(&SIDAuthWorld, 1,
-                                       DWORD(SECURITY_WORLD_RID),
+                                       SECURITY_WORLD_RID,
                                        0, 0, 0, 0, 0, 0, 0,
                                        &psidEveryone))
     defer {
@@ -106,7 +112,7 @@ final class FileOperationsTestWindows: XCTestCase {
                        &psidGroup,
                        &pDacl,
                        nil,
-                       &pSD), DWORD(ERROR_SUCCESS))
+                       &pSD), ERROR_SUCCESS)
       defer {
         LocalFree(pSD)
       }
@@ -135,15 +141,15 @@ final class FileOperationsTestWindows: XCTestCase {
       XCTAssertEqual(GetEffectiveRightsFromAclW(
                        pDacl,
                        &owner,
-                       &ownerAccess), DWORD(ERROR_SUCCESS))
+                       &ownerAccess), ERROR_SUCCESS)
       XCTAssertEqual(GetEffectiveRightsFromAclW(
                        pDacl,
                        &group,
-                       &groupAccess), DWORD(ERROR_SUCCESS))
+                       &groupAccess), ERROR_SUCCESS)
       XCTAssertEqual(GetEffectiveRightsFromAclW(
                        pDacl,
                        &everyone,
-                       &otherAccess), DWORD(ERROR_SUCCESS))
+                       &otherAccess), ERROR_SUCCESS)
 
       return (ownerAccess, groupAccess, otherAccess)
     }
@@ -182,9 +188,9 @@ final class FileOperationsTestWindows: XCTestCase {
 
     try withTemporaryFilePath(basename: "testUmask") { path in
       let tests = [
-        Test(0o000, 0, 0, 0),
-        Test(0o700, r|w|x, 0, 0),
-        Test(0o770, r|w|x, r|x, 0),
+        Test(0o000, none, none, none),
+        Test(0o700, r|w|x, none, none),
+        Test(0o770, r|w|x, r|x, none),
         Test(0o777, r|w|x, r|x, r|x)
       ]
 
@@ -195,9 +201,9 @@ final class FileOperationsTestWindows: XCTestCase {
                                           .otherWrite, .otherExecute]) {
       try withTemporaryFilePath(basename: "testUmask") { path in
         let tests = [
-          Test(0o000, 0, 0, 0),
-          Test(0o700, r|w|x, 0, 0),
-          Test(0o770, r|w|x, r, 0),
+          Test(0o000, none, none, none),
+          Test(0o700, r|w|x, none, none),
+          Test(0o770, r|w|x, r, none),
           Test(0o777, r|w|x, r, r)
         ]
 
@@ -214,28 +220,28 @@ final class FileOperationsTestWindows: XCTestCase {
     try FilePermissions.withCreationMask([]) {
       try withTemporaryFilePath(basename: "testPermissions") { path in
         let tests = [
-          Test(0o000, 0, 0, 0),
+          Test(0o000, none, none, none),
 
-          Test(0o400, r, 0, 0),
-          Test(0o200, w, 0, 0),
-          Test(0o100, x, 0, 0),
-          Test(0o040, 0, r, 0),
-          Test(0o020, 0, w, 0),
-          Test(0o010, 0, x, 0),
-          Test(0o004, 0, 0, r),
-          Test(0o002, 0, 0, w),
-          Test(0o001, 0, 0, x),
+          Test(0o400, r, none, none),
+          Test(0o200, w, none, none),
+          Test(0o100, x, none, none),
+          Test(0o040, none, r, none),
+          Test(0o020, none, w, none),
+          Test(0o010, none, x, none),
+          Test(0o004, none, none, r),
+          Test(0o002, none, none, w),
+          Test(0o001, none, none, x),
 
-          Test(0o700, r|w|x, 0, 0),
-          Test(0o770, r|w|x, r|w|x, 0),
+          Test(0o700, r|w|x, none, none),
+          Test(0o770, r|w|x, r|w|x, none),
           Test(0o777, r|w|x, r|w|x, r|w|x),
 
           Test(0o755, r|w|x, r|x, r|x),
           Test(0o644, r|w, r, r),
 
-          Test(0o007, 0, 0, r|w|x),
-          Test(0o070, 0, r|w|x, 0),
-          Test(0o077, 0, r|w|x, r|w|x),
+          Test(0o007, none, none, r|w|x),
+          Test(0o070, none, r|w|x, none),
+          Test(0o077, none, r|w|x, r|w|x),
         ]
 
         try runTests(tests, at: path)


### PR DESCRIPTION
The compiler now imports these as their canonical type, allowing us to directly use without the explicit type cast. Due to the floor of Swift 6.3, we must preserve the type cast values. Introduce an overlay to explicitly cast the values in the older compilers.

Cherry-pick of #308