### PR TITLE
Fix assertion during lexical path normalization

### DIFF
--- a/Sources/System/FilePath/FilePathParsing.swift
+++ b/Sources/System/FilePath/FilePathParsing.swift
@@ -168,7 +168,7 @@ extension FilePath {
             readIdx = nextStart
             continue
           }
-          assert(self.root == nil && self.components.first!.kind == .parentDirectory)
+          assert(!hasRoot && _isParentDirectory(priorComponent))
         }
       }
 

--- a/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
@@ -437,6 +437,13 @@ final class FilePathSyntaxTest: XCTestCase {
       ),
 
       .unix(
+        "foo/../../../bar",
+        dirname: "foo/../../..", basename: "bar",
+        components: ["foo", "..", "..", "..", "bar"],
+        lexicallyNormalized: "../../bar"
+      ),
+
+      .unix(
         "a/.././.././../b",
         dirname: "a/.././.././..", basename: "b",
         components: ["a", "..", ".", "..", ".", "..", "b"],


### PR DESCRIPTION
Fixes #283

### What changed

- Avoid reparsing mutable compacted storage while asserting the parent-directory invariant during lexical normalization.
- Add a regression case for `foo/../../../bar`.

### Validation

- `swift test --filter FilePathSyntaxTest` — 6 tests passed.

No documentation or release-note changes are required.
