### PR TITLE
Enable FreeBSD checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -61,6 +61,7 @@ jobs:
         ]
       enable_android_sdk_build: true
       enable_android_sdk_checks: true
+      enable_freebsd_checks: true
 
   build-abi-stable:
     name: Build ABI Stable


### PR DESCRIPTION
Enable the FreeBSD build and test checks from https://github.com/swiftlang/github-workflows. Currently, the workflow supports `nightly-main` on FreeBSD 14.3.