### PR TITLE
Recognize non-letter Windows drive designators

### DIFF
--- a/Sources/System/FilePath/FilePathWindows.swift
+++ b/Sources/System/FilePath/FilePathWindows.swift
@@ -85,10 +85,10 @@ struct _Lexer {
     slice._eat(.backslash) != nil
   }
 
-  // Try to consume a drive letter and subsequent `:`.
+  // Try to consume a drive designator and subsequent `:`.
   mutating func eatDrive() -> SystemChar? {
     let copy = slice
-    if let d = slice._eat(if: { $0.isLetter }), slice._eat(.colon) != nil {
+    if let d = slice._eat(if: { !isSeparator($0) && $0 != .colon }), slice._eat(.colon) != nil {
       return d
     }
     // Restore slice

--- a/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathSyntaxTest.swift
@@ -595,7 +595,7 @@ final class FilePathSyntaxTest: XCTestCase {
       ),
     ]
 
-    let windowsPaths: Array<SyntaxTestCase> = [
+    var windowsPaths: Array<SyntaxTestCase> = [
       .windows(#""#, absolute: false,  components: []),
 
       .windows(
@@ -626,6 +626,15 @@ final class FilePathSyntaxTest: XCTestCase {
         dirname: #"C:\foo"#, basename: "bar.exe",
         stem: "bar", extension: "exe",
         components: ["foo", "bar.exe"]
+      ),
+
+      .windows(
+        #"+:\foo"#,
+        absolute: true,
+        root: #"+:\"#, relative: #"foo"#,
+        dirname: #"+:\"#, basename: "foo",
+        stem: "foo",
+        components: ["foo"]
       ),
 
       .windows(
@@ -768,6 +777,19 @@ final class FilePathSyntaxTest: XCTestCase {
 
       // TODO: partially-formed Windows roots, we should fully form them...
     ]
+
+#if os(Windows)
+    windowsPaths.append(
+      .windows(
+        #"€:\foo"#,
+        absolute: true,
+        root: #"€:\"#, relative: #"foo"#,
+        dirname: #"€:\"#, basename: "foo",
+        stem: "foo",
+        components: ["foo"]
+      )
+    )
+#endif
 
     for test in unixPaths {
       test.runAllTests()


### PR DESCRIPTION
Fixes #271

### What changed

- Recognize any single non-separator, non-colon character as a Windows drive designator instead of restricting the syntax to ASCII letters.
- Add simulated-Windows coverage for `+:\\foo`; keep the Unicode `€:` case gated to native Windows where the platform character type supports it.

### Validation

- `swift test --filter FilePathSyntaxTest` — 6 tests passed.
