### PR TITLE
fix(MachPort): silence concurrency check for mach_task_self_

### DIFF
--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -9,7 +9,11 @@
 
 #if SYSTEM_PACKAGE_DARWIN
 
+#if canImport(Darwin, _version: 310)
+import Darwin.Mach
+#else
 @preconcurrency import Darwin.Mach
+#endif
 
 @available(System 1.4.0, *)
 public protocol MachPortRight {}

--- a/Sources/System/MachPort.swift
+++ b/Sources/System/MachPort.swift
@@ -9,7 +9,7 @@
 
 #if SYSTEM_PACKAGE_DARWIN
 
-import Darwin.Mach
+@preconcurrency import Darwin.Mach
 
 @available(System 1.4.0, *)
 public protocol MachPortRight {}


### PR DESCRIPTION
## Summary

Import Darwin.Mach with `@preconcurrency` so `mach_task_self_` (a shared global from Mach) does not trigger Swift 6.3's concurrency check:

```
error: reference to var 'mach_task_self_' is not concurrency-safe because it involves shared mutable state
```

The existing call sites (`mach_port_guard`, `mach_port_destruct`, etc.) keep their current form; the import attribute suppresses the diagnostic for this known thread-safe global without per-call-site workarounds.

## Issue

Fixes #373 — 1.8.0 `mach_task_self_` concurrency error on macos-14 GHA with Swift 6.3.

## Validation

- `git diff --check` passes