### PR TITLE
Update `Stat.generationNumber` to `UInt64`

### DIFF
--- a/Proposals/0006-system-stat.md
+++ b/Proposals/0006-system-stat.md
@@ -693,12 +693,13 @@ public struct Stat: RawRepresentable, Sendable {
 
   /// File generation number
   ///
-  /// The file generation number is used to distinguish between different files
-  /// that have used the same inode over time.
+  /// The file generation number may be used to distinguish between different
+  /// files that have used the same inode over time.
   ///
   /// The corresponding C property is `st_gen`.
-  /// - Note: Only available on Darwin, FreeBSD, and OpenBSD.
-  public var generationNumber: Int { get set }
+  /// - Note: Only available on Darwin, FreeBSD, and OpenBSD. The underlying C
+  ///   field is 32-bit on Darwin and OpenBSD, and 64-bit on FreeBSD.
+  public var generationNumber: UInt64 { get set }
   #endif
 }
 

--- a/Sources/System/FileSystem/Stat.swift
+++ b/Sources/System/FileSystem/Stat.swift
@@ -521,15 +521,16 @@ public struct Stat: RawRepresentable, Sendable {
 
   /// File generation number
   ///
-  /// The file generation number is used to distinguish between different files
-  /// that have used the same inode over time.
+  /// The file generation number may be used to distinguish between different
+  /// files that have used the same inode over time.
   ///
   /// The corresponding C property is `st_gen`.
-  /// - Note: Only available on Darwin, FreeBSD, and OpenBSD.
+  /// - Note: Only available on Darwin, FreeBSD, and OpenBSD. The underlying C
+  ///   field is 32-bit on Darwin and OpenBSD, and 64-bit on FreeBSD.
   @_alwaysEmitIntoClient
-  public var generationNumber: Int {
-    get { Int(rawValue.st_gen) }
-    set { rawValue.st_gen = numericCast(newValue)}
+  public var generationNumber: UInt64 {
+    get { UInt64(rawValue.st_gen) }
+    set { rawValue.st_gen = numericCast(newValue) }
   }
   #endif
 }


### PR DESCRIPTION
The underlying `st_gen` is `uint32_t` on Darwin and OpenBSD, but `__uint64_t` on newer FreeBSD versions. Update this API to return `UInt64` instead of `Int` to support all platforms.