### PR TITLE
[gardening] some corrections

### DIFF
--- a/Sources/System/Errno.swift
+++ b/Sources/System/Errno.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2021 - 2024 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/System/FileOperations.swift
+++ b/Sources/System/FileOperations.swift
@@ -378,13 +378,13 @@ extension FileDescriptor {
 #if !os(WASI)
 @available(System 0.0.2, *)
 extension FileDescriptor {
-  /// Duplicates this file descriptor and return the newly created copy.
+  /// Duplicates this file descriptor and returns the newly created copy.
   ///
   /// - Parameters:
   ///   - `target`: The desired target file descriptor, or `nil`, in which case
   ///      the copy is assigned to the file descriptor with the lowest raw value
   ///      that is not currently in use by the process.
-  ///   - retryOnInterrupt: Whether to retry the write operation
+  ///   - retryOnInterrupt: Whether to retry the duplicate operation
   ///      if it throws ``Errno/interrupted``. The default is `true`.
   ///      Pass `false` to try only once and throw an error upon interruption.
   /// - Returns: The new file descriptor.

--- a/Sources/System/FilePath/FilePathString.swift
+++ b/Sources/System/FilePath/FilePathString.swift
@@ -461,7 +461,10 @@ extension String {
   public init(decoding path: FilePath) {
     self.init(_decoding: path)
   }
+}
 
+@available(System 0.0.2, *)
+extension String {
   /// Creates a string from a file path, validating its contents as UTF-8 on
   /// Unix and UTF-16 on Windows.
   ///
@@ -470,6 +473,7 @@ extension String {
   ///
   /// If the contents of the file path isn't a well-formed Unicode string,
   /// this initializer returns `nil`.
+  @available(System 0.0.2, *)
   public init?(validating path: FilePath) {
     self.init(_validating: path)
   }

--- a/Tests/SystemTests/FileOperationsTest.swift
+++ b/Tests/SystemTests/FileOperationsTest.swift
@@ -158,6 +158,7 @@ final class FileOperationsTest: XCTestCase {
   }
 
   #if !os(WASI) // WASI has no pipe
+  @available(System 1.1.0, *)
   func testAdHocPipe() throws {
     // Ad-hoc test testing `Pipe` functionality.
     // We cannot test `Pipe` using `MockTestCase` because it calls `pipe` with a pointer to an array local to the `Pipe`, the address of which we do not know prior to invoking `Pipe`.
@@ -334,6 +335,7 @@ final class FileOperationsTest: XCTestCase {
   }
   #endif // ENABLE_MOCKING
 
+  @available(System 1.2.0, *)
   func testResizeFile() throws {
     try withTemporaryFilePath(basename: "testResizeFile") { path in 
       let fd = try FileDescriptor.open(path.appending("\(UUID().uuidString).txt"), .readWrite, options: [.create, .truncate], permissions: .ownerReadWrite)


### PR DESCRIPTION
These are simple corrections: some missing availability annotations, an inconsistent copyright notice, and a long-standing copy-paste error in a doc-comment.