### PR TITLE
Prepare for Swift 6 language mode

### DIFF
--- a/Sources/System/CMakeLists.txt
+++ b/Sources/System/CMakeLists.txt
@@ -23,8 +23,27 @@ add_library(SystemPackage
   WinSDK+Overlay.swift)
 set_target_properties(SystemPackage PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+# Availability macro definitions.
+# Should stay in sync with the `availability` array in Package.swift,
+# matching `sourceAvailability`, which is the minimum Swift availability.
+# Availability support for Darwin platforms is omitted.
+set(SWIFT_SYSTEM_AVAILABILITY_VERSIONS
+  0.0.1 0.0.2 0.0.3
+  1.1.0 1.1.1 1.2.0 1.2.1 1.3.0 1.3.1 1.3.2 1.4.0
+  1.7.0
+  199)
+set(SWIFT_SYSTEM_SOURCE_AVAILABILITY
+  "macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, visionOS 1.0")
+set(SWIFT_SYSTEM_AVAILABILITY_MACRO)
+foreach(version IN LISTS SWIFT_SYSTEM_AVAILABILITY_VERSIONS)
+  list(APPEND SWIFT_SYSTEM_AVAILABILITY_MACRO
+    "SHELL:-enable-experimental-feature \"AvailabilityMacro=System ${version}:${SWIFT_SYSTEM_SOURCE_AVAILABILITY}\"")
+endforeach()
+
 target_compile_options(SystemPackage PRIVATE
   -enable-experimental-feature Lifetimes
+  ${SWIFT_SYSTEM_AVAILABILITY_MACRO}
   "SHELL:-package-name swift-system")
 target_sources(SystemPackage PRIVATE
   FilePath/FilePath.swift

--- a/Sources/System/Internals/CInterop.swift
+++ b/Sources/System/Internals/CInterop.swift
@@ -13,10 +13,10 @@ import Darwin
 import CSystem
 import ucrt
 #elseif canImport(Glibc)
-@_implementationOnly import CSystem
+import CSystem
 import Glibc
 #elseif canImport(Musl)
-@_implementationOnly import CSystem
+import CSystem
 import Musl
 #elseif canImport(WASILibc)
 import WASILibc

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -18,15 +18,15 @@ import Darwin
 import CSystem
 import ucrt
 #elseif canImport(Glibc)
-@_implementationOnly import CSystem
+import CSystem
 import Glibc
 #elseif canImport(Musl)
-@_implementationOnly import CSystem
+import CSystem
 import Musl
 #elseif canImport(WASILibc)
 import WASILibc
 #elseif canImport(Android)
-@_implementationOnly import CSystem
+import CSystem
 import Android
 #else
 #error("Unsupported Platform")

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -185,8 +185,9 @@ extension String {
 #if os(Windows)
 internal typealias _PlatformTLSKey = DWORD
 #elseif os(WASI) && (swift(<6.1) || !_runtime(_multithreaded))
-// Mock TLS storage for single-threaded WASI
-internal final class _PlatformTLSKey {
+// Mock TLS storage for single-threaded WASI.
+// Carries no state of its own, and only used to index `sharedTLSStorage`.
+internal final class _PlatformTLSKey: @unchecked Sendable {
   fileprivate init() {}
 }
 private final class TLSStorage: @unchecked Sendable {

--- a/Sources/System/Internals/WindowsSyscallAdapters.swift
+++ b/Sources/System/Internals/WindowsSyscallAdapters.swift
@@ -11,16 +11,15 @@
 
 import ucrt
 import WinSDK
+import Synchronization
 
-fileprivate var _umask: CInterop.Mode = 0o22
+private let _umask = Atomic<CInterop.Mode>(0o22)
 
 @inline(__always)
 func umask(
   _ mode: CInterop.Mode
 ) -> CInterop.Mode {
-  let oldMask = _umask
-  _umask = mode
-  return oldMask
+  _umask.exchange(mode, ordering: .relaxed)
 }
 
 @inline(__always)
@@ -58,7 +57,7 @@ internal func open(
   _ path: UnsafePointer<CInterop.PlatformChar>, _ oflag: Int32,
   _ mode: CInterop.Mode
 ) -> CInt {
-  let actualMode = mode & ~_umask
+  let actualMode = mode & ~_umask.load(ordering: .relaxed)
 
   guard let pSD = _createSecurityDescriptor(from: actualMode, for: .file) else {
     ucrt._set_errno(_mapWindowsErrorToErrno(GetLastError()))
@@ -248,7 +247,7 @@ internal func mkdir(
   _ path: UnsafePointer<CInterop.PlatformChar>,
   _ mode: CInterop.Mode
 ) -> CInt {
-  let actualMode = mode & ~_umask
+  let actualMode = mode & ~_umask.load(ordering: .relaxed)
 
   guard let pSD = _createSecurityDescriptor(from: actualMode,
                                             for: .directory) else {


### PR DESCRIPTION
The newer compilers allow us to remove the `@_implementationOnly import` statements, and at the same time get rid of many warnings when building on Linux. This branch contains many changes that compile correctly in Swift 6 language mode, but the swift-ci macOS runners cannot successfully compile the package in that mode. Once they're updated to macOS 15.4 or later, we should be able to enable Swift 6 language mode.