### PR TITLE
Don't compare padding/reserved fields for `Stat` equality

### DIFF
--- a/Proposals/0006-system-stat.md
+++ b/Proposals/0006-system-stat.md
@@ -712,7 +712,7 @@ extension Stat: Equatable {
 }
 
 extension Stat: Hashable {
-  /// Hashes a subset of the fields compared by `==` that identify a file.
+  /// Hashes the meaningful file-metadata fields of a `Stat` struct.
   public func hash(into hasher: inout Hasher)
 }
 ```

--- a/Proposals/0006-system-stat.md
+++ b/Proposals/0006-system-stat.md
@@ -705,12 +705,14 @@ public struct Stat: RawRepresentable, Sendable {
 // MARK: - Equatable and Hashable
 
 extension Stat: Equatable {
-  /// Compares the raw bytes of two `Stat` structs for equality.
+  /// Compares the meaningful file-metadata fields of two `Stat` values.
+  ///
+  /// Alignment padding and platform reserved/"spare" fields are not compared.
   public static func == (lhs: Self, rhs: Self) -> Bool
 }
 
 extension Stat: Hashable {
-  /// Hashes the raw bytes of this `Stat` struct.
+  /// Hashes a subset of the fields compared by `==` that identify a file.
   public func hash(into hasher: inout Hasher)
 }
 ```

--- a/Proposals/0006-system-stat.md
+++ b/Proposals/0006-system-stat.md
@@ -79,7 +79,7 @@ These initializers use a typed `throws(Errno)` and require Swift 6.0 or later.
 
 See the **Appendix** section at the end of this proposal for a table view of Swift API to C mappings.
 
-All API are marked `@_alwaysEmitIntoClient` for performance and back-dating of availability.
+All API are marked `@_alwaysEmitIntoClient` for performance and back-dating of availability, except `Stat`'s `==` and `hash(into:)`, which are ordinary `public` API.
 
 ### FileType
 

--- a/Sources/System/FileSystem/Stat.swift
+++ b/Sources/System/FileSystem/Stat.swift
@@ -578,15 +578,35 @@ extension Stat: Equatable {
 
 @available(System 1.7.0, *)
 extension Stat: Hashable {
-  /// Hashes a subset of `Stat` fields that identify a file: the device and
-  /// inode identity plus a couple of high-entropy discriminators (size and
-  /// modification time).
+  /// Hashes the meaningful file-metadata fields of a `Stat` struct.
+  ///
+  /// These are the same fields compared by `==`, fed in the same order.
+  /// Alignment padding and platform reserved/"spare" fields are not hashed.
   public func hash(into hasher: inout Hasher) {
     hasher.combine(rawValue.st_dev)
     hasher.combine(rawValue.st_ino)
+    hasher.combine(rawValue.st_mode)
+    hasher.combine(rawValue.st_nlink)
+    hasher.combine(rawValue.st_uid)
+    hasher.combine(rawValue.st_gid)
+    hasher.combine(rawValue.st_rdev)
     hasher.combine(rawValue.st_size)
+    hasher.combine(rawValue.st_blksize)
+    hasher.combine(rawValue.st_blocks)
+    hasher.combine(st_atim.tv_sec)
+    hasher.combine(st_atim.tv_nsec)
     hasher.combine(st_mtim.tv_sec)
     hasher.combine(st_mtim.tv_nsec)
+    hasher.combine(st_ctim.tv_sec)
+    hasher.combine(st_ctim.tv_nsec)
+    #if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
+    hasher.combine(st_birthtim.tv_sec)
+    hasher.combine(st_birthtim.tv_nsec)
+    #endif
+    #if SYSTEM_PACKAGE_DARWIN || os(FreeBSD) || os(OpenBSD)
+    hasher.combine(rawValue.st_flags)
+    hasher.combine(rawValue.st_gen)
+    #endif
   }
 }
 

--- a/Sources/System/FileSystem/Stat.swift
+++ b/Sources/System/FileSystem/Stat.swift
@@ -538,25 +538,57 @@ public struct Stat: RawRepresentable, Sendable {
 
 @available(System 1.7.0, *)
 extension Stat: Equatable {
+  /// Compares the meaningful file-metadata fields of two `Stat` values.
+  ///
+  /// Alignment padding and platform reserved/"spare" fields are not compared.
   @_alwaysEmitIntoClient
-  /// Compares the raw bytes of two `Stat` structs for equality.
   public static func == (lhs: Self, rhs: Self) -> Bool {
-    return withUnsafeBytes(of: lhs.rawValue) { lhsBytes in
-      withUnsafeBytes(of: rhs.rawValue) { rhsBytes in
-        lhsBytes.elementsEqual(rhsBytes)
-      }
+    guard lhs.rawValue.st_dev == rhs.rawValue.st_dev,
+          lhs.rawValue.st_ino == rhs.rawValue.st_ino,
+          lhs.rawValue.st_mode == rhs.rawValue.st_mode,
+          lhs.rawValue.st_nlink == rhs.rawValue.st_nlink,
+          lhs.rawValue.st_uid == rhs.rawValue.st_uid,
+          lhs.rawValue.st_gid == rhs.rawValue.st_gid,
+          lhs.rawValue.st_rdev == rhs.rawValue.st_rdev,
+          lhs.rawValue.st_size == rhs.rawValue.st_size,
+          lhs.rawValue.st_blksize == rhs.rawValue.st_blksize,
+          lhs.rawValue.st_blocks == rhs.rawValue.st_blocks,
+          lhs.st_atim.tv_sec == rhs.st_atim.tv_sec,
+          lhs.st_atim.tv_nsec == rhs.st_atim.tv_nsec,
+          lhs.st_mtim.tv_sec == rhs.st_mtim.tv_sec,
+          lhs.st_mtim.tv_nsec == rhs.st_mtim.tv_nsec,
+          lhs.st_ctim.tv_sec == rhs.st_ctim.tv_sec,
+          lhs.st_ctim.tv_nsec == rhs.st_ctim.tv_nsec else {
+      return false
     }
+    #if SYSTEM_PACKAGE_DARWIN || os(FreeBSD)
+    guard lhs.st_birthtim.tv_sec == rhs.st_birthtim.tv_sec,
+          lhs.st_birthtim.tv_nsec == rhs.st_birthtim.tv_nsec else {
+      return false
+    }
+    #endif
+    #if SYSTEM_PACKAGE_DARWIN || os(FreeBSD) || os(OpenBSD)
+    guard lhs.rawValue.st_flags == rhs.rawValue.st_flags,
+          lhs.rawValue.st_gen == rhs.rawValue.st_gen else {
+      return false
+    }
+    #endif
+    return true
   }
 }
 
 @available(System 1.7.0, *)
 extension Stat: Hashable {
+  /// Hashes a subset of `Stat` fields that identify a file: the device and
+  /// inode identity plus a couple of high-entropy discriminators (size and
+  /// modification time).
   @_alwaysEmitIntoClient
-  /// Hashes the raw bytes of this `Stat` struct.
   public func hash(into hasher: inout Hasher) {
-    withUnsafeBytes(of: rawValue) { bytes in
-      hasher.combine(bytes: bytes)
-    }
+    hasher.combine(rawValue.st_dev)
+    hasher.combine(rawValue.st_ino)
+    hasher.combine(rawValue.st_size)
+    hasher.combine(st_mtim.tv_sec)
+    hasher.combine(st_mtim.tv_nsec)
   }
 }
 

--- a/Sources/System/FileSystem/Stat.swift
+++ b/Sources/System/FileSystem/Stat.swift
@@ -541,7 +541,6 @@ extension Stat: Equatable {
   /// Compares the meaningful file-metadata fields of two `Stat` values.
   ///
   /// Alignment padding and platform reserved/"spare" fields are not compared.
-  @_alwaysEmitIntoClient
   public static func == (lhs: Self, rhs: Self) -> Bool {
     guard lhs.rawValue.st_dev == rhs.rawValue.st_dev,
           lhs.rawValue.st_ino == rhs.rawValue.st_ino,
@@ -582,7 +581,6 @@ extension Stat: Hashable {
   /// Hashes a subset of `Stat` fields that identify a file: the device and
   /// inode identity plus a couple of high-entropy discriminators (size and
   /// modification time).
-  @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     hasher.combine(rawValue.st_dev)
     hasher.combine(rawValue.st_ino)

--- a/Tests/SystemTests/StatTests.swift
+++ b/Tests/SystemTests/StatTests.swift
@@ -397,6 +397,38 @@ private struct StatTests {
   }
   #endif
 
+  @available(System 1.7.0, *)
+  @Test func equalityAndHashing() async throws {
+    try withTemporaryFilePath(basename: "Stat_equality") { tempDir in
+      let file = tempDir.appending("test.txt")
+      let fd = try FileDescriptor.open(
+        file, .writeOnly, options: .create, permissions: .ownerReadWrite)
+      defer { try? fd.close() }
+
+      // Two stats of the same, unchanged file compare equal and hash equal,
+      // so they coalesce in a Set.
+      let stat1 = try file.stat()
+      var stat2 = try file.stat()
+      stat2.st_atim = stat1.st_atim // stat() can bump access time
+      #expect(stat1 == stat2)
+      #expect(stat1.hashValue == stat2.hashValue)
+      #expect(Set([stat1, stat2]).count == 1)
+
+      // Reserved/"spare" and padding bytes must not affect equality.
+      // Poke a reserved field and confirm equality/hashing are stable.
+      #if SYSTEM_PACKAGE_DARWIN
+      var stat3 = stat1
+      stat3.rawValue.st_lspare = stat1.rawValue.st_lspare &+ 1
+      #expect(stat1 == stat3)
+      #expect(stat1.hashValue == stat3.hashValue)
+      #endif
+
+      // A stat of a different file (the containing directory) is not equal.
+      let dirStat = try tempDir.stat()
+      #expect(stat1 != dirStat)
+    }
+  }
+
 }
 
 // Comparison operators for timespec until UTCClock.Instant properties are available


### PR DESCRIPTION
Don't compare arbitrary padding or reserved bytes when comparing two `Stat` values for equality. Instead, perform a field-wise comparison of all meaningful fields.

Similarly, update `Stat.hash(into:)` to use the same set of fields as `==`.