### PR TITLE
fix(wasi): use mock TLS for all non-threaded WASI targets

### DIFF
--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -184,7 +184,7 @@ extension String {
 // TLS
 #if os(Windows)
 internal typealias _PlatformTLSKey = DWORD
-#elseif os(WASI) && (swift(<6.1) || !_runtime(_multithreaded))
+#elseif os(WASI) && !_runtime(_multithreaded)
 // Mock TLS storage for single-threaded WASI.
 // Carries no state of its own, and only used to index `sharedTLSStorage`.
 internal final class _PlatformTLSKey: @unchecked Sendable {
@@ -214,7 +214,7 @@ internal func makeTLSKey() -> _PlatformTLSKey {
     fatalError("Unable to create key")
   }
   return raw
-  #elseif os(WASI) && (swift(<6.1) || !_runtime(_multithreaded))
+  #elseif os(WASI) && !_runtime(_multithreaded)
   return _PlatformTLSKey()
   #else
   var raw = pthread_key_t()


### PR DESCRIPTION
## Summary

Gates mock TLS on WASI solely on `!_runtime(_multithreaded)` rather than `swift(<6.1) || !_runtime`. On Swift 6.1+ standard WASI toolchains the old gate falls into the `#else` branch, which assumes POSIX `pthread_key_t` / `pthread_* `. Standard WASI libc does not expose those symbols for the non-threaded target, producing scope-resolution failures:

```
Sources/System/Internals/Exports.swift:221:14: cannot find 'pthread_key_create' in scope
Sources/System/Internals/Exports.swift:233:14: cannot find 'pthread_setspecific' in scope
```

With the fix, non-threaded WASI always uses the mock `_PlatformTLSKey`/dictionary store and pthread paths are reserved for threaded WASI, regardless of Swift version.

## Issue

Fixes #370 — `[WASI] Compilation failure on Swift 6.1+ due to missing pthread symbols`.

## Validation

- `git diff --check` passes
- Two-line change in `Exports.swift` (typealias and `makeTLSKey`)