### PR TITLE
[TESTING] Add dual-backing FilePath (classic swift-system + SE-0529)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,10 @@
 
 import PackageDescription
 
+/// The availability floor every `System` macro maps to in the SwiftPM build.
+let systemSourceAvailability =
+  "macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, visionOS 1.0"
+
 struct Available {
   var name: String
   var version: String
@@ -25,7 +29,7 @@ struct Available {
     self.name = "System"
     self.version = version
     self.osAvailability = osAvailability
-    self.sourceAvailability = "macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, visionOS 1.0"
+    self.sourceAvailability = systemSourceAvailability
   }
 
   var swiftSetting: SwiftSetting {
@@ -81,6 +85,31 @@ let swiftSettings = swiftSettingsAvailability + swiftSettingsCI + [
   .define("SYSTEM_PACKAGE"),
   .define("ENABLE_MOCKING", .when(configuration: .debug)),
   .enableExperimentalFeature("Lifetimes"),
+
+  // MARK: - Dual-backing FilePath (testing branch)
+  //
+  // FilePath is a wrapper over two backings: the classic swift-system
+  // implementation (_SwiftSystemFilePath, the default) and the SE-0529 one
+  // (_StdlibFilePath), selected by _SWIFT_SYSTEM_NEW_FILEPATH. The settings
+  // below are what that transplanted code was validated with.
+
+  // The SE-0529 core carries @available(SwiftStdlib 9999, *) throughout. That
+  // is a stdlib-build spelling for "a future release". Map it to 26, the floor
+  // where `Span` (which the core's code-unit views vend) became available.
+  //
+  // Deliberately NOT mapped to 9999 with -disable-availability-checking, which
+  // is how the prototype built it: that flag also folds `#available` queries to
+  // true, so runtime-gated tests (the macOS 27 dup3/pipe2 skips in
+  // FileOperationsTest) would stop skipping and fail with ENOSYS. 26 is also
+  // strictly below those 27 gates, so they still skip.
+  .enableExperimentalFeature(
+    "AvailabilityMacro=SwiftStdlib 9999:macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26"),
+  // Selects the package flavor of the SE-0529 core: its own
+  // _internalInvariant, and a libc resolve() instead of the SwiftShims one.
+  .define("FILEPATH_PACKAGE"),
+  // The transplanted code was validated in the Swift 5 language mode; match it
+  // so Swift 6 concurrency diagnostics do not masquerade as real errors.
+  .swiftLanguageMode(.v5),
 ]
 
 let cSettings: [CSetting] = [
@@ -95,8 +124,20 @@ let platforms: [SupportedPlatform] = [
   .tvOS("26"),
   .visionOS("26"),
 ]
-#else 
-let platforms: [SupportedPlatform]? = nil
+#else
+// Dual-backing FilePath (testing branch): the SE-0529 core vends `Span`, which
+// needs a 26 floor, and its `@available(SwiftStdlib 9999, *)` is mapped to 26
+// above. A nil (SwiftPM-default, 10.13-era) deployment target would make every
+// use of those decls "only available in macOS 26 or newer". Upstream this is
+// nil; the 27 runtime gates in FileOperationsTest still evaluate normally
+// because 26 is below them.
+let platforms: [SupportedPlatform]? = [
+  .macOS("26"),
+  .iOS("26"),
+  .watchOS("26"),
+  .tvOS("26"),
+  .visionOS("26"),
+]
 #endif
 
 #if os(Linux)

--- a/Sources/System/CMakeLists.txt
+++ b/Sources/System/CMakeLists.txt
@@ -35,6 +35,11 @@ set(SWIFT_SYSTEM_AVAILABILITY_VERSIONS
   199)
 set(SWIFT_SYSTEM_SOURCE_AVAILABILITY
   "macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, visionOS 1.0")
+# The SE-0529 FilePath core carries @available(SwiftStdlib 9999, *). Mapped to
+# 26, the floor where `Span` (which its code-unit views vend) is available.
+# Should stay in sync with the SwiftStdlib 9999 macro in Package.swift.
+set(SWIFT_SYSTEM_STDLIB_AVAILABILITY
+  "macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26")
 set(SWIFT_SYSTEM_AVAILABILITY_MACRO)
 foreach(version IN LISTS SWIFT_SYSTEM_AVAILABILITY_VERSIONS)
   list(APPEND SWIFT_SYSTEM_AVAILABILITY_MACRO
@@ -44,18 +49,59 @@ endforeach()
 target_compile_options(SystemPackage PRIVATE
   -enable-experimental-feature Lifetimes
   ${SWIFT_SYSTEM_AVAILABILITY_MACRO}
+  "SHELL:-enable-experimental-feature \"AvailabilityMacro=SwiftStdlib 9999:${SWIFT_SYSTEM_STDLIB_AVAILABILITY}\""
+  -swift-version 5
   "SHELL:-package-name swift-system")
+# Selects the package flavor of the SE-0529 core: its own _internalInvariant,
+# and a libc resolve() instead of the SwiftShims one.
+target_compile_definitions(SystemPackage PRIVATE FILEPATH_PACKAGE)
+# The dual-backing FilePath. `FilePath` itself is the wrapper in Wrapper/; the
+# two implementations it dispatches to are _StdlibFilePath/ (SE-0529) and
+# _SwiftSystemFilePath/ (the historical one), and FilePath/ is the compat
+# adapter that reprovisions swift-system's own FilePath API on top of the core.
 target_sources(SystemPackage PRIVATE
-  FilePath/FilePath.swift
+  _StdlibFilePath/FilePath.swift
+  _StdlibFilePath/FilePathAnchor.swift
+  _StdlibFilePath/FilePathCodeUnits.swift
+  _StdlibFilePath/FilePathComponent.swift
+  _StdlibFilePath/FilePathComponentView.swift
+  _StdlibFilePath/FilePathDarwin.swift
+  _StdlibFilePath/FilePathDecomposition.swift
+  _StdlibFilePath/FilePathInternals.swift
+  _StdlibFilePath/FilePathParsing.swift
+  _StdlibFilePath/FilePathResolve.swift
+  _StdlibFilePath/FilePathStringBridging.swift
+  _StdlibFilePath/FilePathSystemString.swift
+  _StdlibFilePath/FilePathWindows.swift)
+target_sources(SystemPackage PRIVATE
+  _SwiftSystemFilePath/_SwiftSystemFilePath.swift
+  _SwiftSystemFilePath/_SwiftSystemFilePathComponents.swift
+  _SwiftSystemFilePath/_SwiftSystemFilePathComponentView.swift
+  _SwiftSystemFilePath/_SwiftSystemFilePathParsing.swift
+  _SwiftSystemFilePath/_SwiftSystemFilePathString.swift
+  _SwiftSystemFilePath/_SwiftSystemFilePathSyntax.swift
+  _SwiftSystemFilePath/_SwiftSystemFilePathWindows.swift)
+target_sources(SystemPackage PRIVATE
+  Wrapper/WrapperComponent.swift
+  Wrapper/WrapperComponentView.swift
+  Wrapper/WrapperConformances.swift
+  Wrapper/WrapperExtras.swift
+  Wrapper/WrapperFilePath.swift
+  Wrapper/WrapperRoot.swift
+  Wrapper/WrapperString.swift
+  Wrapper/WrapperSyntax.swift)
+target_sources(SystemPackage PRIVATE
+  FilePath/FilePathCompatInternals.swift
+  FilePath/FilePathCompatShims.swift
+  FilePath/FilePathComponentCompat.swift
   FilePath/FilePathComponents.swift
-  FilePath/FilePathComponentView.swift
-  FilePath/FilePathParsing.swift
+  FilePath/FilePathConformances.swift
   FilePath/FilePathString.swift
   FilePath/FilePathSyntax.swift
   FilePath/FilePathTemp.swift
   FilePath/FilePathTempPosix.swift
   FilePath/FilePathTempWindows.swift
-  FilePath/FilePathWindows.swift)
+  FilePath/SystemStringShim.swift)
 target_sources(SystemPackage PRIVATE
   FileSystem/FileFlags.swift
   FileSystem/FileMode.swift

--- a/Sources/System/FilePath/FilePathCompatInternals.swift
+++ b/Sources/System/FilePath/FilePathCompatInternals.swift
@@ -1,0 +1,80 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+
+// PORT SHIM: re-plumbs the internal `_StdlibFilePath` helpers that the old package
+// API (FilePathSyntax.swift, FilePathString.swift, …) still calls onto the
+// SE-0529 stdlib copy's internals. These names used to live in the old
+// _StdlibFilePath implementation files that were emptied during the port; the
+// bodies below are reimplemented on the copy's `_storage: _SystemString`,
+// its `_parseRoot()` boundaries, and the `_normalizing` construction funnel.
+//
+// Temporary by design: once the call sites move to the copy's own API
+// (`anchor`, `hasTrailingSeparator`, `components`, …) these compat members
+// and their call sites are the mechanical removal list. Do not grow API here.
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Old debug invariant hook. The stdlib copy has no whole-path recheck
+  /// method (it asserts inline via `_internalInvariant` and establishes
+  /// invariants at construction), so this checks the invariant directly:
+  /// the path must be a fixed point of the `_normalizing` funnel.
+  internal func _invariantCheck() {
+    #if DEBUG
+    // Normal form is a fixed point of the normalizing funnel: renormalizing
+    // this path's own code units must reproduce it.
+    precondition(
+      _StdlibFilePath(_normalizing: _cuArray) == self,
+      "_StdlibFilePath storage not in stdlib normal form")
+    #endif
+  }
+
+  /// Whether the path begins with an anchor/root.
+  ///
+  /// Mirrors the copy's `anchor != nil`.
+  internal var _hasRoot: Bool { anchor != nil }
+
+  /// Append raw path bytes, inserting a platform separator between existing
+  /// content and the new bytes when the current storage does not already end
+  /// in one. Routes the result through the copy's `_normalizing` funnel so
+  /// storage keeps the copy's invariants (coalesced separators, dot rules).
+  internal mutating func _append(
+    unchecked newElements: some Collection<_StdlibFilePath.CodeUnit>
+  ) {
+    guard !newElements.isEmpty else { return }
+    var bytes = _cuArray
+    if !bytes.isEmpty, !_isSeparator(bytes.last!) {
+      bytes.append(_platformSeparator)
+    }
+    bytes.append(contentsOf: newElements)
+    self = _StdlibFilePath(_normalizing: bytes)
+  }
+
+  /// Drop a trailing directory separator, if the path has a non-structural
+  /// one. Delegates to the copy's `hasTrailingSeparator` setter, which
+  /// preserves separators that belong to the anchor (e.g. `\\server\share\`).
+  internal mutating func _removeTrailingSeparator() {
+    hasTrailingSeparator = false
+  }
+
+  /// Lexically collapse `.` and `..` components in place, matching
+  /// swift-system's legacy `lexicallyNormalize()`: drop `.`, resolve `..`
+  /// against preceding regular components, and drop any trailing separator.
+  ///
+  /// This is the legacy configuration of `_StdlibFilePath._lexicallyNormalize`:
+  /// all three aspects enabled.
+  internal mutating func _normalizeSpecialDirectories() {
+    guard !isLexicallyNormal else { return }
+    defer { assert(isLexicallyNormal) }
+    _lexicallyNormalize(
+      removeCurrentDirectory: true,
+      collapseParentDirectory: true,
+      removeTrailingSeparator: true)
+  }
+}

--- a/Sources/System/FilePath/FilePathCompatShims.swift
+++ b/Sources/System/FilePath/FilePathCompatShims.swift
@@ -1,0 +1,95 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+
+// PORT SHIM: in-module reprovisions of the _StdlibFilePath-internal helpers the compat
+// layer used to reach across the module boundary. Everything here is expressed
+// on _StdlibFilePath's PUBLIC API (`codeUnits` / `nullTerminatedCodeUnits` spans,
+// `_StdlibFilePath.separator`) or on generic code-unit sequences. No _StdlibFilePath
+// internal (`_storage`, `_SystemString`, `_isSeparator`, `_platformSeparator`,
+// `_Encoding`) is named.
+
+// MARK: - Separator helpers and code-unit constants (removed)
+
+// `_platformSeparator`, `_isSeparator`, and the `_null` / `_dot` / `_slash`
+// constants used to be reprovisioned here because the base's own copies were
+// _StdlibFilePath-internal, across a module boundary. The base now compiles into this
+// module and each reprovision was identical to the base's by construction: the
+// base's public `separator` is defined as `{ _platformSeparator }`, and the
+// constants reduce to the same `numericCast(UInt8(ascii:))`. So they are gone
+// and every caller resolves to the base's.
+
+// MARK: - Span materialization
+
+/// Copy a code-unit span into an `Array` so it can be fed to the
+/// `_StdlibFilePath(_normalizing:)` funnel (which takes a `Sequence`, and `Span` is
+/// not one) or iterated freely.
+@available(SwiftStdlib 9999, *)
+internal func _copyToArray(
+  _ span: borrowing Span<_StdlibFilePath.CodeUnit>
+) -> [_StdlibFilePath.CodeUnit] {
+  var a = [_StdlibFilePath.CodeUnit]()
+  a.reserveCapacity(span.count)
+  for i in span.indices { a.append(span[i]) }
+  return a
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// This path's code units (no null terminator) as an `Array`.
+  internal var _cuArray: [_StdlibFilePath.CodeUnit] { _copyToArray(codeUnits) }
+}
+
+// MARK: - Platform-string (NUL-terminated C pointer) access
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Calls `body` with a pointer to the path's null-terminated platform-string
+  /// contents. Materializes the null-terminated code units and rebinds them to
+  /// `CInterop.PlatformChar` (layout-identical to `_StdlibFilePath.CodeUnit`).
+  internal func _withPlatformString<Result>(
+    _ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result
+  ) rethrows -> Result {
+    let units = _copyToArray(nullTerminatedCodeUnits)
+    return try units.withUnsafeBufferPointer { buf in
+      try buf.baseAddress!.withMemoryRebound(
+        to: CInterop.PlatformChar.self, capacity: buf.count
+      ) { try body($0) }
+    }
+  }
+}
+
+// MARK: - Decode a code-unit sequence to String
+
+@available(SwiftStdlib 9999, *)
+extension Array where Element == _StdlibFilePath.CodeUnit {
+  /// Decode as `CInterop.PlatformUnicodeEncoding` (UTF-8 on Unix, UTF-16 on
+  /// Windows), replacing ill-formed sequences with U+FFFD.
+  internal var _decodedString: String {
+    withUnsafeBufferPointer { buf in
+      buf.withMemoryRebound(
+        to: CInterop.PlatformUnicodeEncoding.CodeUnit.self
+      ) { String(decoding: $0, as: CInterop.PlatformUnicodeEncoding.self) }
+    }
+  }
+}
+
+// MARK: - SystemString from raw code units
+
+@available(SwiftStdlib 9999, *)
+extension SystemString {
+  /// Build a `SystemString` from raw (NUL-free) code units, adding the null
+  /// terminator. Used to encode a component's / root's exact bytes.
+  internal init(_codeUnits bytes: [_StdlibFilePath.CodeUnit]) {
+    self.init(
+      nullTerminated: (bytes + [_StdlibFilePath.CodeUnit._null]).map {
+        SystemChar(rawValue: $0)
+      })
+  }
+}

--- a/Sources/System/FilePath/FilePathComponentCompat.swift
+++ b/Sources/System/FilePath/FilePathComponentCompat.swift
@@ -1,0 +1,32 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+
+// PORT SHIM: internal helpers for _StdlibFilePath.Component that the old package
+// API (Component.extension / Component.stem in FilePathSyntax.swift) relies
+// on. The SE-0529 copy has no stem/extension notion, so these are the old
+// swift-system algorithms retyped from the old substrate (SystemChar,
+// Slice<SystemString>) onto the copy's (_StdlibFilePath.CodeUnit,
+// Slice<_SystemString>). Algorithm bodies are unchanged from the originals
+// in FilePathComponents.swift (now PORT-CLOBBERED there).
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Component {
+  /// The index, into this component's code units (`_codeUnits`), of the `.`
+  /// that denotes an extension, or `nil` if there is none (no interior `.`,
+  /// a leading-only `.`, or a special `.`/`..` component).
+  internal func _extensionIndex(_ bytes: [_StdlibFilePath.CodeUnit]) -> Int? {
+    guard kind == .regular,
+          let idx = bytes.lastIndex(of: ._dot),
+          idx != bytes.startIndex
+    else { return nil }
+
+    return idx
+  }
+}

--- a/Sources/System/FilePath/FilePathComponents.swift
+++ b/Sources/System/FilePath/FilePathComponents.swift
@@ -7,10 +7,11 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
+
 // MARK: - API
 
 @available(System 0.0.2, *)
-extension FilePath {
+extension _StdlibFilePath {
   /// Represents a root of a file path.
   ///
   /// On Unix, a root is simply the directory separator `/`.
@@ -30,13 +31,11 @@ extension FilePath {
   ///   * `\\?\Volume{12345678-abcd-1111-2222-123445789abc}\`
   @available(System 0.0.2, *)
   public struct Root: Sendable {
-    internal var _path: FilePath
-    internal var _rootEnd: SystemString.Index
+    // Root is a thin wrapper over the stdlib copy's public `Anchor`.
+    internal var _anchor: _StdlibFilePath.Anchor
 
-    internal init(_ path: FilePath, rootEnd: SystemString.Index) {
-      self._path = path
-      self._rootEnd = rootEnd
-      _invariantCheck()
+    internal init(_ anchor: _StdlibFilePath.Anchor) {
+      self._anchor = anchor
     }
     // TODO: Definitely want a small form for this on Windows,
     // and intern "/" for Unix.
@@ -50,32 +49,35 @@ extension FilePath {
   ///
   /// Example:
   ///
-  ///     var path: FilePath = "/tmp"
-  ///     let file: FilePath.Component = "foo.txt"
+  ///     var path: _StdlibFilePath = "/tmp"
+  ///     let file: _StdlibFilePath.Component = "foo.txt"
   ///     file.kind == .regular           // true
   ///     file.extension                  // "txt"
   ///     path.append(file)               // path is "/tmp/foo.txt"
+#if false // PORT-CLOBBERED: superseded by stdlib copy
   @available(System 0.0.2, *)
   public struct Component: Sendable {
-    internal var _path: FilePath
+    internal var _path: _StdlibFilePath
     internal var _range: Range<SystemString.Index>
 
     // TODO: Make a small-component form to save on ARC overhead when
     // extracted from a path, and especially to save on allocation overhead
     // when constructing one from a String literal.
 
-    internal init<RE: RangeExpression>(_ path: FilePath, _ range: RE)
+    internal init<RE: RangeExpression>(_ path: _StdlibFilePath, _ range: RE)
     where RE.Bound == SystemString.Index {
       self._path = path
       self._range = range.relative(to: path._storage)
-      precondition(!self._range.isEmpty, "FilePath components cannot be empty")
+      precondition(!self._range.isEmpty, "_StdlibFilePath components cannot be empty")
       self._invariantCheck()
     }
   }
+#endif
 }
 
+#if false // PORT-CLOBBERED: superseded by stdlib copy
 @available(System 0.0.2, *)
-extension FilePath.Component {
+extension _StdlibFilePath.Component {
 
   /// Whether a component is a regular file or directory name, or a special
   /// directory `.` or `..`
@@ -99,25 +101,55 @@ extension FilePath.Component {
     return .regular
   }
 }
+#endif
 
 @available(System 0.0.2, *)
-extension FilePath.Root {
+extension _StdlibFilePath.Root {
   // TODO: Windows analysis APIs
+}
+
+// Reconstruct a path from an optional root plus components. swift-system
+// public API. The `ComponentView` overload copies the view's contribution
+// verbatim via the public `components` setter, preserving a trailing separator
+// on the source path (matching swift-system); the generic-collection overload
+// rebuilds from discrete components, which carry no trailing separator.
+// `Root` is a thin wrapper over the copy's `Anchor`.
+@available(System 0.0.2, *)
+extension _StdlibFilePath {
+  /// Create a file path from an optional root and no components.
+  public init(root: _StdlibFilePath.Root?) {
+    self = _StdlibFilePath(anchor: root?._anchor, [])
+  }
+
+  /// Create a file path from an optional root and a component view.
+  public init(root: _StdlibFilePath.Root?, _ components: _StdlibFilePath.ComponentView) {
+    self.init(root: root)
+    self.components = components
+  }
+
+  /// Create a file path from an optional root and a collection of components.
+  public init<C: Collection>(
+    root: _StdlibFilePath.Root?, _ components: C
+  ) where C.Element == _StdlibFilePath.Component {
+    self = _StdlibFilePath(anchor: root?._anchor, Array(components))
+  }
 }
 
 // MARK: - Internals
 
+#if false // PORT-CLOBBERED: dead code; its callers died with the old
+// ComponentView, and the stdlib copy's ComponentView machinery supersedes it.
 extension SystemString {
   // TODO: take insertLeadingSlash: Bool
   // TODO: turn into an insert operation with slide
   internal mutating func appendComponents<C: Collection>(
     components: C
-  ) where C.Element == FilePath.Component {
+  ) where C.Element == _StdlibFilePath.Component {
     // TODO(perf): Consider pre-pass to count capacity, slide
 
     defer {
       _removeTrailingSeparator()
-      FilePath(self)._invariantCheck()
+      _StdlibFilePath(self)._invariantCheck()
     }
 
     for idx in components.indices {
@@ -127,89 +159,87 @@ extension SystemString {
     }
   }
 }
+#endif
 
-// Unifying protocol for common functionality between roots, components,
-// and views onto SystemString and FilePath.
-internal protocol _StrSlice: _PlatformStringable, Hashable, Codable {
-  var _storage: SystemString { get }
-  var _range: Range<SystemString.Index> { get }
+// Unifying protocol for common functionality between roots and components.
+// Reprovisioned over the stdlib copy's PUBLIC byte access: each conformer
+// exposes its code units (no NUL) via `_codeUnits` and can be rebuilt from a
+// code-unit array. No _StdlibFilePath internal (`_storage`, `_range`) is named.
+internal protocol _StrSlice: _PlatformStringable {
+  /// The slice's code units, excluding any null terminator.
+  var _codeUnits: [_StdlibFilePath.CodeUnit] { get }
 
-  init?(_ str: SystemString)
+  init?(_ codeUnits: [_StdlibFilePath.CodeUnit])
 
   func _invariantCheck()
 }
 extension _StrSlice {
-  internal var _slice: Slice<SystemString> {
-    Slice(base: _storage, bounds: _range)
-  }
-
   internal func _withSystemChars<T>(
-    _ f: (UnsafeBufferPointer<SystemChar>) throws -> T
+    _ f: (UnsafeBufferPointer<_StdlibFilePath.CodeUnit>) throws -> T
   ) rethrows -> T {
-    try _storage.withNullTerminatedSystemChars {
-      try f(UnsafeBufferPointer(rebasing: $0[_range]))
-    }
+    try _codeUnits.withUnsafeBufferPointer(f)
   }
   internal func _withCodeUnits<T>(
     _ f: (UnsafeBufferPointer<CInterop.PlatformUnicodeEncoding.CodeUnit>) throws -> T
   ) rethrows -> T {
-    try _slice.withCodeUnits(f)
+    try _codeUnits.withUnsafeBufferPointer { buf in
+      try buf.withMemoryRebound(
+        to: CInterop.PlatformUnicodeEncoding.CodeUnit.self
+      ) { try f($0) }
+    }
   }
 
   internal init?(_platformString s: UnsafePointer<CInterop.PlatformChar>) {
-    self.init(SystemString(platformString: s))
+    // Copy the C string's code units (up to the NUL) via the substrate, then
+    // validate. `SystemChar.rawValue` is `CInterop.PlatformChar`, which is
+    // `_StdlibFilePath.CodeUnit` on every platform.
+    self.init(SystemString(platformString: s).map { $0.rawValue })
   }
 
   internal func _withPlatformString<Result>(
     _ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result
   ) rethrows -> Result {
-    try _slice.withPlatformString(body)
-  }
-
-  internal var _systemString: SystemString { SystemString(_slice) }
-}
-extension _StrSlice {
-  public static func == (lhs: Self, rhs: Self) -> Bool {
-    lhs._slice.elementsEqual(rhs._slice)
-  }
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(_slice.count) // discriminator
-    for element in _slice {
-      hasher.combine(element)
+    var units = _codeUnits
+    units.append(._null)
+    return try units.withUnsafeBufferPointer { buf in
+      try buf.baseAddress!.withMemoryRebound(
+        to: CInterop.PlatformChar.self, capacity: buf.count
+      ) { try body($0) }
     }
   }
 }
-internal protocol _PathSlice: _StrSlice {
-  var _path: FilePath { get }
-}
-extension _PathSlice {
-  internal var _storage: SystemString { _path._storage }
-}
 
 @available(System 0.0.2, *)
-extension FilePath.Component: _PathSlice {
+extension _StdlibFilePath.Component: _StrSlice {
+  internal var _codeUnits: [_StdlibFilePath.CodeUnit] { _copyToArray(codeUnits) }
 }
 @available(System 0.0.2, *)
-extension FilePath.Root: _PathSlice {
-  internal var _range: Range<SystemString.Index> {
-    (..<_rootEnd).relative(to: _path._storage)
+extension _StdlibFilePath.Root: _StrSlice {
+  internal var _codeUnits: [_StdlibFilePath.CodeUnit] { _copyToArray(_anchor.codeUnits) }
+}
+
+// Root's currency conformances (Component's come from the stdlib copy).
+@available(System 0.0.2, *)
+extension _StdlibFilePath.Root: Equatable, Hashable {
+  public static func == (lhs: _StdlibFilePath.Root, rhs: _StdlibFilePath.Root) -> Bool {
+    lhs._anchor == rhs._anchor
+  }
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_anchor)
   }
 }
 
 @available(System 0.0.1, *)
-extension FilePath: _PlatformStringable {
-  func _withPlatformString<Result>(_ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result) rethrows -> Result {
-    try _storage.withPlatformString(body)
-  }
-
+extension _StdlibFilePath: _PlatformStringable {
+  // `_withPlatformString` is provided in FilePathCompatShims.swift.
   init(_platformString: UnsafePointer<CInterop.PlatformChar>) {
     self.init(SystemString(platformString: _platformString))
   }
-
 }
 
+#if false // PORT-CLOBBERED: superseded by stdlib copy
 @available(System 0.0.2, *)
-extension FilePath.Component {
+extension _StdlibFilePath.Component {
   // The index of the `.` denoting an extension
   internal func _extensionIndex() -> SystemString.Index? {
     guard kind == .regular,
@@ -229,6 +259,7 @@ extension FilePath.Component {
     _slice.startIndex ..< (_extensionIndex() ?? _slice.endIndex)
   }
 }
+#endif
 
 internal func _makeExtension(_ ext: String) -> SystemString {
   var result = SystemString()
@@ -238,27 +269,46 @@ internal func _makeExtension(_ ext: String) -> SystemString {
 }
 
 @available(System 0.0.2, *)
-extension FilePath.Component {
-  internal init?(_ str: SystemString) {
-    // FIXME: explicit null root? Or something else?
-    let path = FilePath(str)
-    guard path.root == nil, path.components.count == 1 else {
+extension _StdlibFilePath.Component {
+  internal init?(_ codeUnits: [_StdlibFilePath.CodeUnit]) {
+    let path = _StdlibFilePath(_normalizing: codeUnits)
+    guard path.anchor == nil, path.components.count == 1 else {
       return nil
     }
     self = path.components.first!
     self._invariantCheck()
   }
+
+  /// Creates a component from substrate string storage.
+  ///
+  /// The `SystemString` spelling of `init?(_ codeUnits:)`, reprovisioned
+  /// because swift-system's own test suite constructs components that way.
+  internal init?(_ str: SystemString) {
+    self.init(str.map { $0.rawValue })
+  }
+
+  /// This component's containing storage, as substrate string storage.
+  ///
+  /// Spelled `_slice.base` by swift-system's test suite, which reads it to
+  /// check that a component points into the path's bytes rather than a copy.
+  /// The SE-0529 `Component` slices `_SystemString`, so this restates that
+  /// base in the substrate's type. O(n).
+  internal var _sliceBase: SystemString {
+    SystemString(
+      nullTerminated: _path._storage.nullTerminatedStorage.map {
+        SystemChar(rawValue: $0)
+      })
+  }
 }
 
 @available(System 0.0.2, *)
-extension FilePath.Root {
-  internal init?(_ str: SystemString) {
-    // FIXME: explicit null root? Or something else?
-    let path = FilePath(str)
-    guard path.root != nil, path.components.isEmpty else {
+extension _StdlibFilePath.Root {
+  internal init?(_ codeUnits: [_StdlibFilePath.CodeUnit]) {
+    let path = _StdlibFilePath(_normalizing: codeUnits)
+    guard let anchor = path.anchor, path.components.isEmpty else {
       return nil
     }
-    self = path.root!
+    self = _StdlibFilePath.Root(anchor)
     self._invariantCheck()
   }
 }
@@ -266,24 +316,23 @@ extension FilePath.Root {
 // MARK: - Invariants
 
 @available(System 0.0.2, *)
-extension FilePath.Component {
+extension _StdlibFilePath.Component {
   // TODO: ensure this all gets easily optimized away in release...
   internal func _invariantCheck() {
     #if DEBUG
-    precondition(!_slice.isEmpty)
-    precondition(_slice.last != .null)
-    precondition(_slice.allSatisfy { !isSeparator($0) } )
-    precondition(_path._relativeStart <= _slice.startIndex)
+    let bytes = _codeUnits
+    precondition(!bytes.isEmpty)
+    precondition(bytes.last != ._null)
+    precondition(bytes.allSatisfy { !_isSeparator($0) } )
     #endif // DEBUG
   }
 }
 
 @available(System 0.0.2, *)
-extension FilePath.Root {
+extension _StdlibFilePath.Root {
   internal func _invariantCheck() {
     #if DEBUG
-    precondition(self._rootEnd > _path._storage.startIndex)
-
+    precondition(!_anchor.codeUnits.isEmpty)
     // TODO: Windows root invariants
     #endif
   }

--- a/Sources/System/FilePath/FilePathConformances.swift
+++ b/Sources/System/FilePath/FilePathConformances.swift
@@ -1,0 +1,283 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+
+// Conformances swift-system's _StdlibFilePath has always shipped that the stdlib
+// implementation deliberately does not. SE-0529 excludes Codable from the
+// stdlib _StdlibFilePath by design (serialization is left to application-level
+// code), so this file is permanent package-side surface, not a port shim.
+//
+// Wire-format compatibility contract: the historical encoding was the
+// synthesized form over `_storage: SystemString`, i.e.
+//   { "_storage": { "nullTerminatedStorage": [code units...] } }
+// SystemString still carries its original Codable (including the
+// invariant-validating decoder), so encoding through it reproduces the old
+// bytes exactly.
+//
+// Forward-compat side channel (`_v2`). The new _StdlibFilePath can carry a trailing
+// separator, which the historical `_storage` decoder rejects. So `_storage`
+// stays in the historical (separator-stripped) form old decoders accept, and
+// new-only distinctions travel in a sibling `_v2` object old decoders ignore:
+//
+//   { "_storage": <stripped SystemString>,
+//     "_v2": { "hasTrailingSeparator": <bool> } }
+//
+// `_v2` is append-only: decode each field with `decodeIfPresent` and default
+// when absent, never remove or repurpose a field, and always emit `_v2` (no
+// omit-when-default branch to keep in sync). That yields new->old (old reads
+// `_storage`, ignores `_v2`), old->new (no `_v2`, fields default), and
+// new->new (full fidelity).
+//
+// `hasTrailingSeparator` covers the removable trailing separator (`/tmp/foo`
+// vs `/tmp/foo/`) only; a structural anchor separator (`\\server\share\`)
+// stays in `_storage`, so the flag is false and old still reads it correctly.
+//
+// TODO: validate against real archives. The decoder also normalizes
+// non-normal `_storage` the historical one rejected (safe for old->new). Other
+// new-only forms with no old equivalent (Darwin resource forks, canonicalized
+// `.vol`/`.nofollow` anchors) are out of scope for `_v2`.
+
+@available(System 0.0.1, *)
+extension _StdlibFilePath: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case _storage
+    case _v2
+  }
+
+  // Append-only side channel; see the contract above.
+  private struct _V2: Codable {
+    var hasTrailingSeparator: Bool = false
+
+    private enum CodingKeys: String, CodingKey {
+      case hasTrailingSeparator
+    }
+
+    init(hasTrailingSeparator: Bool) {
+      self.hasTrailingSeparator = hasTrailingSeparator
+    }
+
+    init(from decoder: any Decoder) throws {
+      let c = try decoder.container(keyedBy: CodingKeys.self)
+      // Every field defaulted when absent, per the append-only contract.
+      self.hasTrailingSeparator =
+        try c.decodeIfPresent(Bool.self, forKey: .hasTrailingSeparator)
+        ?? false
+    }
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    // Keep `_storage` in old-normal form so old decoders accept it: strip the
+    // removable trailing separator, if any. Structural anchor separators are
+    // not removable and stay in `_storage` (the setter no-ops on them), so
+    // `stripped != self` is true only for the removable case.
+    let stripped = withoutTrailingSeparator()
+    let hadTrailingSeparator = (stripped != self)
+    try container.encode(stripped._systemStringStorage, forKey: ._storage)
+
+    // Always emit `_v2` (append-only contract; no omit-when-default check).
+    try container.encode(
+      _V2(hasTrailingSeparator: hadTrailingSeparator), forKey: ._v2)
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let storage = try container.decode(SystemString.self, forKey: ._storage)
+    // SystemString's decoder has already validated storage invariants on
+    // untrusted input, matching the old explicit _StdlibFilePath decoder.
+    //
+    // Construction goes through the stdlib copy's normalizing funnel: every
+    // payload the old decoder accepted still decodes. The stored byte spelling
+    // is the copy's normal form (which for old-normal input matches).
+    var path = _StdlibFilePath(storage)
+
+    // Absent `_v2` (old / v1 archives) defaults every field, reproducing old
+    // behavior. Present `_v2` re-applies the new-only distinctions.
+    if let v2 = try container.decodeIfPresent(_V2.self, forKey: ._v2) {
+      if v2.hasTrailingSeparator {
+        path.hasTrailingSeparator = true
+      }
+    }
+    self = path
+  }
+}
+
+// Component and Root historically got their Codable synthesized over their
+// stored properties, via the internal `_StrSlice` protocol's Codable
+// requirement:
+//
+//   Component = { _path: _StdlibFilePath, _range: Range<SystemString.Index> }
+//   Root      = { _path: _StdlibFilePath, _rootEnd: SystemString.Index }
+//
+// with SystemString.Index == Array<SystemChar>.Index == Int. On the wire:
+//
+//   Component: { "_path": <_StdlibFilePath>, "_range": [lower, upper] }
+//   Root:      { "_path": <_StdlibFilePath>, "_rootEnd": N }
+//
+// (Range's stdlib Codable uses an unkeyed container: lower, then upper.)
+//
+// Two things to keep straight.
+//
+// DECODE: the offsets index the ENCODED bytes. The old _StdlibFilePath decoder did
+// not normalize (it validated and rejected), so `_path`'s stored bytes are
+// exactly what the offsets were computed against. Decoding `_path` as a
+// _StdlibFilePath here would run the copy's normalizing funnel and shift those bytes
+// out from under the offsets: old stored "/./foo" verbatim with a Component
+// `_range` of 3..<6, and the copy normalizes that to "/foo", where 3..<6 is
+// out of bounds. So we reach into `_path`'s nested `{_storage:}` container,
+// take the raw SystemString, slice THAT, and only then normalize the slice
+// into a Component/Root.
+//
+// ENCODE: the copy's Component and Root cannot reproduce the old `_path`. The
+// originating path is _StdlibFilePath-internal (Component's `_path`/`_range`,
+// Anchor's `_path`) and invisible across the module boundary, so `_path` is
+// synthesized from the value's own bytes with the offsets spanning it. Old
+// swift-system decodes that to an equal value (its `==` and `hash` are
+// slice-only), so the format is preserved even though the payload is narrower
+// than old would have emitted for the same value.
+
+// The old `_path` payload is `{ "_storage": SystemString }`. Pulling the raw
+// SystemString out directly is what keeps the offsets meaningful; see DECODE
+// above.
+private enum _PathStorageKeys: String, CodingKey {
+  case _storage
+}
+
+extension KeyedDecodingContainer {
+  fileprivate func _decodeRawPathStorage(
+    forKey key: Key
+  ) throws -> SystemString {
+    let pathContainer = try nestedContainer(
+      keyedBy: _PathStorageKeys.self, forKey: key)
+    // SystemString's own decoder validates its invariants on untrusted input.
+    return try pathContainer.decode(SystemString.self, forKey: ._storage)
+  }
+}
+
+// Shared by `_StdlibFilePath.Component` and `_StdlibFilePath.Root`: synthesize
+// the `_path` payload from a slice's own bytes.
+//
+// The payload is always the SE-0529 shape, because both callers are SE-0529
+// types: a `_StdlibFilePath.Component` encodes as itself whatever backing
+// happens to be selected. This used to branch on
+// `_FilePathBackingSelection.useStdlib`, which was needed while `Component` was
+// a typealias to this type and therefore had to answer for both eras. Now that
+// `FilePath.Component` and `FilePath.Root` are dispatching wrappers, each era's
+// value encodes through its own backing (the historical one via its synthesized
+// Codable), so nothing here has to consult the selection. See
+// WrapperComponent.swift.
+//
+// Throws when normalization would not reproduce those bytes, i.e. when the
+// synthesized `_path` would not actually contain the value at the offsets we are
+// about to write. On Linux and Darwin this cannot fire: slice bytes are
+// non-empty and separator-free, separator coalescing is a no-op on them, and the
+// dot rules keep a leading `.` on a rootless path and always keep `..`. On
+// Windows it fires for a component of a verbatim (\\?\) path containing `/`,
+// which is a component byte there but a separator everywhere else, a value the
+// old format has no encoding for either, since old
+// `Component.init?(SystemString)` would have split it and returned nil.
+@available(System 0.0.2, *)
+private func _synthesizePathPayload<T>(
+  for value: T,
+  bytes: [_StdlibFilePath.CodeUnit],
+  codingPath: [any CodingKey]
+) throws -> _StdlibFilePath {
+  func bytesDoNotSurvive() -> EncodingError {
+    EncodingError.invalidValue(
+      value,
+      EncodingError.Context(
+        codingPath: codingPath,
+        debugDescription: """
+          Bytes do not survive path normalization, so the historical \
+          {_path, _range} encoding cannot represent this value. This fires on \
+          Windows for components of verbatim (\\\\?\\) paths containing '/'. \
+          Such values have no old-format encoding.
+          """))
+  }
+
+  let path = _StdlibFilePath(_normalizing: bytes)
+  guard path._cuArray == bytes else { throw bytesDoNotSurvive() }
+  return path
+}
+
+@available(System 0.0.2, *)
+extension _StdlibFilePath.Component: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case _path
+    case _range
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    let bytes = _codeUnits
+    let path = try _synthesizePathPayload(
+      for: self, bytes: bytes, codingPath: container.codingPath)
+    try container.encode(path, forKey: ._path)
+    // The synthesized path holds exactly this component, so the historical
+    // offsets into it span the whole storage.
+    try container.encode(0 ..< bytes.count, forKey: ._range)
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let raw = try container._decodeRawPathStorage(forKey: ._path)
+    let range = try container.decode(
+      Range<SystemString.Index>.self, forKey: ._range)
+    // Slice the RAW bytes, then normalize. Not the other way around.
+    guard range.lowerBound >= raw.startIndex,
+          range.upperBound <= raw.endIndex,
+          !range.isEmpty,
+          let component = _StdlibFilePath.Component(raw[range].map { $0.rawValue })
+    else {
+      throw DecodingError.dataCorruptedError(
+        forKey: ._range, in: container,
+        debugDescription:
+          "_range does not select a single path component from _path")
+    }
+    self = component
+  }
+}
+
+@available(System 0.0.2, *)
+extension _StdlibFilePath.Root: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case _path
+    case _rootEnd
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    let bytes = _codeUnits
+    let path = try _synthesizePathPayload(
+      for: self, bytes: bytes, codingPath: container.codingPath)
+    try container.encode(path, forKey: ._path)
+    // Old `Root._range` was `(..<_rootEnd)`, so `_rootEnd` is the root's byte
+    // count. The synthesized path is root-only, so that is its whole storage.
+    try container.encode(bytes.count, forKey: ._rootEnd)
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let raw = try container._decodeRawPathStorage(forKey: ._path)
+    let rootEnd = try container.decode(
+      SystemString.Index.self, forKey: ._rootEnd)
+    // Slice the RAW bytes, then normalize. `rootEnd > startIndex` mirrors the
+    // old Root invariant check.
+    guard rootEnd > raw.startIndex,
+          rootEnd <= raw.endIndex,
+          let root = _StdlibFilePath.Root(raw[..<rootEnd].map { $0.rawValue })
+    else {
+      throw DecodingError.dataCorruptedError(
+        forKey: ._rootEnd, in: container,
+        debugDescription: "_rootEnd does not select a path root from _path")
+    }
+    self = root
+  }
+}

--- a/Sources/System/FilePath/FilePathTemp.swift
+++ b/Sources/System/FilePath/FilePathTemp.swift
@@ -7,6 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
+
 // MARK: - API
 
 /// Create a temporary path for the duration of the closure.
@@ -19,7 +20,7 @@
 /// executes `body`, passing in the path of the created directory, then
 /// deletes the directory and all of its contents before returning.
 internal func withTemporaryFilePath<R>(
-  basename: FilePath.Component,
+  basename: _StdlibFilePath.Component,
   _ body: (FilePath) throws -> R
 ) throws -> R {
   let temporaryDir = try createUniqueTemporaryDirectory(basename: basename)
@@ -27,7 +28,12 @@ internal func withTemporaryFilePath<R>(
     try? _recursiveRemove(at: temporaryDir)
   }
 
-  return try body(temporaryDir)
+  // The directory machinery below works on the stdlib backing, but callers get
+  // a `FilePath`, and it has to honor the process-wide backing selection rather
+  // than inherit this file's. Rebuilding it from the platform string routes it
+  // through the wrapper's normal construction funnel.
+  let handedOut = temporaryDir.withPlatformString { FilePath(platformString: $0) }
+  return try body(handedOut)
 }
 
 // MARK: - Internals
@@ -44,7 +50,7 @@ fileprivate let base64 = Array<UInt8>(
 ///
 /// This function will throw if there is an error, except if the error
 /// is that the directory exists, in which case it returns `false`.
-fileprivate func makeLockedDownDirectory(at path: FilePath) throws -> Bool {
+fileprivate func makeLockedDownDirectory(at path: _StdlibFilePath) throws -> Bool {
   return try path.withPlatformString {
     if system_mkdir($0, 0o700) == 0 {
       return true
@@ -82,8 +88,8 @@ fileprivate func createRandomString(length: Int) -> String {
 /// starts with `basename`, followed by a `.` and then a random
 /// string of characters.
 fileprivate func createUniqueTemporaryDirectory(
-  basename: FilePath.Component
-) throws -> FilePath {
+  basename: _StdlibFilePath.Component
+) throws -> _StdlibFilePath {
   var tempDir = try _getTemporaryDirectory()
   tempDir.append(basename)
 

--- a/Sources/System/FilePath/FilePathTempPosix.swift
+++ b/Sources/System/FilePath/FilePathTempPosix.swift
@@ -7,6 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
  */
 
+
 #if !os(Windows)
 
 #if SYSTEM_PACKAGE_DARWIN
@@ -27,12 +28,12 @@ import Android
 #endif
 
 /// Get the path to the system temporary directory.
-internal func _getTemporaryDirectory() throws -> FilePath {
+internal func _getTemporaryDirectory() throws -> _StdlibFilePath {
   guard let tmp = system_getenv("TMPDIR") else {
     return "/tmp"
   }
 
-  return FilePath(SystemString(platformString: tmp))
+  return _StdlibFilePath(SystemString(platformString: tmp))
 }
 
 /// Delete the entire contents of a directory, including its subdirectories.
@@ -42,9 +43,16 @@ internal func _getTemporaryDirectory() throws -> FilePath {
 ///
 /// Removes a directory completely, including all of its contents.
 internal func _recursiveRemove(
-  at path: FilePath
+  at path: _StdlibFilePath
 ) throws {
-  let dirfd = try FileDescriptor.open(path, .readOnly, options: .directory)
+  // Opened through the platform-string overload rather than the `FilePath`
+  // one: `FilePath` is now the wrapper, and this helper works on the stdlib
+  // backing directly. Going through the C-string overload keeps that plain
+  // instead of building a wrapper whose backing would not honor the
+  // process-wide selection.
+  let dirfd = try path.withPlatformString {
+    try FileDescriptor.open($0, .readOnly, options: .directory)
+  }
   defer {
     try? dirfd.close()
   }

--- a/Sources/System/FilePath/FilePathTempWindows.swift
+++ b/Sources/System/FilePath/FilePathTempWindows.swift
@@ -7,12 +7,13 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
+
 #if os(Windows)
 
 import WinSDK
 
 /// Get the path to the system temporary directory.
-internal func _getTemporaryDirectory() throws -> FilePath {
+internal func _getTemporaryDirectory() throws -> _StdlibFilePath {
   return try withUnsafeTemporaryAllocation(of: CInterop.PlatformChar.self,
                                            capacity: Int(MAX_PATH) + 1) {
     buffer in
@@ -21,7 +22,7 @@ internal func _getTemporaryDirectory() throws -> FilePath {
       throw Errno(windowsError: GetLastError())
     }
 
-    return FilePath(SystemString(platformString: buffer.baseAddress!))
+    return _StdlibFilePath(SystemString(platformString: buffer.baseAddress!))
   }
 }
 
@@ -33,7 +34,7 @@ internal func _getTemporaryDirectory() throws -> FilePath {
 ///
 /// We skip the `.` and `..` pseudo-entries.
 fileprivate func forEachFile(
-  at path: FilePath,
+  at path: _StdlibFilePath,
   _ body: (WIN32_FIND_DATAW) throws -> ()
 ) rethrows {
   let searchPath = path.appending("\\*")
@@ -69,7 +70,7 @@ fileprivate func forEachFile(
 ///
 /// Removes a directory completely, including all of its contents.
 internal func _recursiveRemove(
-  at path: FilePath
+  at path: _StdlibFilePath
 ) throws {
   // First, deal with subdirectories
   try forEachFile(at: path) { findData in
@@ -78,7 +79,7 @@ internal func _recursiveRemove(
         return SystemString(platformString: $0.assumingMemoryBound(
                               to: CInterop.PlatformChar.self).baseAddress!)
       }
-      let component = FilePath.Component(name)!
+      let component = _StdlibFilePath.Component(name)!
       let subpath = path.appending(component)
 
       try _recursiveRemove(at: subpath)
@@ -91,7 +92,7 @@ internal func _recursiveRemove(
       return SystemString(platformString: $0.assumingMemoryBound(
                             to: CInterop.PlatformChar.self).baseAddress!)
     }
-    let component = FilePath.Component(name)!
+    let component = _StdlibFilePath.Component(name)!
     let subpath = path.appending(component)
 
     if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0 {

--- a/Sources/System/FilePath/SystemStringShim.swift
+++ b/Sources/System/FilePath/SystemStringShim.swift
@@ -1,0 +1,46 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+
+// PORT SHIM: bidirectional converters between the old package substrate
+// (SystemString/SystemChar) and the SE-0529 stdlib copy's substrate
+// (_SystemString/_StdlibFilePath.CodeUnit).
+//
+// SystemChar.RawValue is CInterop.PlatformChar and _StdlibFilePath.CodeUnit is
+// CChar on Unix / UInt16 on Windows: the same underlying type on every
+// platform, so conversion is a per-element rewrap, O(n) copy.
+//
+// Temporary by design: once one substrate wins (long-term plan: converge
+// on _SystemString), these converters and their call sites are the
+// mechanical removal list. Do not grow API on top of them.
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Construct from the old package string representation.
+  ///
+  /// Goes through the copy's `_normalizing` funnel so the result satisfies
+  /// the stdlib implementation's storage invariants (coalesced separators,
+  /// normalized dots). Note this can store a different byte spelling than
+  /// the old _StdlibFilePath(SystemString) did.
+  internal init(_ str: SystemString) {
+    // `SystemChar.rawValue` is `_StdlibFilePath.CodeUnit` on every platform; the
+    // SystemString collection excludes its null terminator, so these bytes
+    // are NUL-free as `_normalizing` requires.
+    self.init(_normalizing: str.map { $0.rawValue })
+  }
+
+  /// View the copy's storage as the old package string representation.
+  /// O(n) copy; port-transition use only.
+  internal var _systemStringStorage: SystemString {
+    SystemString(
+      nullTerminated: _copyToArray(nullTerminatedCodeUnits).map {
+        SystemChar(rawValue: $0)
+      })
+  }
+}

--- a/Sources/System/Internals/Exports.swift
+++ b/Sources/System/Internals/Exports.swift
@@ -242,3 +242,14 @@ internal func getTLS(_ key: _PlatformTLSKey) -> UnsafeMutableRawPointer? {
   return pthread_getspecific(key)
   #endif
 }
+
+// MARK: - Environment
+
+/// Whether the named environment variable is present, whatever its value.
+///
+/// Lives here because this is the one file that has already done the
+/// platform-import dance, and `getenv` needs it. Used by the `FilePath`
+/// wrapper's backing selection.
+internal func system_hasEnv(_ name: String) -> Bool {
+  getenv(name) != nil
+}

--- a/Sources/System/Util.swift
+++ b/Sources/System/Util.swift
@@ -120,13 +120,8 @@ where C.Element: Equatable {
   return (lhs, rhs)
 }
 
-extension MutableCollection where Element: Equatable {
-  mutating func _replaceAll(_ e: Element, with new: Element) {
-    for idx in self.indices {
-      if self[idx] == e { self[idx] = new }
-    }
-  }
-}
+// `_replaceAll` now lives in _StdlibFilePath/FilePathInternals.swift, which
+// compiles into this same module. Redeclaring it here would be ambiguous.
 
 internal func _withOptionalUnsafePointerOrNull<T, R>(
   to value: T?,

--- a/Sources/System/UtilConsumers.swift
+++ b/Sources/System/UtilConsumers.swift
@@ -10,36 +10,15 @@
 // TODO: Below should return an optional of what was eaten
 
 extension Slice where Element: Equatable {
-  internal mutating func _eat(if p: (Element) -> Bool) -> Element? {
-    guard let s = self.first, p(s) else { return nil }
-    self = self.dropFirst()
-    return s
-  }
-  internal mutating func _eat(_ e: Element) -> Element? {
-    _eat(if: { $0 == e })
-  }
+  // The primitive eaters `_eat(if:)`, `_eat(_:)`, `_eat(count:)`,
+  // `_eatSequence(_:)`, `_eatUntil(_ idx:)` and `_eatWhile(_:)` now live in
+  // _StdlibFilePath/FilePathInternals.swift, which compiles into this same
+  // module. Redeclaring them here would be ambiguous, so only the derived
+  // helpers remain, calling the base's.
 
   internal mutating func _eat(asserting e: Element) {
     let p = _eat(e)
     assert(p != nil)
-  }
-
-  internal mutating func _eat(count c: Int) -> Slice {
-    defer { self = self.dropFirst(c) }
-    return self.prefix(c)
-  }
-
-  internal mutating func _eatSequence<C: Collection>(_ es: C) -> Slice?
-  where C.Element == Element
-  {
-    guard self.starts(with: es) else { return nil }
-    return _eat(count: es.count)
-  }
-
-  internal mutating func _eatUntil(_ idx: Index) -> Slice {
-    precondition(idx >= startIndex && idx <= endIndex)
-    defer { self = self[idx...] }
-    return self[..<idx]
   }
 
   internal mutating func _eatThrough(_ idx: Index) -> Slice {
@@ -62,12 +41,5 @@ extension Slice where Element: Equatable {
   internal mutating func _eatThrough(_ e: Element) -> Slice? {
     guard let idx = self.firstIndex(of: e) else { return nil }
     return _eatThrough(idx)
-  }
-
-  // Eat any elements from the front matching the predicate
-  internal mutating func _eatWhile(_ p: (Element) -> Bool) -> Slice? {
-    let idx = firstIndex(where: { !p($0) }) ?? endIndex
-    guard idx != startIndex else { return nil }
-    return _eatUntil(idx)
   }
 }

--- a/Sources/System/Wrapper/WrapperComponent.swift
+++ b/Sources/System/Wrapper/WrapperComponent.swift
@@ -1,0 +1,506 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// MARK: - FilePath.Component
+//
+// A thin dispatching wrapper, like `Root` and `ComponentView`.
+//
+// It was a typealias to the SE-0529 component at first, on the reasoning that a
+// component is just a separator-free byte run, so both eras agree on what one
+// *is* and only disagree about how paths decompose into them. That reasoning
+// holds for a component that already exists. It does not hold for VALIDATION:
+// deciding whether a given string is one component is era-specific.
+//
+//   legacy:  `Component("a/")` succeeds, yielding `a`. Historical swift-system
+//            ran the string through path normalization first, which stripped a
+//            trailing separator, and then checked for a single component.
+//   SE-0529: `Component("a/")` is nil. A trailing separator is now significant,
+//            so a string carrying one is not a bare component.
+//
+// With a shared typealias there is one initializer answering for both eras, and
+// the only way to serve both is to ask the global backing selection inside it.
+// That was the band-aid this type replaces: it fixed the one divergence we had
+// found and would need another `if` for the next one. Trailing separators are
+// unlikely to be the only case, since normalization is exactly where the eras
+// differ and every failable construction here runs input through it.
+//
+// So `Component` holds each backing's own component and forwards. Construction
+// routes through `_make` / `_makeIfSome`, the same funnel `FilePath` uses, which
+// means the era rule is applied by the backing that owns it rather than by a
+// conditional here.
+//
+// Not vended: `codeUnits` and `init?(codeUnits:)`, the SE-0529 `Span` API. The
+// `FilePath` wrapper does not vend `Span` either, for the same reason: a `Span`
+// borrowed from an enum payload cannot outlive the `switch` that binds it. That
+// API stays reachable on `_StdlibFilePath.Component`.
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Represents an individual, non-root component of a file path.
+  ///
+  /// Components can be one of the special directory components (`.` or `..`)
+  /// or a file or directory name. Components are never empty and never
+  /// contain the directory separator.
+  ///
+  /// Example:
+  ///
+  ///     var path: FilePath = "/tmp"
+  ///     let file: FilePath.Component = "foo.txt"
+  ///     file.kind == .regular           // true
+  ///     file.extension                  // "txt"
+  ///     path.append(file)               // path is "/tmp/foo.txt"
+  public struct Component: Sendable {
+    @usableFromInline
+    internal enum Backing: Sendable {
+      case stdlib(_StdlibFilePath.Component)
+      case swiftSystem(_SwiftSystemFilePath.Component)
+    }
+
+    @usableFromInline
+    internal var _backing: Backing
+
+    @usableFromInline
+    internal init(_backing: Backing) {
+      self._backing = _backing
+    }
+  }
+}
+
+// MARK: - Construction funnel
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component {
+  internal static func _make(
+    stdlib: () -> _StdlibFilePath.Component,
+    swiftSystem: () -> _SwiftSystemFilePath.Component
+  ) -> FilePath.Component {
+    _filePathSelect(
+      stdlib: { FilePath.Component(_backing: .stdlib(stdlib())) },
+      swiftSystem: {
+        FilePath.Component(_backing: .swiftSystem(swiftSystem()))
+      })
+  }
+
+  internal static func _makeIfSome(
+    stdlib: () -> _StdlibFilePath.Component?,
+    swiftSystem: () -> _SwiftSystemFilePath.Component?
+  ) -> FilePath.Component? {
+    _filePathSelect(
+      stdlib: { stdlib().map { FilePath.Component(_backing: .stdlib($0)) } },
+      swiftSystem: {
+        swiftSystem().map { FilePath.Component(_backing: .swiftSystem($0)) }
+      })
+  }
+}
+
+// MARK: - Backing access
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component {
+  internal var _stdlib: _StdlibFilePath.Component {
+    guard case .stdlib(let c) = _backing else {
+      _filePathBackingMismatch("FilePath.Component")
+    }
+    return c
+  }
+
+  internal var _swiftSystem: _SwiftSystemFilePath.Component {
+    guard case .swiftSystem(let c) = _backing else {
+      _filePathBackingMismatch("FilePath.Component")
+    }
+    return c
+  }
+}
+
+// MARK: - Kind
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component {
+  /// Whether a component is a regular file or directory name, or a special
+  /// directory `.` or `..`
+  @frozen
+  public enum Kind: Sendable, Equatable {
+    /// The special directory `.`, representing the current directory.
+    case currentDirectory
+
+    /// The special directory `..`, representing the parent directory.
+    case parentDirectory
+
+    /// A file or directory name
+    case regular
+  }
+
+  /// The kind of this component.
+  public var kind: Kind {
+    switch _backing {
+    case .stdlib(let c):
+      switch c.kind {
+      case .currentDirectory: return .currentDirectory
+      case .parentDirectory: return .parentDirectory
+      case .regular: return .regular
+      }
+    case .swiftSystem(let c):
+      switch c.kind {
+      case .currentDirectory: return .currentDirectory
+      case .parentDirectory: return .parentDirectory
+      case .regular: return .regular
+      }
+    }
+  }
+}
+
+// MARK: - Construction from strings
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component {
+  /// Creates a file path component from a string.
+  ///
+  /// Returns `nil` if `string` is empty, is a root, or has more than one
+  /// component in it.
+  ///
+  /// The era difference lives here rather than in a conditional: each backing
+  /// applies its own rule, so `"a/"` is accepted (and stripped) under the
+  /// historical backing and rejected under SE-0529.
+  public init?(_ string: String) {
+    guard let c = FilePath.Component._makeIfSome(
+      stdlib: { _StdlibFilePath.Component(string) },
+      swiftSystem: { _SwiftSystemFilePath.Component(string) })
+    else { return nil }
+    self = c
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component: ExpressibleByStringLiteral {
+  /// Creates a file path component from a string literal.
+  ///
+  /// Precondition: `stringLiteral` is non-empty, is not a root, and has only
+  /// one component in it.
+  public init(stringLiteral: String) {
+    self = FilePath.Component._make(
+      stdlib: { _StdlibFilePath.Component(stringLiteral: stringLiteral) },
+      swiftSystem: {
+        _SwiftSystemFilePath.Component(stringLiteral: stringLiteral)
+      })
+  }
+}
+
+// MARK: - Platform string
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component {
+  /// Creates a file path component by copying bytes from a null-terminated
+  /// platform string.
+  ///
+  /// Returns `nil` if `platformString` is empty, is a root, or has more than
+  /// one component in it.
+  public init?(platformString: UnsafePointer<CInterop.PlatformChar>) {
+    guard let c = FilePath.Component._makeIfSome(
+      stdlib: { _StdlibFilePath.Component(platformString: platformString) },
+      swiftSystem: {
+        _SwiftSystemFilePath.Component(platformString: platformString)
+      })
+    else { return nil }
+    self = c
+  }
+
+  /// Creates a file path component by copying bytes from a null-terminated
+  /// platform string.
+  ///
+  /// - Note It is a precondition that `platformString` must be null-terminated.
+  /// The absence of a null byte will trigger a runtime error.
+  public init?(platformString: [CInterop.PlatformChar]) {
+    guard let c = FilePath.Component._makeIfSome(
+      stdlib: { _StdlibFilePath.Component(platformString: platformString) },
+      swiftSystem: {
+        _SwiftSystemFilePath.Component(platformString: platformString)
+      })
+    else { return nil }
+    self = c
+  }
+
+  @available(*, deprecated, message: "Use FilePath.Component.init(_ scalar: Unicode.Scalar)")
+  public init?(platformString: inout CInterop.PlatformChar) {
+    guard let c = FilePath.Component._makeIfSome(
+      stdlib: { _StdlibFilePath.Component(platformString: &platformString) },
+      swiftSystem: {
+        _SwiftSystemFilePath.Component(platformString: &platformString)
+      })
+    else { return nil }
+    self = c
+  }
+
+  @available(*, deprecated, message: "Use FilePath.Component.init(_: String)")
+  public init?(platformString: String) {
+    guard let c = FilePath.Component._makeIfSome(
+      stdlib: { _StdlibFilePath.Component(platformString: platformString) },
+      swiftSystem: {
+        _SwiftSystemFilePath.Component(platformString: platformString)
+      })
+    else { return nil }
+    self = c
+  }
+
+  /// Calls `body` with a pointer to this component's null-terminated
+  /// platform-string contents.
+  public func withPlatformString<Result>(
+    _ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result
+  ) rethrows -> Result {
+    switch _backing {
+    case .stdlib(let c): return try c.withPlatformString(body)
+    case .swiftSystem(let c): return try c.withPlatformString(body)
+    }
+  }
+}
+
+// MARK: - String rendering
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component {
+  /// Creates a string by interpreting the component's content as UTF-8 on Unix
+  /// and UTF-16 on Windows.
+  ///
+  /// This property is equivalent to calling `String(decoding: component)`.
+  public var string: String {
+    switch _backing {
+    case .stdlib(let c): return c.string
+    case .swiftSystem(let c): return c.string
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component: CustomStringConvertible, CustomDebugStringConvertible {
+  public var description: String {
+    switch _backing {
+    case .stdlib(let c): return c.description
+    case .swiftSystem(let c): return c.description
+    }
+  }
+
+  public var debugDescription: String { description.debugDescription }
+}
+
+// MARK: - Extension and stem
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component {
+  /// The extension of this file or directory component.
+  ///
+  /// If `self` does not contain a `.` anywhere, or only at the start, returns
+  /// `nil`. Otherwise, returns everything after the dot.
+  ///
+  /// Examples:
+  ///   * `foo.txt    => txt`
+  ///   * `foo.tar.gz => gz`
+  ///   * `Foo.app    => app`
+  ///   * `.hidden    => nil`
+  ///   * `..         => nil`
+  public var `extension`: String? {
+    switch _backing {
+    case .stdlib(let c): return c.extension
+    case .swiftSystem(let c): return c.extension
+    }
+  }
+
+  /// The non-extension portion of this file or directory component.
+  ///
+  /// Examples:
+  ///   * `foo.txt => foo`
+  ///   * `foo.tar.gz => foo.tar`
+  ///   * `Foo.app => Foo`
+  ///   * `.hidden => .hidden`
+  ///   * `..      => ..`
+  public var stem: String {
+    switch _backing {
+    case .stdlib(let c): return c.stem
+    case .swiftSystem(let c): return c.stem
+    }
+  }
+}
+
+// MARK: - Equatable, Hashable, Comparable
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component: Equatable, Hashable {
+  public static func == (lhs: FilePath.Component, rhs: FilePath.Component) -> Bool {
+    switch (lhs._backing, rhs._backing) {
+    case (.stdlib(let l), .stdlib(let r)): return l == r
+    case (.swiftSystem(let l), .swiftSystem(let r)): return l == r
+    default: _filePathBackingMismatch("FilePath.Component")
+    }
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    switch _backing {
+    case .stdlib(let c): hasher.combine(c)
+    case .swiftSystem(let c): hasher.combine(c)
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component: Comparable {
+  /// Orders components lexicographically by code unit.
+  ///
+  /// The SE-0529 component is `Comparable`; the historical one is not, so its
+  /// arm spells out the same rule (`_slice.lexicographicallyPrecedes`) that the
+  /// SE-0529 `<` uses. Both slice the same platform code unit type, so the two
+  /// arms agree on ordering for any component representable in both.
+  public static func < (lhs: FilePath.Component, rhs: FilePath.Component) -> Bool {
+    switch (lhs._backing, rhs._backing) {
+    case (.stdlib(let l), .stdlib(let r)): return l < r
+    case (.swiftSystem(let l), .swiftSystem(let r)):
+      return l._slice.lexicographicallyPrecedes(r._slice)
+    default: _filePathBackingMismatch("FilePath.Component")
+    }
+  }
+}
+
+// MARK: - Codable
+
+// The wire format is the historical synthesized shape over the old stored
+// properties, `{ "_path": <FilePath>, "_range": [lower, upper] }`, where the
+// nested `_path` is whichever backing is active. See FilePathConformances.swift
+// for why the offsets force decoding to slice `_path`'s RAW storage before
+// normalizing, rather than decoding `_path` as a path and slicing after.
+
+private enum _ComponentCodingKeys: String, CodingKey {
+  case _path
+  case _range
+}
+
+// The old `_path` payload is `{ "_storage": SystemString }`, whatever else the
+// active era adds alongside it. Reading the raw `SystemString` out directly is
+// what keeps the offsets meaningful, and ignoring every other key is what lets
+// one decoder accept both eras' archives.
+private enum _ComponentPathStorageKeys: String, CodingKey {
+  case _storage
+}
+
+@available(SwiftStdlib 9999, *)
+private func _decodeSlicePayload(
+  from decoder: any Decoder
+) throws -> (SystemString, Range<SystemString.Index>) {
+  let container = try decoder.container(keyedBy: _ComponentCodingKeys.self)
+  let pathContainer = try container.nestedContainer(
+    keyedBy: _ComponentPathStorageKeys.self, forKey: ._path)
+  // SystemString's own decoder validates its invariants on untrusted input.
+  let raw = try pathContainer.decode(SystemString.self, forKey: ._storage)
+  let range = try container.decode(
+    Range<SystemString.Index>.self, forKey: ._range)
+  return (raw, range)
+}
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component: Codable {
+  /// Encodes in the active backing's shape.
+  ///
+  /// Each backing already encodes its own era's format: the historical one gets
+  /// the synthesized `{_path, _range}` over its real stored path and offsets,
+  /// and `_StdlibFilePath.Component` synthesizes an equivalent payload plus the
+  /// `_v2` side channel. Dispatching is all this needs to do, so unlike the old
+  /// typealias there is no era switch inside the encoder.
+  public func encode(to encoder: any Encoder) throws {
+    switch _backing {
+    case .stdlib(let c): try c.encode(to: encoder)
+    case .swiftSystem(let c): try c.encode(to: encoder)
+    }
+  }
+
+  /// Decodes from either era's archive.
+  ///
+  /// Deliberately NOT forwarded to the backing's own `init(from:)`. The
+  /// historical backing's decoder is synthesized, so it validates nothing
+  /// beyond what `_path` itself checks and would accept a `_range` spanning a
+  /// separator or running out of bounds. The raw-slice-then-validate path below
+  /// is the one that holds in both eras, and the final construction goes
+  /// through `_makeIfSome`, so the era's own rule decides whether those bytes
+  /// are a component.
+  public init(from decoder: any Decoder) throws {
+    let (raw, range) = try _decodeSlicePayload(from: decoder)
+    guard range.lowerBound >= raw.startIndex,
+          range.upperBound <= raw.endIndex,
+          !range.isEmpty,
+          let component = FilePath.Component(SystemString(raw[range]))
+    else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription:
+            "_range does not select a single path component from _path"))
+    }
+    self = component
+  }
+}
+
+// MARK: - Substrate and test SPI
+
+// Underscored, so it can change in a patch release. These exist because the
+// substrate and swift-system's own test suite reach for them; each one
+// dispatches rather than deriving, so a caller sees the active era's bytes.
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Component {
+  /// Creates a component from substrate string storage, per the active backing's
+  /// rules.
+  internal init?(_ str: SystemString) {
+    guard let c = FilePath.Component._makeIfSome(
+      stdlib: { _StdlibFilePath.Component(str) },
+      swiftSystem: { _SwiftSystemFilePath.Component(str) })
+    else { return nil }
+    self = c
+  }
+
+  /// This component's code units, excluding any null terminator.
+  internal var _codeUnits: [FilePath.CodeUnit] {
+    switch _backing {
+    case .stdlib(let c): return c._codeUnits
+    case .swiftSystem(let c): return c._wrapperCodeUnits
+    }
+  }
+
+  /// This component's containing storage, as substrate string storage.
+  ///
+  /// Spelled `_slice.base` by swift-system's test suite, which reads it to
+  /// check that a component points into the path's bytes rather than a copy.
+  internal var _sliceBase: SystemString {
+    switch _backing {
+    case .stdlib(let c): return c._sliceBase
+    case .swiftSystem(let c): return c._path._storage
+    }
+  }
+}
+
+// MARK: - String from a component
+
+@available(SwiftStdlib 9999, *)
+extension String {
+  /// Creates a string by decoding a component's content, repairing invalid code
+  /// unit sequences.
+  public init(decoding component: FilePath.Component) {
+    switch component._backing {
+    case .stdlib(let c): self.init(decoding: c)
+    case .swiftSystem(let c): self.init(decoding: c)
+    }
+  }
+
+  /// Creates a string from a component, or `nil` if its content is not valid in
+  /// the platform's encoding.
+  public init?(validating component: FilePath.Component) {
+    switch component._backing {
+    case .stdlib(let c):
+      guard let s = String(validating: c) else { return nil }
+      self = s
+    case .swiftSystem(let c):
+      guard let s = String(validating: c) else { return nil }
+      self = s
+    }
+  }
+}

--- a/Sources/System/Wrapper/WrapperComponentView.swift
+++ b/Sources/System/Wrapper/WrapperComponentView.swift
@@ -1,0 +1,279 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// MARK: - FilePath.ComponentView
+//
+// Unlike `Component` and `Root`, this is a wrapper type and not a typealias.
+//
+// It has to be. Decomposing a path into components and recomposing a path from
+// edited components is exactly where the two eras disagree, so the view must
+// stay on the active backing and every mutation must land in the backing's own
+// `replaceSubrange`. Rebuilding a stdlib path out of bytes taken from a
+// swiftSystem view would renormalize under the wrong era's rules and quietly
+// produce a different path.
+//
+// So the view holds the backing's view, forwards iteration and mutation to it,
+// and converts only at the boundary: components handed out are restated in the
+// SE-0529 shape, components handed in are restated in the active backing's
+// shape. The path arithmetic itself never leaves the backing.
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// A view of a path's components.
+  public struct ComponentView: Sendable {
+    @usableFromInline
+    internal enum Backing: Sendable {
+      case stdlib(_StdlibFilePath.ComponentView)
+      case swiftSystem(_SwiftSystemFilePath.ComponentView)
+    }
+
+    @usableFromInline
+    internal var _backing: Backing
+
+    @usableFromInline
+    internal init(_backing: Backing) {
+      self._backing = _backing
+    }
+  }
+}
+
+// MARK: - Index
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.ComponentView {
+  /// A position in a component view.
+  public struct Index: Sendable, Comparable, Hashable {
+    @usableFromInline
+    internal enum Backing: Sendable, Hashable {
+      case stdlib(_StdlibFilePath.ComponentView.Index)
+      case swiftSystem(_SwiftSystemFilePath.ComponentView.Index)
+    }
+
+    @usableFromInline
+    internal var _backing: Backing
+
+    @usableFromInline
+    internal init(_backing: Backing) {
+      self._backing = _backing
+    }
+
+    internal var _stdlib: _StdlibFilePath.ComponentView.Index {
+      guard case .stdlib(let i) = _backing else {
+        _filePathBackingMismatch("FilePath.ComponentView.Index")
+      }
+      return i
+    }
+
+    internal var _swiftSystem: _SwiftSystemFilePath.ComponentView.Index {
+      guard case .swiftSystem(let i) = _backing else {
+        _filePathBackingMismatch("FilePath.ComponentView.Index")
+      }
+      return i
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      switch (lhs._backing, rhs._backing) {
+      case (.stdlib(let l), .stdlib(let r)): return l < r
+      case (.swiftSystem(let l), .swiftSystem(let r)): return l < r
+      default: _filePathBackingMismatch("FilePath.ComponentView.Index")
+      }
+    }
+  }
+}
+
+// MARK: - Backing access
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.ComponentView {
+  internal var _stdlib: _StdlibFilePath.ComponentView {
+    guard case .stdlib(let v) = _backing else {
+      _filePathBackingMismatch("FilePath.ComponentView")
+    }
+    return v
+  }
+
+  internal var _swiftSystem: _SwiftSystemFilePath.ComponentView {
+    guard case .swiftSystem(let v) = _backing else {
+      _filePathBackingMismatch("FilePath.ComponentView")
+    }
+    return v
+  }
+
+  /// The path this view is a view of.
+  ///
+  /// Spelled `_path` because that is the name swift-system's own test suite
+  /// reaches for. Rewrapped, so the result carries the same backing.
+  internal var _path: FilePath {
+    switch _backing {
+    case .stdlib(let v): return FilePath(_backing: .stdlib(v._path))
+    case .swiftSystem(let v): return FilePath(_backing: .swiftSystem(v._path))
+    }
+  }
+}
+
+// MARK: - Index storage offset
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.ComponentView.Index {
+  /// This index's offset into the path's substrate string storage.
+  ///
+  /// Spelled `_storage` because that is the name swift-system's own test suite
+  /// reaches for. Both backings index a null-terminated array of the same code
+  /// unit width, so the offset means the same thing on either side and matches
+  /// `FilePath._storage`.
+  internal var _storage: SystemString.Index {
+    switch _backing {
+    case .stdlib(let i): return i._storage
+    case .swiftSystem(let i): return i._storage
+    }
+  }
+}
+
+// MARK: - Collection
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.ComponentView: BidirectionalCollection {
+  public typealias Element = FilePath.Component
+
+  public var startIndex: Index {
+    switch _backing {
+    case .stdlib(let v): return Index(_backing: .stdlib(v.startIndex))
+    case .swiftSystem(let v): return Index(_backing: .swiftSystem(v.startIndex))
+    }
+  }
+
+  public var endIndex: Index {
+    switch _backing {
+    case .stdlib(let v): return Index(_backing: .stdlib(v.endIndex))
+    case .swiftSystem(let v): return Index(_backing: .swiftSystem(v.endIndex))
+    }
+  }
+
+  public func index(after i: Index) -> Index {
+    switch _backing {
+    case .stdlib(let v):
+      return Index(_backing: .stdlib(v.index(after: i._stdlib)))
+    case .swiftSystem(let v):
+      return Index(_backing: .swiftSystem(v.index(after: i._swiftSystem)))
+    }
+  }
+
+  public func index(before i: Index) -> Index {
+    switch _backing {
+    case .stdlib(let v):
+      return Index(_backing: .stdlib(v.index(before: i._stdlib)))
+    case .swiftSystem(let v):
+      return Index(_backing: .swiftSystem(v.index(before: i._swiftSystem)))
+    }
+  }
+
+  /// The component at `position`, wrapped so it carries this view's backing.
+  public subscript(position: Index) -> FilePath.Component {
+    switch _backing {
+    case .stdlib(let v):
+      return FilePath.Component(_backing: .stdlib(v[position._stdlib]))
+    case .swiftSystem(let v):
+      return FilePath.Component(
+        _backing: .swiftSystem(v[position._swiftSystem]))
+    }
+  }
+}
+
+// MARK: - RangeReplaceableCollection
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.ComponentView: RangeReplaceableCollection {
+  /// An empty component view, backed by whichever implementation is active.
+  public init() {
+    self = _filePathSelect(
+      stdlib: {
+        FilePath.ComponentView(_backing: .stdlib(_StdlibFilePath.ComponentView()))
+      },
+      swiftSystem: {
+        FilePath.ComponentView(
+          _backing: .swiftSystem(_SwiftSystemFilePath.ComponentView()))
+      })
+  }
+
+  /// Replaces components in `subrange` with `newElements`.
+  ///
+  /// Forwarded to the active backing's own `replaceSubrange`, which is what
+  /// makes the resulting path era-correct. Incoming components are unwrapped to
+  /// the backing's own type first; no path is rebuilt here.
+  public mutating func replaceSubrange<C: Collection>(
+    _ subrange: Range<Index>, with newElements: C
+  ) where C.Element == FilePath.Component {
+    switch _backing {
+    case .stdlib(var v):
+      v.replaceSubrange(
+        subrange.lowerBound._stdlib..<subrange.upperBound._stdlib,
+        with: newElements.map { $0._stdlib })
+      _backing = .stdlib(v)
+    case .swiftSystem(var v):
+      v.replaceSubrange(
+        subrange.lowerBound._swiftSystem..<subrange.upperBound._swiftSystem,
+        with: newElements.map { $0._swiftSystem })
+      _backing = .swiftSystem(v)
+    }
+  }
+}
+
+// MARK: - Equatable, Hashable
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.ComponentView: Equatable, Hashable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs._backing, rhs._backing) {
+    case (.stdlib(let l), .stdlib(let r)): return l == r
+    case (.swiftSystem(let l), .swiftSystem(let r)): return l == r
+    default: _filePathBackingMismatch("FilePath.ComponentView")
+    }
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    switch _backing {
+    case .stdlib(let v): hasher.combine(v)
+    case .swiftSystem(let v): hasher.combine(v)
+    }
+  }
+}
+
+// MARK: - The components property
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// A view of this path's components.
+  ///
+  /// Both getter and setter forward to the active backing's own `components`
+  /// accessor, which is where each era's recomposition rules live. In
+  /// particular the setter does not rebuild the path here: the backing decides
+  /// how an edited component list becomes a path again.
+  public var components: ComponentView {
+    get {
+      switch _backing {
+      case .stdlib(let p):
+        return ComponentView(_backing: .stdlib(p.components))
+      case .swiftSystem(let p):
+        return ComponentView(_backing: .swiftSystem(p.components))
+      }
+    }
+    set {
+      switch (_backing, newValue._backing) {
+      case (.stdlib(var p), .stdlib(let v)):
+        p.components = v
+        _backing = .stdlib(p)
+      case (.swiftSystem(var p), .swiftSystem(let v)):
+        p.components = v
+        _backing = .swiftSystem(p)
+      default:
+        _filePathBackingMismatch("FilePath.ComponentView")
+      }
+    }
+  }
+}

--- a/Sources/System/Wrapper/WrapperConformances.swift
+++ b/Sources/System/Wrapper/WrapperConformances.swift
@@ -1,0 +1,105 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// MARK: - Conformances
+
+// MARK: Equatable, Hashable, Comparable
+
+// All three get their own switch rather than being derived from `string` or from
+// the code units. Equality is one of the things SE-0529 revisits: the historical
+// implementation compares normalized storage bytes, while SE-0529 compares by
+// decomposition, so paths that differ only in a trailing separator can compare
+// differently between eras. Deriving here would impose one era's answer on both.
+
+@available(SwiftStdlib 9999, *)
+extension FilePath: Equatable {
+  public static func == (lhs: FilePath, rhs: FilePath) -> Bool {
+    switch (lhs._backing, rhs._backing) {
+    case (.stdlib(let l), .stdlib(let r)): return l == r
+    case (.swiftSystem(let l), .swiftSystem(let r)): return l == r
+    default: _filePathBackingMismatch()
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension FilePath: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    switch _backing {
+    case .stdlib(let p): hasher.combine(p)
+    case .swiftSystem(let p): hasher.combine(p)
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension FilePath: Comparable {
+  public static func < (lhs: FilePath, rhs: FilePath) -> Bool {
+    switch (lhs._backing, rhs._backing) {
+    case (.stdlib(let l), .stdlib(let r)): return l < r
+    case (.swiftSystem(let l), .swiftSystem(let r)):
+      // The historical implementation has no `Comparable` conformance, so
+      // order by content the way its own storage does.
+      return l.string < r.string
+    default: _filePathBackingMismatch()
+    }
+  }
+}
+
+// MARK: CustomStringConvertible
+
+@available(SwiftStdlib 9999, *)
+extension FilePath: CustomStringConvertible, CustomDebugStringConvertible {
+  public var description: String {
+    switch _backing {
+    case .stdlib(let p): return p.description
+    case .swiftSystem(let p): return p.description
+    }
+  }
+
+  public var debugDescription: String { description.debugDescription }
+}
+
+// MARK: Codable
+
+// Given its own switch, and deliberately strict about era.
+//
+// A path's encoded form is just its string, so nothing in the payload records
+// which implementation produced it. That makes a cross-era decode silently
+// lossy rather than loudly wrong: the bytes would round-trip through the other
+// era's normalization and could come back as a different path. Since the
+// backing selection is process-wide, any value this process decodes must belong
+// to the active era, so the safe thing is to decode through the active backing
+// and let its own decoder reject what it cannot represent.
+//
+// The cross-era hazard the wrapper *can* detect is a value that was encoded by
+// one era and is being compared or combined with values from the other, which
+// is what `_filePathBackingMismatch` reports throughout.
+
+@available(SwiftStdlib 9999, *)
+extension FilePath: Codable {
+  public func encode(to encoder: any Encoder) throws {
+    switch _backing {
+    case .stdlib(let p): try p.encode(to: encoder)
+    case .swiftSystem(let p): try p.encode(to: encoder)
+    }
+  }
+
+  public init(from decoder: any Decoder) throws {
+    // Decode through the active backing. If the payload was written by the
+    // other era and its content is not representable here, the backing's own
+    // decoder is the right thing to raise the objection: it knows its era's
+    // validity rules, and the wrapper does not.
+    if _FilePathBackingSelection.useStdlib {
+      self.init(_backing: .stdlib(try _StdlibFilePath(from: decoder)))
+    } else {
+      self.init(_backing: .swiftSystem(try _SwiftSystemFilePath(from: decoder)))
+    }
+  }
+}

--- a/Sources/System/Wrapper/WrapperExtras.swift
+++ b/Sources/System/Wrapper/WrapperExtras.swift
@@ -1,0 +1,152 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// MARK: - Root-relative operations
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// This path with its root removed, leaving a relative path.
+  public __consuming func removingRoot() -> FilePath {
+    switch _backing {
+    case .stdlib(let p):
+      return FilePath(_backing: .stdlib(p.removingRoot()))
+    case .swiftSystem(let p):
+      return FilePath(_backing: .swiftSystem(p.removingRoot()))
+    }
+  }
+
+  /// Resolves `subpath` against this path lexically, refusing to escape it.
+  ///
+  /// Returns `nil` when `subpath` would climb above this path. Forwarded rather
+  /// than reimplemented: it is built out of `removingRoot`,
+  /// `lexicallyNormalized` and component inspection, every one of which SE-0529
+  /// revisits, so the answer has to come from the active backing.
+  public __consuming func lexicallyResolving(
+    _ subpath: __owned FilePath
+  ) -> FilePath? {
+    switch _backing {
+    case .stdlib(let p):
+      return p.lexicallyResolving(subpath._stdlib).map {
+        FilePath(_backing: .stdlib($0))
+      }
+    case .swiftSystem(let p):
+      return p.lexicallyResolving(subpath._swiftSystem).map {
+        FilePath(_backing: .swiftSystem($0))
+      }
+    }
+  }
+}
+
+// MARK: - Composition from a root and components
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Creates a path from an optional root and no components.
+  public init(root: FilePath.Root?) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(root: root?._stdlib) },
+      swiftSystem: { _SwiftSystemFilePath(root: root?._swiftSystem, []) })
+  }
+
+  /// Creates a path from an optional root and a collection of components.
+  ///
+  /// The components are handed to the active backing, which composes them by
+  /// its own era's rules. Nothing is assembled here.
+  public init<C: Collection>(
+    root: FilePath.Root?, _ components: C
+  ) where C.Element == FilePath.Component {
+    self = FilePath._make(
+      stdlib: {
+        _StdlibFilePath(
+          root: root?._stdlib, components.map { $0._stdlib })
+      },
+      swiftSystem: {
+        _SwiftSystemFilePath(
+          root: root?._swiftSystem, components.map { $0._swiftSystem })
+      })
+  }
+
+  /// Creates a path from an optional root and a component view.
+  public init(root: FilePath.Root?, _ components: FilePath.ComponentView) {
+    self.init(root: root, Array(components))
+  }
+
+  /// Creates a path from an optional root and a list of components.
+  public init(root: FilePath.Root?, components: FilePath.Component...) {
+    self.init(root: root, components)
+  }
+}
+
+// MARK: - Substrate and test SPI
+
+// Underscored, so it can change in a patch release. These exist because the
+// substrate and swift-system's own test suite reach for them; each one
+// dispatches rather than deriving, so a caller sees the active era's bytes.
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Creates a path from substrate string storage, normalizing per the active
+  /// backing's rules.
+  internal init(_ str: SystemString) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(str) },
+      swiftSystem: { _SwiftSystemFilePath(str) })
+  }
+
+  /// Creates a path by normalizing raw code units per the active backing.
+  internal init(_normalizing codeUnits: [FilePath.CodeUnit]) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(_normalizing: codeUnits) },
+      swiftSystem: {
+        _SwiftSystemFilePath(SystemString(_codeUnits: codeUnits))
+      })
+  }
+
+  /// This path's code units, excluding the null terminator.
+  internal var _cuArray: [FilePath.CodeUnit] {
+    switch _backing {
+    case .stdlib(let p): return p._cuArray
+    case .swiftSystem(let p):
+      return p.withPlatformString { _filePathCodeUnits(fromNulTerminated: $0) }
+    }
+  }
+
+  /// This path's content as substrate string storage.
+  internal var _systemStringStorage: SystemString {
+    switch _backing {
+    case .stdlib(let p): return p._systemStringStorage
+    case .swiftSystem(let p): return p._storage
+    }
+  }
+
+  /// This path's content as substrate string storage.
+  ///
+  /// Spelled `_storage` because that is the name swift-system's own test suite
+  /// reaches for. On the swiftSystem backing it is the real storage; on the
+  /// stdlib backing it is a restatement of that backing's bytes, so a test
+  /// that asserts on *pointer identity* rather than content will legitimately
+  /// diverge between the two.
+  internal var _storage: SystemString { _systemStringStorage }
+
+  /// Renormalizes separators in place, per the active backing's rules.
+  ///
+  /// A path built by either backing is already separator-normal, so this is a
+  /// no-op on a well-formed value. It exists because swift-system's suite calls
+  /// it to prove exactly that.
+  internal mutating func _normalizeSeparators() {
+    switch _backing {
+    case .stdlib(var p):
+      p._storage._normalizeSeparators()
+      _backing = .stdlib(p)
+    case .swiftSystem(var p):
+      p._normalizeSeparators()
+      _backing = .swiftSystem(p)
+    }
+  }
+}

--- a/Sources/System/Wrapper/WrapperFilePath.swift
+++ b/Sources/System/Wrapper/WrapperFilePath.swift
@@ -1,0 +1,227 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// MARK: - The wrapper
+//
+// `FilePath` is swift-system's public path type. It carries no path storage of
+// its own: it holds one of two complete implementations and forwards every
+// member to whichever is active.
+//
+//   .swiftSystem  the historical swift-system implementation, recovered at
+//                 commit 8ac955b. The default, so existing behavior is what a
+//                 client gets unless it opts in.
+//   .stdlib       the SE-0529 implementation destined for the standard library.
+//
+// Forwarding is the whole design. The wrapper must not re-derive behavior that
+// differs between the two eras, because the interesting differences all live in
+// how a path is recomposed after an edit (appending, pushing,
+// removeLastComponent, the component setters, normalization). Each backing
+// already implements its own era's rules, so the wrapper's job is only to pick
+// one and get out of the way.
+
+// MARK: - Backing selection
+
+/// Chooses which implementation backs every `FilePath` in this process.
+///
+/// The environment default is read once, on first use, and cached. A client can
+/// override it at runtime with `_setFilePathSemanticMode`, which affects only
+/// `FilePath`s constructed afterward: an existing instance keeps the backing it
+/// was built with, so a path never changes era underneath its owner.
+@available(SwiftStdlib 9999, *)
+internal enum _FilePathBackingSelection {
+  /// True when `_SWIFT_SYSTEM_NEW_FILEPATH` is present in the environment.
+  ///
+  /// Presence alone opts in, whatever the value. Absence keeps the historical
+  /// implementation, which is the safe default.
+  private static let envDefault: Bool = system_hasEnv(
+    "_SWIFT_SYSTEM_NEW_FILEPATH")
+
+  /// Opt-in override. `nil` means defer to `envDefault`.
+  ///
+  /// Mutated only by `_setFilePathSemanticMode`. Marked
+  /// `nonisolated(unsafe)` rather than guarded: the intended use is a single
+  /// selection made during start-up, before paths exist and before other
+  /// threads run. Flipping it concurrently with `FilePath` construction is a
+  /// data race and is the caller's responsibility to avoid.
+  nonisolated(unsafe) internal static var _override: Bool? = nil
+
+  internal static var useStdlib: Bool { _override ?? envDefault }
+}
+
+/// Which set of path semantics `FilePath` implements.
+@available(SwiftStdlib 9999, *)
+public enum _FilePathSemanticMode {
+  /// swift-system's historical semantics. The default.
+  case legacy
+
+  /// The SE-0529 semantics destined for the standard library.
+  case stdlibNew
+}
+
+/// Selects the path semantics used by `FilePath`s constructed after this call.
+///
+/// Overrides the `_SWIFT_SYSTEM_NEW_FILEPATH` environment default, which
+/// otherwise sets the mode for the lifetime of the process.
+///
+/// Instances built before the switch keep their original backing. Combining a
+/// pre-switch and a post-switch value in one operation traps: see
+/// `_filePathBackingMismatch`. Call this once during start-up, before any
+/// `FilePath` exists.
+@available(SwiftStdlib 9999, *)
+public func _setFilePathSemanticMode(_ mode: _FilePathSemanticMode) {
+  _FilePathBackingSelection._override = (mode == .stdlibNew)
+}
+
+/// The only place the backing selection is read.
+///
+/// Both closures are written at every call site even though only one runs. That
+/// is deliberate: it keeps the two eras' construction visibly paired, so a
+/// reader can see what each does side by side.
+@available(SwiftStdlib 9999, *)
+internal func _filePathSelect<T>(
+  stdlib: () -> T,
+  swiftSystem: () -> T
+) -> T {
+  _FilePathBackingSelection.useStdlib ? stdlib() : swiftSystem()
+}
+
+// MARK: - FilePath
+
+/// Represents a location in the file system.
+@available(SwiftStdlib 9999, *)
+public struct FilePath: Sendable {
+  @usableFromInline
+  internal enum Backing: Sendable {
+    case stdlib(_StdlibFilePath)
+    case swiftSystem(_SwiftSystemFilePath)
+  }
+
+  @usableFromInline
+  internal var _backing: Backing
+
+  @usableFromInline
+  internal init(_backing: Backing) {
+    self._backing = _backing
+  }
+}
+
+// MARK: - Construction funnel
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// The single point where a `FilePath` is built from scratch.
+  ///
+  /// Every initializer in the wrapper routes through here or through
+  /// `_makeIfSome`, so no initializer can accidentally hard-code a backing.
+  internal static func _make(
+    stdlib: () -> _StdlibFilePath,
+    swiftSystem: () -> _SwiftSystemFilePath
+  ) -> FilePath {
+    _filePathSelect(
+      stdlib: { FilePath(_backing: .stdlib(stdlib())) },
+      swiftSystem: { FilePath(_backing: .swiftSystem(swiftSystem())) })
+  }
+
+  /// `_make` for failable initializers: the active backing decides, and its
+  /// `nil` propagates.
+  internal static func _makeIfSome(
+    stdlib: () -> _StdlibFilePath?,
+    swiftSystem: () -> _SwiftSystemFilePath?
+  ) -> FilePath? {
+    _filePathSelect(
+      stdlib: { stdlib().map { FilePath(_backing: .stdlib($0)) } },
+      swiftSystem: { swiftSystem().map { FilePath(_backing: .swiftSystem($0)) } })
+  }
+}
+
+// MARK: - Backing access
+
+/// Reports a value whose backing does not match the process-wide selection.
+///
+/// Reachable only by decoding a `FilePath` that a different era encoded; see
+/// the `Codable` conformance, which diagnoses that case directly.
+@available(SwiftStdlib 9999, *)
+internal func _filePathBackingMismatch(
+  _ what: String = "FilePath"
+) -> Never {
+  fatalError(
+    """
+    \(what) backing mismatch: this value was created by the other \
+    implementation. A FilePath cannot mix the SE-0529 and historical \
+    swift-system backings, because their path semantics differ.
+    """)
+}
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// The stdlib backing, or a trap when this value is swiftSystem-backed.
+  internal var _stdlib: _StdlibFilePath {
+    guard case .stdlib(let p) = _backing else { _filePathBackingMismatch() }
+    return p
+  }
+
+  /// The swiftSystem backing, or a trap when this value is stdlib-backed.
+  internal var _swiftSystem: _SwiftSystemFilePath {
+    guard case .swiftSystem(let p) = _backing else { _filePathBackingMismatch() }
+    return p
+  }
+
+  /// True when this value is backed by the SE-0529 implementation.
+  internal var _isStdlibBacked: Bool {
+    switch _backing {
+    case .stdlib: return true
+    case .swiftSystem: return false
+    }
+  }
+}
+
+// MARK: - Nested types
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// The platform's path code unit: `CChar` on Unix, `UInt16` on Windows.
+  public typealias CodeUnit = _StdlibFilePath.CodeUnit
+
+  // Neither `Component` nor `Root` is a typealias. Both are thin dispatching
+  // wrappers, declared in WrapperComponent.swift and WrapperRoot.swift, because
+  // deciding whether a given string is one component (or one root) is
+  // era-specific. See those files for the full reasoning.
+}
+
+// MARK: - Component code units
+
+/// Copies a null-terminated platform string into a code-unit array, dropping
+/// the terminator.
+///
+/// `CInterop.PlatformChar` and `FilePath.CodeUnit` are the same type on every
+/// supported platform, so this is a copy and not a reinterpretation.
+@available(SwiftStdlib 9999, *)
+internal func _filePathCodeUnits(
+  fromNulTerminated p: UnsafePointer<CInterop.PlatformChar>
+) -> [FilePath.CodeUnit] {
+  var out = [FilePath.CodeUnit]()
+  var i = 0
+  while p[i] != 0 {
+    out.append(p[i])
+    i += 1
+  }
+  return out
+}
+
+@available(SwiftStdlib 9999, *)
+extension _SwiftSystemFilePath.Component {
+  /// This component's code units, excluding any null terminator.
+  ///
+  /// Reads through `withPlatformString`, the backing's own public byte
+  /// accessor, so this does not reach into the backing's internals.
+  internal var _wrapperCodeUnits: [FilePath.CodeUnit] {
+    withPlatformString { _filePathCodeUnits(fromNulTerminated: $0) }
+  }
+}
+

--- a/Sources/System/Wrapper/WrapperRoot.swift
+++ b/Sources/System/Wrapper/WrapperRoot.swift
@@ -1,0 +1,265 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// MARK: - FilePath.Root
+//
+// A thin dispatching wrapper, like `ComponentView` and unlike `Component`.
+//
+// `Component` can be a stdlib-side typealias with conversion at the boundary
+// because a component is a separator-free byte run: every backing agrees such a
+// value is well formed, so it is always representable on the other side.
+//
+// A root is not like that. Root validity is platform-dependent, and the two
+// backings do not decide platform-ness the same way. The historical backing
+// honors the runtime `withWindowsPaths(enabled:)` mock, while SE-0529's base
+// resolves the platform at compile time from `#if os(Windows)`. So on a Unix
+// host under a forced-Windows test, the historical backing hands out roots like
+// `C:` and `\` that the base cannot parse as roots at all, and a converting
+// design has nowhere to put them.
+//
+// Holding each backing's own root representation removes the conversion, and
+// with it the failure. Note also that SE-0529's base has no `Root` of its own,
+// only `Anchor`; `_StdlibFilePath.Root` is itself a shim presenting
+// swift-system's `Root` over that `Anchor`. So both arms of this wrapper are
+// already era-specific presentations, and this type just picks one.
+//
+// `Root` stays exposed because swift-system's public API has it.
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// A path's root, such as `/` on Unix or `C:\` on Windows.
+  public struct Root: Sendable {
+    @usableFromInline
+    internal enum Backing: Sendable {
+      case stdlib(_StdlibFilePath.Root)
+      case swiftSystem(_SwiftSystemFilePath.Root)
+    }
+
+    @usableFromInline
+    internal var _backing: Backing
+
+    @usableFromInline
+    internal init(_backing: Backing) {
+      self._backing = _backing
+    }
+  }
+}
+
+// MARK: - Construction funnel
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Root {
+  internal static func _make(
+    stdlib: () -> _StdlibFilePath.Root,
+    swiftSystem: () -> _SwiftSystemFilePath.Root
+  ) -> FilePath.Root {
+    _filePathSelect(
+      stdlib: { FilePath.Root(_backing: .stdlib(stdlib())) },
+      swiftSystem: { FilePath.Root(_backing: .swiftSystem(swiftSystem())) })
+  }
+
+  internal static func _makeIfSome(
+    stdlib: () -> _StdlibFilePath.Root?,
+    swiftSystem: () -> _SwiftSystemFilePath.Root?
+  ) -> FilePath.Root? {
+    _filePathSelect(
+      stdlib: { stdlib().map { FilePath.Root(_backing: .stdlib($0)) } },
+      swiftSystem: {
+        swiftSystem().map { FilePath.Root(_backing: .swiftSystem($0)) }
+      })
+  }
+}
+
+// MARK: - Backing access
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Root {
+  internal var _stdlib: _StdlibFilePath.Root {
+    guard case .stdlib(let r) = _backing else {
+      _filePathBackingMismatch("FilePath.Root")
+    }
+    return r
+  }
+
+  internal var _swiftSystem: _SwiftSystemFilePath.Root {
+    guard case .swiftSystem(let r) = _backing else {
+      _filePathBackingMismatch("FilePath.Root")
+    }
+    return r
+  }
+}
+
+// MARK: - Construction from strings
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Root {
+  /// Creates a root from a string, or `nil` if it is not exactly a root.
+  public init?(_ string: String) {
+    guard let r = FilePath.Root._makeIfSome(
+      stdlib: { _StdlibFilePath.Root(string) },
+      swiftSystem: { _SwiftSystemFilePath.Root(string) })
+    else { return nil }
+    self = r
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Root: ExpressibleByStringLiteral {
+  /// Creates a root from a string literal.
+  public init(stringLiteral: String) {
+    self = FilePath.Root._make(
+      stdlib: { _StdlibFilePath.Root(stringLiteral: stringLiteral) },
+      swiftSystem: { _SwiftSystemFilePath.Root(stringLiteral: stringLiteral) })
+  }
+}
+
+// MARK: - Platform string
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Root {
+  /// Creates a root by copying bytes from a null-terminated platform string.
+  public init?(platformString: UnsafePointer<CInterop.PlatformChar>) {
+    guard let r = FilePath.Root._makeIfSome(
+      stdlib: { _StdlibFilePath.Root(platformString: platformString) },
+      swiftSystem: { _SwiftSystemFilePath.Root(platformString: platformString) })
+    else { return nil }
+    self = r
+  }
+
+  /// Creates a root by copying bytes from a null-terminated platform string.
+  public init?(platformString: [CInterop.PlatformChar]) {
+    guard let r = FilePath.Root._makeIfSome(
+      stdlib: { _StdlibFilePath.Root(platformString: platformString) },
+      swiftSystem: { _SwiftSystemFilePath.Root(platformString: platformString) })
+    else { return nil }
+    self = r
+  }
+
+  @available(*, deprecated, message: "Use FilePath.Root.init(_ scalar: Unicode.Scalar)")
+  public init?(platformString: inout CInterop.PlatformChar) {
+    guard let r = FilePath.Root._makeIfSome(
+      stdlib: { _StdlibFilePath.Root(platformString: &platformString) },
+      swiftSystem: { _SwiftSystemFilePath.Root(platformString: &platformString) })
+    else { return nil }
+    self = r
+  }
+
+  @available(*, deprecated, message: "Use FilePath.Root.init(_: String)")
+  public init?(platformString: String) {
+    guard let r = FilePath.Root._makeIfSome(
+      stdlib: { _StdlibFilePath.Root(platformString: platformString) },
+      swiftSystem: { _SwiftSystemFilePath.Root(platformString: platformString) })
+    else { return nil }
+    self = r
+  }
+
+  /// Calls `body` with a pointer to this root's null-terminated platform-string
+  /// contents.
+  public func withPlatformString<Result>(
+    _ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result
+  ) rethrows -> Result {
+    switch _backing {
+    case .stdlib(let r): return try r.withPlatformString(body)
+    case .swiftSystem(let r): return try r.withPlatformString(body)
+    }
+  }
+}
+
+// MARK: - String rendering
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Root {
+  /// This root rendered as a string, repairing invalid code unit sequences.
+  public var string: String {
+    switch _backing {
+    case .stdlib(let r): return r.string
+    case .swiftSystem(let r): return r.string
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Root: CustomStringConvertible, CustomDebugStringConvertible {
+  public var description: String {
+    switch _backing {
+    case .stdlib(let r): return r.description
+    case .swiftSystem(let r): return r.description
+    }
+  }
+
+  public var debugDescription: String { description.debugDescription }
+}
+
+// MARK: - Equatable, Hashable
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Root: Equatable, Hashable {
+  public static func == (lhs: FilePath.Root, rhs: FilePath.Root) -> Bool {
+    switch (lhs._backing, rhs._backing) {
+    case (.stdlib(let l), .stdlib(let r)): return l == r
+    case (.swiftSystem(let l), .swiftSystem(let r)): return l == r
+    default: _filePathBackingMismatch("FilePath.Root")
+    }
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    switch _backing {
+    case .stdlib(let r): hasher.combine(r)
+    case .swiftSystem(let r): hasher.combine(r)
+    }
+  }
+}
+
+// MARK: - Codable
+
+@available(SwiftStdlib 9999, *)
+extension FilePath.Root: Codable {
+  public func encode(to encoder: any Encoder) throws {
+    switch _backing {
+    case .stdlib(let r): try r.encode(to: encoder)
+    case .swiftSystem(let r): try r.encode(to: encoder)
+    }
+  }
+
+  public init(from decoder: any Decoder) throws {
+    if _FilePathBackingSelection.useStdlib {
+      self.init(_backing: .stdlib(try _StdlibFilePath.Root(from: decoder)))
+    } else {
+      self.init(
+        _backing: .swiftSystem(try _SwiftSystemFilePath.Root(from: decoder)))
+    }
+  }
+}
+
+// MARK: - String from a root
+
+@available(SwiftStdlib 9999, *)
+extension String {
+  /// Creates a string by decoding a root's content, repairing invalid code unit
+  /// sequences.
+  public init(decoding root: FilePath.Root) {
+    switch root._backing {
+    case .stdlib(let r): self.init(decoding: r)
+    case .swiftSystem(let r): self.init(decoding: r)
+    }
+  }
+
+  /// Creates a string from a root, or `nil` if its content is not valid in the
+  /// platform's encoding.
+  public init?(validating root: FilePath.Root) {
+    switch root._backing {
+    case .stdlib(let r):
+      guard let s = String(validating: r) else { return nil }
+      self = s
+    case .swiftSystem(let r):
+      guard let s = String(validating: r) else { return nil }
+      self = s
+    }
+  }
+}

--- a/Sources/System/Wrapper/WrapperString.swift
+++ b/Sources/System/Wrapper/WrapperString.swift
@@ -1,0 +1,208 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// MARK: - String and platform-string interop
+//
+// Signatures here are the ABI contract. They are fixed at compile time and do
+// not vary with the backing: a client links against one set of symbols whether
+// or not the opt-in is set. Only the bodies dispatch.
+
+// MARK: - Construction from a String
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Creates a file path from a string.
+  ///
+  /// Non-failable, because that is the signature swift-system ships. The
+  /// signature cannot depend on the backing even though the two eras disagree
+  /// about what an embedded NUL means:
+  ///
+  ///   .stdlib       NUL is not a valid path byte, so this traps. SE-0529
+  ///                 exposes a failable `init?` for callers that want to
+  ///                 handle it, but that is a different signature and not this
+  ///                 one.
+  ///   .swiftSystem  truncates at the first NUL, as swift-system always did.
+  ///
+  /// A string literal does not reach this initializer: `FilePath("...")`
+  /// coerces to `init(stringLiteral:)` under SE-0213, so literals keep working
+  /// exactly as before.
+  public init(_ string: String) {
+    self = FilePath._make(
+      stdlib: {
+        guard let p = _StdlibFilePath(string) else {
+          preconditionFailure(
+            """
+            FilePath(_: String): the string contains NUL, which is not a valid \
+            path byte. Use the failable initializer to handle this case.
+            """)
+        }
+        return p
+      },
+      swiftSystem: { _SwiftSystemFilePath(string) })
+  }
+
+  /// This path rendered as a string, repairing any invalid code unit sequences.
+  public var string: String {
+    switch _backing {
+    case .stdlib(let p): return p.string
+    case .swiftSystem(let p): return p.string
+    }
+  }
+}
+
+// MARK: - ExpressibleByStringLiteral
+
+@available(SwiftStdlib 9999, *)
+extension FilePath: ExpressibleByStringLiteral {
+  /// Creates a file path from a string literal.
+  public init(stringLiteral: String) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(stringLiteral: stringLiteral) },
+      swiftSystem: { _SwiftSystemFilePath(stringLiteral: stringLiteral) })
+  }
+}
+
+// MARK: - Platform string
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Creates a file path by copying bytes from a null-terminated platform
+  /// string.
+  public init(platformString: UnsafePointer<CInterop.PlatformChar>) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(platformString: platformString) },
+      swiftSystem: { _SwiftSystemFilePath(platformString: platformString) })
+  }
+
+  /// Creates a file path by copying bytes from a null-terminated platform
+  /// string.
+  public init(platformString: [CInterop.PlatformChar]) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(platformString: platformString) },
+      swiftSystem: { _SwiftSystemFilePath(platformString: platformString) })
+  }
+
+  @available(*, deprecated, message: "Use FilePath.init(_ scalar: Unicode.Scalar)")
+  public init(platformString: inout CInterop.PlatformChar) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(platformString: &platformString) },
+      swiftSystem: { _SwiftSystemFilePath(platformString: &platformString) })
+  }
+
+  @available(*, deprecated, message: "Use FilePath(_: String) to create a path from a String")
+  public init(platformString: String) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(platformString: platformString) },
+      swiftSystem: { _SwiftSystemFilePath(platformString: platformString) })
+  }
+
+  /// Calls `body` with a pointer to this path's null-terminated platform-string
+  /// contents.
+  public func withPlatformString<Result>(
+    _ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result
+  ) rethrows -> Result {
+    switch _backing {
+    case .stdlib(let p): return try p.withPlatformString(body)
+    case .swiftSystem(let p): return try p.withPlatformString(body)
+    }
+  }
+}
+
+// MARK: - C string (deprecated spellings)
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  @available(*, deprecated, renamed: "init(platformString:)")
+  public init(cString: UnsafePointer<CChar>) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(cString: cString) },
+      swiftSystem: { _SwiftSystemFilePath(cString: cString) })
+  }
+
+  @available(*, deprecated, renamed: "init(platformString:)")
+  public init(cString: [CChar]) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(cString: cString) },
+      swiftSystem: { _SwiftSystemFilePath(cString: cString) })
+  }
+
+  @available(*, deprecated, renamed: "init(platformString:)")
+  public init(cString: inout CChar) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(cString: &cString) },
+      swiftSystem: { _SwiftSystemFilePath(cString: &cString) })
+  }
+
+  @available(*, deprecated, renamed: "init(platformString:)")
+  public init(cString: String) {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath(cString: cString) },
+      swiftSystem: { _SwiftSystemFilePath(cString: cString) })
+  }
+
+  @available(*, deprecated, renamed: "withPlatformString")
+  public func withCString<Result>(
+    _ body: (UnsafePointer<CChar>) throws -> Result
+  ) rethrows -> Result {
+    switch _backing {
+    case .stdlib(let p): return try p.withCString(body)
+    case .swiftSystem(let p): return try p.withCString(body)
+    }
+  }
+}
+
+// MARK: - _PlatformStringable
+
+// Lets the substrate's generic platform-string helpers accept the wrapper the
+// same way they accept either backing.
+@available(SwiftStdlib 9999, *)
+extension FilePath: _PlatformStringable {
+  internal func _withPlatformString<Result>(
+    _ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result
+  ) rethrows -> Result {
+    try withPlatformString(body)
+  }
+
+  internal init(_platformString: UnsafePointer<CInterop.PlatformChar>) {
+    self.init(platformString: _platformString)
+  }
+}
+
+// MARK: - String from a path
+
+@available(SwiftStdlib 9999, *)
+extension String {
+  /// Creates a string by decoding this path's content, repairing any invalid
+  /// code unit sequences.
+  public init(decoding path: FilePath) {
+    switch path._backing {
+    case .stdlib(let p): self.init(decoding: p)
+    case .swiftSystem(let p): self.init(decoding: p)
+    }
+  }
+
+  /// Creates a string from this path, or `nil` if its content is not valid in
+  /// the platform's encoding.
+  public init?(validating path: FilePath) {
+    switch path._backing {
+    case .stdlib(let p):
+      guard let s = String(validating: p) else { return nil }
+      self = s
+    case .swiftSystem(let p):
+      guard let s = String(validating: p) else { return nil }
+      self = s
+    }
+  }
+
+  @available(*, deprecated, renamed: "init(decoding:)")
+  public init(_ path: FilePath) { self.init(decoding: path) }
+
+  @available(*, deprecated, renamed: "init(validating:)")
+  public init?(validatingUTF8 path: FilePath) { self.init(validating: path) }
+}

--- a/Sources/System/Wrapper/WrapperSyntax.swift
+++ b/Sources/System/Wrapper/WrapperSyntax.swift
@@ -1,0 +1,355 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// MARK: - Syntactic operations
+//
+// Straight forwarding. Every member below switches on the backing and calls the
+// same member on it. Nothing here re-derives era-specific behavior: the members
+// that recompose a path (append, push, removeLastComponent, lexicallyNormalize
+// and their non-mutating twins) are precisely the ones whose rules changed in
+// SE-0529, so each backing's own implementation has to be the one that runs.
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Creates an empty path.
+  public init() {
+    self = FilePath._make(
+      stdlib: { _StdlibFilePath() },
+      swiftSystem: { _SwiftSystemFilePath() })
+  }
+}
+
+// MARK: - Queries
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Whether this path uniquely identifies a location independent of any
+  /// working directory.
+  public var isAbsolute: Bool {
+    switch _backing {
+    case .stdlib(let p): return p.isAbsolute
+    case .swiftSystem(let p): return p.isAbsolute
+    }
+  }
+
+  /// Whether this path is not absolute.
+  public var isRelative: Bool { !isAbsolute }
+
+  /// Whether this path is empty.
+  public var isEmpty: Bool {
+    switch _backing {
+    case .stdlib(let p): return p.isEmpty
+    case .swiftSystem(let p): return p.isEmpty
+    }
+  }
+
+  /// The length of this path's content, in code units.
+  public var length: Int {
+    switch _backing {
+    case .stdlib(let p): return p.length
+    case .swiftSystem(let p): return p.length
+    }
+  }
+
+  /// Whether `other` is a prefix of this path.
+  public func starts(with other: FilePath) -> Bool {
+    switch _backing {
+    case .stdlib(let p): return p.starts(with: other._stdlib)
+    case .swiftSystem(let p): return p.starts(with: other._swiftSystem)
+    }
+  }
+
+  /// Whether `other` is a suffix of this path.
+  public func ends(with other: FilePath) -> Bool {
+    switch _backing {
+    case .stdlib(let p): return p.ends(with: other._stdlib)
+    case .swiftSystem(let p): return p.ends(with: other._swiftSystem)
+    }
+  }
+}
+
+// MARK: - Root
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// This path's root, if it has one.
+  ///
+  /// Both sides stay in their own era's root representation; nothing is
+  /// converted. See WrapperRoot.swift.
+  public var root: FilePath.Root? {
+    get {
+      switch _backing {
+      case .stdlib(let p):
+        return p.root.map { FilePath.Root(_backing: .stdlib($0)) }
+      case .swiftSystem(let p):
+        return p.root.map { FilePath.Root(_backing: .swiftSystem($0)) }
+      }
+    }
+    set {
+      switch _backing {
+      case .stdlib(var p):
+        p.root = newValue?._stdlib
+        _backing = .stdlib(p)
+      case .swiftSystem(var p):
+        p.root = newValue?._swiftSystem
+        _backing = .swiftSystem(p)
+      }
+    }
+  }
+}
+
+// MARK: - Components
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// This path's last component, if it has one.
+  public var lastComponent: Component? {
+    switch _backing {
+    case .stdlib(let p):
+      return p.lastComponent.map { Component(_backing: .stdlib($0)) }
+    case .swiftSystem(let p):
+      return p.lastComponent.map { Component(_backing: .swiftSystem($0)) }
+    }
+  }
+
+  /// Removes this path's last component, returning whether it did so.
+  @discardableResult
+  public mutating func removeLastComponent() -> Bool {
+    switch _backing {
+    case .stdlib(var p):
+      let r = p.removeLastComponent()
+      _backing = .stdlib(p)
+      return r
+    case .swiftSystem(var p):
+      let r = p.removeLastComponent()
+      _backing = .swiftSystem(p)
+      return r
+    }
+  }
+
+  /// This path with its last component removed.
+  public __consuming func removingLastComponent() -> FilePath {
+    switch _backing {
+    case .stdlib(let p): return FilePath(_backing: .stdlib(p.removingLastComponent()))
+    case .swiftSystem(let p):
+      return FilePath(_backing: .swiftSystem(p.removingLastComponent()))
+    }
+  }
+
+  /// This path with its last component removed.
+  public var dirname: FilePath { removingLastComponent() }
+
+  /// This path's last component, if it has one.
+  public var basename: Component? { lastComponent }
+}
+
+// MARK: - Extension and stem
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// The file extension of this path's last component.
+  public var `extension`: String? {
+    get {
+      switch _backing {
+      case .stdlib(let p): return p.extension
+      case .swiftSystem(let p): return p.extension
+      }
+    }
+    set {
+      switch _backing {
+      case .stdlib(var p):
+        p.extension = newValue
+        _backing = .stdlib(p)
+      case .swiftSystem(var p):
+        p.extension = newValue
+        _backing = .swiftSystem(p)
+      }
+    }
+  }
+
+  /// The non-extension portion of this path's last component.
+  public var stem: String? { lastComponent?.stem }
+}
+
+// MARK: - Normalization
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Whether this path is in lexical-normal form.
+  ///
+  /// Given its own switch rather than derived, because what counts as normal is
+  /// one of the things SE-0529 changes.
+  public var isLexicallyNormal: Bool {
+    switch _backing {
+    case .stdlib(let p): return p.isLexicallyNormal
+    case .swiftSystem(let p): return p.isLexicallyNormal
+    }
+  }
+
+  /// Normalizes this path lexically, without consulting the file system.
+  public mutating func lexicallyNormalize() {
+    switch _backing {
+    case .stdlib(var p):
+      p.lexicallyNormalize()
+      _backing = .stdlib(p)
+    case .swiftSystem(var p):
+      p.lexicallyNormalize()
+      _backing = .swiftSystem(p)
+    }
+  }
+
+  /// This path, normalized lexically.
+  public __consuming func lexicallyNormalized() -> FilePath {
+    switch _backing {
+    case .stdlib(let p): return FilePath(_backing: .stdlib(p.lexicallyNormalized()))
+    case .swiftSystem(let p):
+      return FilePath(_backing: .swiftSystem(p.lexicallyNormalized()))
+    }
+  }
+}
+
+// MARK: - Prefix removal
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Removes `prefix` from the front of this path, returning whether it did so.
+  public mutating func removePrefix(_ prefix: FilePath) -> Bool {
+    switch _backing {
+    case .stdlib(var p):
+      let r = p.removePrefix(prefix._stdlib)
+      _backing = .stdlib(p)
+      return r
+    case .swiftSystem(var p):
+      let r = p.removePrefix(prefix._swiftSystem)
+      _backing = .swiftSystem(p)
+      return r
+    }
+  }
+}
+
+// MARK: - Appending
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Appends a component.
+  public mutating func append(_ other: __owned FilePath.Component) {
+    switch _backing {
+    case .stdlib(var p):
+      p.append(other._stdlib)
+      _backing = .stdlib(p)
+    case .swiftSystem(var p):
+      p.append(other._swiftSystem)
+      _backing = .swiftSystem(p)
+    }
+  }
+
+  /// Appends a collection of components.
+  public mutating func append<C: Collection>(
+    _ components: __owned C
+  ) where C.Element == FilePath.Component {
+    switch _backing {
+    case .stdlib(var p):
+      p.append(components.map { $0._stdlib })
+      _backing = .stdlib(p)
+    case .swiftSystem(var p):
+      p.append(components.map { $0._swiftSystem })
+      _backing = .swiftSystem(p)
+    }
+  }
+
+  /// Appends the components of `other`, parsed from a string.
+  public mutating func append(_ other: __owned String) {
+    switch _backing {
+    case .stdlib(var p):
+      p.append(other)
+      _backing = .stdlib(p)
+    case .swiftSystem(var p):
+      p.append(other)
+      _backing = .swiftSystem(p)
+    }
+  }
+
+  /// This path with `other` appended.
+  public __consuming func appending(
+    _ other: __owned FilePath.Component
+  ) -> FilePath {
+    var result = self
+    result.append(other)
+    return result
+  }
+
+  /// This path with `components` appended.
+  public __consuming func appending<C: Collection>(
+    _ components: __owned C
+  ) -> FilePath where C.Element == FilePath.Component {
+    var result = self
+    result.append(components)
+    return result
+  }
+
+  /// This path with the components of `other` appended.
+  public __consuming func appending(_ other: __owned String) -> FilePath {
+    var result = self
+    result.append(other)
+    return result
+  }
+}
+
+// MARK: - Pushing
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Appends `other`, replacing this path entirely if `other` is absolute.
+  public mutating func push(_ other: __owned FilePath) {
+    switch _backing {
+    case .stdlib(var p):
+      p.push(other._stdlib)
+      _backing = .stdlib(p)
+    case .swiftSystem(var p):
+      p.push(other._swiftSystem)
+      _backing = .swiftSystem(p)
+    }
+  }
+
+  /// This path with `other` pushed onto it.
+  public __consuming func pushing(_ other: __owned FilePath) -> FilePath {
+    var result = self
+    result.push(other)
+    return result
+  }
+}
+
+// MARK: - Storage management
+
+@available(SwiftStdlib 9999, *)
+extension FilePath {
+  /// Removes this path's contents.
+  public mutating func removeAll(keepingCapacity: Bool = false) {
+    switch _backing {
+    case .stdlib(var p):
+      p.removeAll(keepingCapacity: keepingCapacity)
+      _backing = .stdlib(p)
+    case .swiftSystem(var p):
+      p.removeAll(keepingCapacity: keepingCapacity)
+      _backing = .swiftSystem(p)
+    }
+  }
+
+  /// Reserves storage for at least `minimumCapacity` code units.
+  public mutating func reserveCapacity(_ minimumCapacity: Int) {
+    switch _backing {
+    case .stdlib(var p):
+      p.reserveCapacity(minimumCapacity)
+      _backing = .stdlib(p)
+    case .swiftSystem(var p):
+      p.reserveCapacity(minimumCapacity)
+      _backing = .swiftSystem(p)
+    }
+  }
+}

--- a/Sources/System/_StdlibFilePath/FilePath.swift
+++ b/Sources/System/_StdlibFilePath/FilePath.swift
@@ -1,0 +1,330 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+/// A file path is a null-terminated sequence of bytes that represents
+/// a location in the file system.
+@available(SwiftStdlib 9999, *)
+public struct _StdlibFilePath: Sendable {
+  internal var _storage: _SystemString
+
+  /// Creates an empty file path.
+  @available(SwiftStdlib 9999, *)
+  public init() {
+    self._storage = _SystemString()
+  }
+
+  internal init(_storage: _SystemString) {
+    self._storage = _storage
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  // Normalizing init: the funnel for all path construction.
+  //
+  // All three platforms coalesce separators first, then parse. Darwin
+  // additionally canonicalizes the anchor and excludes the resource-fork
+  // suffix from dot-normalization (see _normalizeDarwin).
+  internal init(_normalizing str: _SystemString) {
+    if _isDarwin {
+      self = _normalizeDarwin(str)
+    } else if _isWindows {
+      self = _normalizeWindows(str)
+    } else {
+      self = _normalizeLinux(str)
+    }
+  }
+
+  /// Creates a file path by normalizing a sequence of platform code units.
+  ///
+  /// This is the non-failable construction funnel: it coalesces separators
+  /// and applies the platform's dot rules, the same normalization every
+  /// public initializer performs, but without the `NUL`-rejection of the
+  /// public initializers. The caller is responsible for ensuring the code
+  /// units contain no `NUL`.
+  ///
+  /// Underscored SPI: this is the primitive a source-compatibility layer
+  /// (e.g. swift-system's _StdlibFilePath API) constructs paths through when it has
+  /// already-validated bytes and needs a non-failable, non-`Span` entry
+  /// point. It is not public API in the proposal.
+  @available(SwiftStdlib 9999, *)
+  public init<C: Sequence<_StdlibFilePath.CodeUnit>>(_normalizing codeUnits: C) {
+    self.init(_normalizing: _SystemString(codeUnits))
+  }
+
+  /// The platform's canonical directory separator, as a code unit.
+  ///
+  /// On Linux and Darwin, this is the code unit for `/`.
+  /// On Windows, it is the code unit for `\`.
+  @available(SwiftStdlib 9999, *)
+  public static var separator: _StdlibFilePath.CodeUnit {
+    _platformSeparator
+  }
+
+  /// Whether this path is empty.
+  @available(SwiftStdlib 9999, *)
+  public var isEmpty: Bool { _storage.isEmpty }
+}
+
+// MARK: - Lexical normalization
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Lexically normalize this path in place. Purely lexical: it consults
+  /// only the path's own bytes, never the file system, so a result that
+  /// resolves `..` may not match what following symlinks would produce.
+  ///
+  /// Each flag selects one independent aspect of normalization. The anchor
+  /// is never altered; only the relative components are folded.
+  ///
+  /// - `removeCurrentDirectory`: drop every `.` (current-directory)
+  ///   component.
+  /// - `collapseParentDirectory`: resolve each `..` (parent-directory)
+  ///   component against a preceding regular component, dropping both. A
+  ///   `..` with nothing to resolve is dropped when the path is rooted (it
+  ///   cannot climb above the anchor) and preserved when the path is
+  ///   rootless. A leading run of `..` on a relative path survives, since
+  ///   a `..` never resolves another `..`.
+  /// - `removeTrailingSeparator`: drop a trailing directory separator from
+  ///   the relative portion (a structural separator belonging to the anchor
+  ///   is left in place).
+  ///
+  /// In a Windows verbatim path (`\\?\…`), `.` and `..` are ordinary
+  /// component names, so the two dot flags leave them untouched.
+  ///
+  /// Underscored SPI: the low-level primitive that source-compatibility
+  /// layers and higher-level normalization API build on. `.` -dropping and
+  /// `..` -collapsing legacy lexical normalization is all three flags set.
+  /// Not public API in the proposal.
+  @available(SwiftStdlib 9999, *)
+  public mutating func _lexicallyNormalize(
+    removeCurrentDirectory: Bool,
+    collapseParentDirectory: Bool,
+    removeTrailingSeparator: Bool
+  ) {
+    let src = _storage
+    guard !src.isEmpty else { return }
+
+    let verbatim = _isVerbatimComponentPath(src)
+    let (rootEnd, relBegin) = src._parseRoot()
+
+    // "Rooted" here means: does an underflowing `..` get dropped? Only when
+    // there is an anchor it cannot climb above. The Windows drive-relative
+    // form `C:` is not such an anchor (`C:..` is meaningful), matching the
+    // construction funnel's notion of rooted.
+    let rooted: Bool
+    if rootEnd == src.startIndex {
+      rooted = false
+    } else if _isWindows {
+      rooted = !_isDriveRelativeAnchor(src[src.startIndex..<rootEnd])
+    } else {
+      rooted = true
+    }
+
+    // result = anchor + gap, then the folded relative components. `relBegin`
+    // already includes the gap separator, so the first appended component
+    // needs no separator before it. Components are appended without a
+    // trailing separator, so during the walk the byte before `result`'s end
+    // is always a component byte.
+    var result = _SystemString()
+    result.append(contentsOf: src[..<relBegin])
+    let prefixEnd = result.endIndex
+
+    var lastComponentStart = prefixEnd
+    var appendedAny = false
+    var sourceHadTrailingSep = false
+
+    var readIdx = relBegin
+    let end = src.endIndex
+    while readIdx < end {
+      // Storage is coalesced, so separators are single; one at the end of the
+      // range is a trailing separator on the relative portion.
+      if _isSeparator(src[readIdx]) {
+        let next = src.index(after: readIdx)
+        if next >= end { sourceHadTrailingSep = true }
+        readIdx = next
+        continue
+      }
+
+      let compStart = readIdx
+      while readIdx < end && !_isSeparator(src[readIdx]) {
+        readIdx = src.index(after: readIdx)
+      }
+      let compEnd = readIdx
+      let compLen = src.distance(from: compStart, to: compEnd)
+
+      // In a verbatim path `.` and `..` are ordinary component names.
+      let isDot =
+        !verbatim && compLen == 1 && src[compStart] == ._dot
+      let isDotDot =
+        !verbatim && compLen == 2 && src[compStart] == ._dot
+        && src[src.index(after: compStart)] == ._dot
+
+      if isDot {
+        if removeCurrentDirectory { continue }
+      } else if isDotDot && collapseParentDirectory {
+        // Resolve against the last appended component if it is regular. The
+        // only non-regular thing we ever append is a `..` (rootless case),
+        // which a `..` cannot resolve.
+        var poppable = false
+        if appendedAny {
+          let len = result.distance(from: lastComponentStart, to: result.endIndex)
+          let lastIsDotDot =
+            len == 2 && result[lastComponentStart] == ._dot
+            && result[result.index(after: lastComponentStart)] == ._dot
+          poppable = !lastIsDotDot
+        }
+        if poppable {
+          // Drop the last component and the separator that precedes it.
+          var cut = lastComponentStart
+          if cut > prefixEnd { cut = result.index(before: cut) }
+          result.removeSubrange(cut..<result.endIndex)
+          // Re-derive the new last component's start by scanning back over
+          // its bytes (bounded by the anchor prefix).
+          var i = result.endIndex
+          while i > prefixEnd
+                && !_isSeparator(result[result.index(before: i)]) {
+            result.formIndex(before: &i)
+          }
+          lastComponentStart = i
+          appendedAny = result.endIndex > prefixEnd
+          continue
+        }
+        if rooted { continue }
+        // Rootless underflow: fall through and preserve the `..`.
+      }
+
+      if result.endIndex > prefixEnd { result.append(_platformSeparator) }
+      lastComponentStart = result.endIndex
+      result.append(contentsOf: src[compStart..<compEnd])
+      appendedAny = true
+    }
+
+    if sourceHadTrailingSep && !removeTrailingSeparator && appendedAny {
+      result.append(_platformSeparator)
+    }
+
+    _storage = result
+  }
+}
+
+// MARK: - Per-platform normalization
+
+@available(SwiftStdlib 9999, *)
+private func _normalizeLinux(_ str: _SystemString) -> _StdlibFilePath {
+  _internalInvariant(_isLinux)
+  var s = str
+  s._normalizeSeparators()
+  let (rootEnd, relBegin) = s._parseRoot()
+  let isRooted = rootEnd != s.startIndex
+  var result = _SystemString()
+  result.append(contentsOf: s[s.startIndex..<relBegin])  // anchor + gap
+  _ = s._normalizeDots(
+    over: relBegin..<s.endIndex, isRooted: isRooted, into: &result)
+  return _StdlibFilePath(_storage: result)
+}
+
+@available(SwiftStdlib 9999, *)
+private func _normalizeWindows(_ str: _SystemString) -> _StdlibFilePath {
+  var s = str
+  s._normalizeSeparators()
+  let isVerbatim = _isVerbatimComponentPath(s)
+  let (rootEnd, relBegin) = s._parseRoot()
+  // The only non-rooted Windows anchor is the 2-byte drive-relative `C:`;
+  // empty/no-root counts as not rooted. Every other anchor (`\`, `C:\`,
+  // UNC, verbatim, …) is rooted.
+  let isRooted = rootEnd != s.startIndex
+    && !_isDriveRelativeAnchor(s[s.startIndex..<rootEnd])
+  var result = _SystemString()
+  result.append(contentsOf: s[s.startIndex..<relBegin])  // anchor + gap
+  if isVerbatim {
+    // Verbatim paths: `.` and `..` are regular component names.
+    result.append(contentsOf: s[relBegin..<s.endIndex])
+  } else {
+    _ = s._normalizeDots(
+      over: relBegin..<s.endIndex, isRooted: isRooted, into: &result)
+  }
+  return _StdlibFilePath(_storage: result)
+}
+
+@available(SwiftStdlib 9999, *)
+private func _normalizeDarwin(_ str: _SystemString) -> _StdlibFilePath {
+  // Coalesce separators across the whole string first, then canonicalize
+  // the anchor and parse the anchor / resource-fork suffix boundaries on
+  // those coalesced bytes the way XNU classifies them.
+  //
+  // This is deliberately *not* what XNU does byte-for-byte: the kernel
+  // does not coalesce separators before recognizing the
+  // .vol/.resolve/.nofollow anchors. Because we coalesce first, our
+  // canonicalization is XNU's modulo separator-coalescing: spellings
+  // that differ only in runs of separators store identically. e.g.
+  // /.resolve//1/foo and /.resolve/1/foo both coalesce and canonicalize
+  // to /.nofollow/foo.
+  var s = str
+  s._normalizeSeparators()
+  s._canonicalizeDarwinAnchor()
+
+  // Parse the anchor and resource-fork suffix on the
+  // coalesced+canonicalized string.
+  let (rootEnd, relBegin) = s._parseRoot()
+  let hasAnchor = rootEnd != s.startIndex
+  var suffixStart = s._resourceForkSuffixStart ?? s.endIndex
+  // If the suffix overlaps the anchor region, it's not a real suffix.
+  if suffixStart < relBegin {
+    suffixStart = s.endIndex
+  }
+
+  // TODO(post-PR): Single pass instead of both `s` and `result` copies.
+
+  // Reassemble: anchor + gap + dot-normalized relative + suffix,
+  // appending the relative portion into `result`
+  var result = _SystemString()
+  result.append(contentsOf: s[..<relBegin])
+
+  // If the anchor doesn't already end in `/` and there is no gap
+  // separator, we may need to insert one between anchor and relative.
+  // Insert speculatively; roll back if the relative dot-normalizes to
+  // empty.
+  let needsAnchorSep =
+    hasAnchor && rootEnd == relBegin
+    && s[s.index(before: rootEnd)] != ._slash
+  if needsAnchorSep {
+    result.append(._slash)
+  }
+
+  let didEmitRelative = s._normalizeDots(
+    over: relBegin..<suffixStart, isRooted: hasAnchor, into: &result)
+
+  if needsAnchorSep && !didEmitRelative {
+    _internalInvariant(result.last == ._slash)
+    result.removeLast()
+  }
+
+  // Strip a trailing separator on the relative portion when a suffix
+  // follows it.
+  let hasSuffix = suffixStart < s.endIndex
+  if hasSuffix && didEmitRelative
+     && _isSeparator(result[result.index(before: result.endIndex)]) {
+    _internalInvariant(_isSeparator(result.last!))
+    result.removeLast()
+  }
+
+  result.append(contentsOf: s[suffixStart..<s.endIndex])
+
+  return _StdlibFilePath(_storage: result)
+}
+
+// Check if a path is a verbatim-component Windows path
+@available(SwiftStdlib 9999, *)
+internal func _isVerbatimComponentPath(_ storage: _SystemString) -> Bool {
+  guard _isWindows else { return false }
+  guard let parsed = storage._parseWindowsRootInternal() else { return false }
+  return parsed.isVerbatimComponent
+}

--- a/Sources/System/_StdlibFilePath/FilePathAnchor.swift
+++ b/Sources/System/_StdlibFilePath/FilePathAnchor.swift
@@ -1,0 +1,192 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// The anchor of a file path identifies a reference point
+  /// and precedes any components.
+  @available(SwiftStdlib 9999, *)
+  public struct Anchor: Sendable {
+    internal var _path: _StdlibFilePath
+    internal var _end: _SystemString.Index
+
+    internal init(_path: _StdlibFilePath, _end: _SystemString.Index) {
+      self._path = _path
+      self._end = _end
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Anchor {
+  internal var _slice: _SystemString.SubSequence {
+    _internalInvariant(_end >= _path._storage.startIndex && _end <= _path._storage.endIndex)
+    return _path._storage[_path._storage.startIndex..<_end]
+  }
+
+  /// Whether this anchor is rooted.
+  @available(SwiftStdlib 9999, *)
+  public var isRooted: Bool {
+    guard _isWindows else { return true }
+
+    // On Windows, the only non-rooted anchor is drive-relative `C:`
+    // (relative to the CWD on that drive). Everything else (`\`,
+    // `C:\`, `\\server\share`, `\\?\...`) is rooted.
+    return !_isDriveRelativeAnchor(_slice)
+  }
+}
+
+#if os(Windows)
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Anchor {
+  /// The drive letter of this anchor, if any.
+  ///
+  /// Returns the single code unit preceding the colon for drive-style
+  /// anchors (`C:\`, `C:`, `\\?\C:\`, `\\.\C:\`), and `nil` for UNC
+  /// anchors, non-drive device anchors, and the current-drive root `\`.
+  ///
+  /// The value is presented as written, without case normalization.
+  /// If the drive letter is an unpaired surrogate, `U+FFFD` is returned.
+  @available(SwiftStdlib 9999, *)
+  public var driveLetter: Unicode.Scalar? {
+    _parseWindowsAnchor()?.drive?._driveLetterScalar
+  }
+
+  /// Whether this anchor uses the Windows verbatim-component form.
+  @available(SwiftStdlib 9999, *)
+  public var isVerbatimComponent: Bool {
+    guard let parsed = _parseWindowsAnchor() else { return false }
+    return parsed.isVerbatimComponent
+  }
+
+  private func _parseWindowsAnchor() -> _ParsedWindowsRoot? {
+    _path._storage._parseWindowsRootInternal()
+  }
+}
+#endif
+
+// MARK: - Anchor Hashable, Comparable, descriptions
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Anchor: Hashable {
+  @available(SwiftStdlib 9999, *)
+  public static func == (lhs: _StdlibFilePath.Anchor, rhs: _StdlibFilePath.Anchor) -> Bool {
+    lhs._slice.elementsEqual(rhs._slice)
+  }
+  @available(SwiftStdlib 9999, *)
+  public func hash(into hasher: inout Hasher) {
+    for c in _slice {
+      hasher.combine(c)
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Anchor: Comparable {
+  @available(SwiftStdlib 9999, *)
+  public static func < (lhs: _StdlibFilePath.Anchor, rhs: _StdlibFilePath.Anchor) -> Bool {
+    lhs._slice.lexicographicallyPrecedes(rhs._slice)
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Anchor: CustomStringConvertible, CustomDebugStringConvertible {
+  @available(SwiftStdlib 9999, *)
+  public var description: String {
+    unsafe _slice.withCodeUnits {
+      unsafe $0.withMemoryRebound(to: _StdlibFilePath._Encoding.CodeUnit.self) {
+        unsafe String(decoding: $0, as: _StdlibFilePath._Encoding.self)
+      }
+    }
+  }
+  @available(SwiftStdlib 9999, *)
+  public var debugDescription: String {
+    description.debugDescription
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Anchor: ExpressibleByStringLiteral {
+  /// Creates an anchor from a string literal.
+  ///
+  /// Precondition: the literal is non-empty, contains no `NUL`,
+  /// and forms a valid anchor.
+  @available(SwiftStdlib 9999, *)
+  public init(stringLiteral: String) {
+    guard let a = _StdlibFilePath.Anchor(stringLiteral) else {
+      fatalError(
+        "_StdlibFilePath.Anchor string literal must be non-empty,"
+        + " must not contain NUL, and must form a valid anchor")
+    }
+    self = a
+  }
+
+  /// Creates an anchor from a string.
+  ///
+  /// Returns `nil` if `string` is empty, contains `NUL`, or is
+  /// not a valid anchor.
+  @available(SwiftStdlib 9999, *)
+  public init?(_ string: String) {
+    guard let path = _StdlibFilePath(_nulValidating: string) else { return nil }
+    guard let anchor = path.anchor else { return nil }
+    guard path.components.isEmpty && !path.hasTrailingSeparator else {
+      return nil
+    }
+    // A named anchor form must carry its name. `_StdlibFilePath.init?` is total
+    // and coalesces the degenerate Windows roots (incomplete UNC (`\\`,
+    // `\\server`), empty device (`\\.`/`\\.\`), and empty verbatim
+    // (`\\?`/`\\?\`)) into a degraded anchor, but as a typed `Anchor`
+    // value they name a volume/device/share that isn't there, so the
+    // failable `Anchor` initializer rejects them. This strictness lives
+    // here, in anchor validation only; `_StdlibFilePath` decomposition of these
+    // inputs is unchanged.
+    if _isWindows && _isIncompleteWindowsNamedAnchor(anchor._slice) {
+      return nil
+    }
+    self = anchor
+  }
+}
+
+/// Returns `true` when `anchorBytes` is a Windows UNC/device/verbatim
+/// anchor form that is missing its name: incomplete UNC (`\\`, `\\server`),
+/// empty device (`\\.\`), or empty verbatim (`\\?\`).
+///
+/// This is the strictness predicate for `_StdlibFilePath.Anchor.init?`. The walk is
+/// local to anchor validation and shares nothing with the construction
+/// parser (`_parseWindowsRootInternal` and friends), which must keep
+/// coalescing these forms unchanged for `_StdlibFilePath`.
+///
+/// A named form requires its name: UNC needs a non-empty server AND a
+/// non-empty share; device (`\\.\`) needs a non-empty device name; verbatim
+/// (`\\?\`) needs a non-empty component after the prefix. Traditional roots
+/// (`\`, `C:`, `C:\`) carry no separate name and are never rejected here.
+@available(SwiftStdlib 9999, *)
+private func _isIncompleteWindowsNamedAnchor(
+  _ anchorBytes: Slice<_SystemString>
+) -> Bool {
+  // A named form begins with the two-backslash UNC/device/verbatim prefix.
+  // One leading `\` is the bare current-drive root, and `C:` / `C:\` carry a
+  // drive; none of those are a name-bearing form with the name missing.
+  var s = anchorBytes
+  guard s._eat(._backslash) != nil, s._eat(._backslash) != nil else {
+    return false
+  }
+  // Device (`\\.\<device>`) or verbatim (`\\?\<component>`). Separator
+  // coalescing always stores the prefix backslash (`\\.\` / `\\?\`), so
+  // whatever follows it is the name; an empty name means incomplete.
+  if s._eat(if: { $0 == ._dot || $0 == ._question }) != nil {
+    guard s._eat(._backslash) != nil else { return true }
+    return s.isEmpty
+  }
+  // UNC (`\\server\share`): require a non-empty server AND a non-empty share.
+  guard s._eatWhile({ $0 != ._backslash }) != nil else { return true }
+  guard s._eat(._backslash) != nil else { return true }
+  return s.isEmpty
+}

--- a/Sources/System/_StdlibFilePath/FilePathCodeUnits.swift
+++ b/Sources/System/_StdlibFilePath/FilePathCodeUnits.swift
@@ -1,0 +1,151 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+// MARK: - CodeUnit typealias
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// The type used to represent a "character" in the platform's
+  /// native path encoding.
+  #if os(Windows)
+  @available(SwiftStdlib 9999, *)
+  public typealias CodeUnit = UInt16
+  #else
+  @available(SwiftStdlib 9999, *)
+  public typealias CodeUnit = CChar
+  #endif
+
+  /// The Unicode encoding corresponding to `CodeUnit`.
+  #if os(Windows)
+  internal typealias _Encoding = UTF16
+  #else
+  internal typealias _Encoding = UTF8
+  #endif
+}
+
+// MARK: - withCodeUnits (C interop)
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Calls the given closure with a pointer to the path's null-terminated
+  /// contents and the number of code units preceding the null terminator.
+  /// The pointer is valid only for the duration of the closure, and the
+  /// count does not include the null terminator.
+  ///
+  /// On Windows the pointer is wide (`UnsafePointer<UInt16>`); see
+  /// also `String.withCString(encodedAs:_:)`.
+  @available(SwiftStdlib 9999, *)
+  public func withCodeUnits<Result, E: Error>(
+    _ body: (UnsafePointer<_StdlibFilePath.CodeUnit>, Int) throws(E) -> Result
+  ) throws(E) -> Result {
+    // Storage is already [_StdlibFilePath.CodeUnit] with a trailing null, so
+    // we can just hand out its base address and the length sans null.
+    let storage = _storage.nullTerminatedStorage
+    let count = storage.count - 1
+    return try unsafe storage.withUnsafeBufferPointer { buf throws(E) in
+      try unsafe body(buf.baseAddress!, count)
+    }
+  }
+}
+
+// MARK: - Code unit access (Span)
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// A span of the platform code units comprising this path, not
+  /// including the null terminator.
+  @available(SwiftStdlib 9999, *)
+  public var codeUnits: Span<_StdlibFilePath.CodeUnit> {
+    _storage._span
+  }
+
+  /// A span of the platform code units comprising this path, including
+  /// the trailing null terminator as its final element.
+  @available(SwiftStdlib 9999, *)
+  public var nullTerminatedCodeUnits: Span<_StdlibFilePath.CodeUnit> {
+    _storage._nullTerminatedSpan
+  }
+
+  /// Creates a file path from a span of platform code units.
+  ///
+  /// The span should not include a null terminator. Returns `nil`
+  /// if the span contains `NUL`, which is not a valid path byte
+  /// on any supported platform.
+  @available(SwiftStdlib 9999, *)
+  public init?(codeUnits: Span<CodeUnit>) {
+    var chars = [_StdlibFilePath.CodeUnit]()
+    chars.reserveCapacity(codeUnits.count + 1)
+    for i in codeUnits.indices {
+      let c = codeUnits[i]
+      guard c != ._null else { return nil }
+      chars.append(c)
+    }
+    chars.append(._null)
+    let str = _SystemString(nullTerminated: chars)
+    self.init(_normalizing: str)
+  }
+
+  // TODO: Add the init
+
+  // NOTE: The proposal specifies an OutputSpan-based initializer:
+  //
+  //   public init<E: Error>(
+  //     capacity: Int,
+  //     initializingCodeUnitsWith initializer:
+  //       (inout OutputSpan<_StdlibFilePath.CodeUnit>) throws(E) -> Void
+  //   ) throws(E)
+  //
+  // OutputSpan requires experimental features not available without
+  // compiler flags.  Stubbed until OutputSpan is generally available.
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Component {
+  /// A span of the platform code units comprising this component.
+  @available(SwiftStdlib 9999, *)
+  public var codeUnits: Span<_StdlibFilePath.CodeUnit> {
+    _path._storage._nullTerminatedSpan.extracting(_range)
+  }
+
+  /// Creates a file path component from a span of platform code units.
+  ///
+  /// Returns `nil` if the code units are empty, contain `NUL`, or are
+  /// otherwise invalid (e.g. contain more than one component).
+  @available(SwiftStdlib 9999, *)
+  public init?(codeUnits: Span<_StdlibFilePath.CodeUnit>) {
+    guard !codeUnits.isEmpty else { return nil }
+    guard let path = _StdlibFilePath(codeUnits: codeUnits) else { return nil }
+    self.init(_validating: path)
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Anchor {
+  /// A span of the platform code units comprising this anchor.
+  @available(SwiftStdlib 9999, *)
+  public var codeUnits: Span<_StdlibFilePath.CodeUnit> {
+    _path._storage._nullTerminatedSpan.extracting(
+      _path._storage.startIndex..<_end)
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.ComponentView {
+  /// A span of the platform code units comprising the relative
+  /// components portion of the path.
+  @available(SwiftStdlib 9999, *)
+  public var codeUnits: Span<_StdlibFilePath.CodeUnit> {
+    // The component view spans `[_relStart, _relEnd)`. By construction
+    // `_relEnd` excludes any structural suffix (trailing separator on the
+    // relative region, or a Darwin resource-fork suffix), so this range
+    // is exactly the components-region bytes.
+    _path._storage._nullTerminatedSpan.extracting(_relStart..<_relEnd)
+  }
+}

--- a/Sources/System/_StdlibFilePath/FilePathComponent.swift
+++ b/Sources/System/_StdlibFilePath/FilePathComponent.swift
@@ -1,0 +1,137 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Represents an individual component of a file path.
+  @available(SwiftStdlib 9999, *)
+  public struct Component: Sendable {
+    internal var _path: _StdlibFilePath
+    internal var _range: Range<_SystemString.Index>
+    internal var _verbatimContext: Bool
+
+    internal init(_path: _StdlibFilePath, _range: Range<_SystemString.Index>, _verbatimContext: Bool) {
+      self._path = _path
+      self._range = _range
+      self._verbatimContext = _verbatimContext
+    }
+
+    internal var _slice: _SystemString.SubSequence {
+      _internalInvariant(_range.lowerBound >= _path._storage.startIndex)
+      _internalInvariant(_range.upperBound <= _path._storage.endIndex)
+      return _path._storage[_range]
+    }
+
+    /// Whether a component is a regular file or directory name, or a special
+    /// directory `.` or `..`
+    @available(SwiftStdlib 9999, *)
+    public enum Kind: Sendable, Equatable {
+      case currentDirectory
+      case parentDirectory
+      case regular
+    }
+
+    /// The kind of this component.
+    @available(SwiftStdlib 9999, *)
+    public var kind: Kind {
+      if _verbatimContext { return .regular }
+      let s = _slice
+      if s.elementsEqual([._dot]) { return .currentDirectory }
+      if s.elementsEqual([._dot, ._dot]) { return .parentDirectory }
+      return .regular
+    }
+  }
+}
+
+// MARK: - Component Hashable, Comparable, descriptions
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Component: Hashable {
+  @available(SwiftStdlib 9999, *)
+  public static func == (lhs: _StdlibFilePath.Component, rhs: _StdlibFilePath.Component) -> Bool {
+    lhs._slice.elementsEqual(rhs._slice)
+  }
+  @available(SwiftStdlib 9999, *)
+  public func hash(into hasher: inout Hasher) {
+    for c in _slice {
+      hasher.combine(c)
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Component: Comparable {
+  @available(SwiftStdlib 9999, *)
+  public static func < (lhs: _StdlibFilePath.Component, rhs: _StdlibFilePath.Component) -> Bool {
+    lhs._slice.lexicographicallyPrecedes(rhs._slice)
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Component: CustomStringConvertible, CustomDebugStringConvertible {
+  @available(SwiftStdlib 9999, *)
+  public var description: String {
+    unsafe _slice.withCodeUnits {
+      unsafe $0.withMemoryRebound(to: _StdlibFilePath._Encoding.CodeUnit.self) {
+        unsafe String(decoding: $0, as: _StdlibFilePath._Encoding.self)
+      }
+    }
+  }
+  @available(SwiftStdlib 9999, *)
+  public var debugDescription: String {
+    description.debugDescription
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Component: ExpressibleByStringLiteral {
+  /// Creates a file path component from a string literal.
+  ///
+  /// Precondition: `stringLiteral` is non-empty and contains no `NUL`
+  /// or directory separator.
+  @available(SwiftStdlib 9999, *)
+  public init(stringLiteral: String) {
+    guard let c = _StdlibFilePath.Component(stringLiteral) else {
+      fatalError(
+        "_StdlibFilePath.Component string literal must be non-empty"
+        + " and must not contain NUL or a directory separator")
+    }
+    self = c
+  }
+
+  /// Creates a file path component from a string.
+  ///
+  /// Returns `nil` if `string` is empty or contains `NUL` or a
+  /// directory separator.
+  @available(SwiftStdlib 9999, *)
+  public init?(_ string: String) {
+    guard !string.isEmpty else { return nil }
+    guard let path = _StdlibFilePath(_nulValidating: string) else { return nil }
+    self.init(_validating: path)
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.Component {
+  /// Shared validation behind `init?(_:)` and `init?(codeUnits:)`.
+  ///
+  /// Succeeds only when `path` is exactly one component with no anchor and
+  /// no trailing separator, i.e. a bare component with no embedded *or*
+  /// trailing directory separator, matching the contract that a component
+  /// contains no separators. So `a/b` (interior) and `a/` (trailing) are
+  /// both rejected, as is any anchored input. NUL-rejection has already
+  /// happened in `_StdlibFilePath.init?`; callers funnel through one of those.
+  internal init?(_validating path: _StdlibFilePath) {
+    guard path.anchor == nil, !path.hasTrailingSeparator else { return nil }
+    let comps = path.components
+    guard comps.count == 1 else { return nil }
+    self = comps.first!
+  }
+}

--- a/Sources/System/_StdlibFilePath/FilePathComponentView.swift
+++ b/Sources/System/_StdlibFilePath/FilePathComponentView.swift
@@ -1,0 +1,312 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// A bidirectional, range-replaceable collection of the
+  /// components that make up a file path.
+  @available(SwiftStdlib 9999, *)
+  public struct ComponentView: Sendable {
+    internal var _path: _StdlibFilePath
+
+    // Start of this view's contribution in _path._storage. Set at
+    // creation (= source path's rootEnd at that moment), immutable
+    // through mutations. Used by the splice in `_StdlibFilePath.components`'s
+    // `set` to copy this view's bytes into a target. _relStart may move
+    // forward as absorption shifts the re-parsed anchor; _originalStart
+    // does not.
+    internal let _originalStart: _SystemString.Index
+
+    // Recomputed after each `replaceSubrange`. Used for iteration.
+    internal var _relStart: _SystemString.Index   // first byte of components
+    internal var _relEnd: _SystemString.Index     // start of suffix (or storage end)
+    internal var _suffixEnd: _SystemString.Index  // end of storage
+
+    internal init(_path: _StdlibFilePath) {
+      self._path = _path
+      let (rootEnd, relBegin) = _path._storage._parseRoot()
+      self._originalStart = rootEnd
+      self._relStart = relBegin
+      self._relEnd = _path._storage._componentViewRelEnd(relBegin: relBegin)
+      self._suffixEnd = _path._storage.endIndex
+
+      _internalInvariant(_originalStart <= _relStart)
+      _internalInvariant(_relStart <= _relEnd)
+      _internalInvariant(_relEnd <= _suffixEnd)
+      _internalInvariant(_suffixEnd == _path._storage.endIndex)
+    }
+  }
+}
+
+// MARK: - Index
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.ComponentView {
+  @available(SwiftStdlib 9999, *)
+  public struct Index: Sendable, Comparable, Hashable {
+    internal var _storage: _SystemString.Index
+
+    @available(SwiftStdlib 9999, *)
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      lhs._storage < rhs._storage
+    }
+
+    internal init(_storage: _SystemString.Index) {
+      self._storage = _storage
+    }
+  }
+}
+
+// MARK: - Internal helpers
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  /// The end of the iterable component region for `ComponentView`.
+  ///
+  /// Excludes structural suffixes that live in `[_relEnd, _suffixEnd)`:
+  /// a Darwin resource-fork suffix (the leading `/` of `/..namedfork/rsrc`)
+  /// or a trailing separator on the relative region. Returns `endIndex`
+  /// when there is no such suffix.
+  ///
+  /// The `relBegin` guard for the trailing separator is essential: for
+  /// paths like `/`, `\\server\share\`, `C:\`, the trailing byte of
+  /// storage IS a separator but it belongs to the anchor/gap, not the
+  /// relative region. For the resource-fork case, an overlap with the
+  /// anchor region (`/..namedfork/rsrc` → `rsrcStart < relBegin`) means
+  /// there are no relative components at all.
+  internal func _componentViewRelEnd(
+    relBegin: Index
+  ) -> Index {
+    if _isDarwin, let rsrcStart = _resourceForkSuffixStart {
+      return rsrcStart >= relBegin ? rsrcStart : relBegin
+    }
+    if !isEmpty {
+      let lastIdx = index(before: endIndex)
+      if _isSeparator(self[lastIdx]) && lastIdx >= relBegin {
+        return lastIdx
+      }
+    }
+    return endIndex
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.ComponentView {
+  // Re-derive _relStart/_relEnd/_suffixEnd from current _path._storage.
+  // _originalStart is intentionally NOT touched: it's set at view
+  // creation and stays put even when re-decomposition shifts the anchor.
+  internal mutating func _recomputeIndices() {
+    let (_, relBegin) = _path._storage._parseRoot()
+    _relStart = relBegin
+    _relEnd = _path._storage._componentViewRelEnd(relBegin: relBegin)
+    _suffixEnd = _path._storage.endIndex
+  }
+
+  internal func _componentEnd(at pos: _SystemString.Index) -> _SystemString.Index {
+    var i = pos
+    while i < _relEnd && !_isSeparator(_path._storage[i]) {
+      _path._storage.formIndex(after: &i)
+    }
+    return i
+  }
+
+  internal func _skipSeparators(from pos: _SystemString.Index) -> _SystemString.Index {
+    var i = pos
+    while i < _relEnd && _isSeparator(_path._storage[i]) {
+      _path._storage.formIndex(after: &i)
+    }
+    return i
+  }
+}
+
+// MARK: - BidirectionalCollection
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.ComponentView: BidirectionalCollection {
+  @available(SwiftStdlib 9999, *)
+  public typealias Element = _StdlibFilePath.Component
+
+  @available(SwiftStdlib 9999, *)
+  public var startIndex: Index {
+    // Skip gap separator(s) between anchor and first component
+    Index(_storage: _skipSeparators(from: _relStart))
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public var endIndex: Index {
+    // endIndex is the end of the iterable (component) region: the start
+    // of any structural suffix (a trailing separator on the relative
+    // region, or a Darwin resource-fork suffix), or end of storage if
+    // there is no such suffix.
+    Index(_storage: _relEnd)
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public var isEmpty: Bool {
+    startIndex == endIndex
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public func index(after i: Index) -> Index {
+    let compEnd = _componentEnd(at: i._storage)
+    let next = _skipSeparators(from: compEnd)
+    return Index(_storage: next)
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public func index(before i: Index) -> Index {
+    var idx = i._storage
+    // Back up past separator(s)
+    while idx > startIndex._storage
+          && _isSeparator(_path._storage[_path._storage.index(before: idx)]) {
+      _path._storage.formIndex(before: &idx)
+    }
+    // Back up past component bytes
+    while idx > startIndex._storage
+          && !_isSeparator(_path._storage[_path._storage.index(before: idx)]) {
+      _path._storage.formIndex(before: &idx)
+    }
+    return Index(_storage: idx)
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public subscript(position: Index) -> _StdlibFilePath.Component {
+    let end = _componentEnd(at: position._storage)
+    _internalInvariant(end > position._storage, "Component must be non-empty")
+    let isVerbatim = _isVerbatimComponentPath(_path._storage)
+    return _StdlibFilePath.Component(
+      _path: _path, _range: position._storage..<end,
+      _verbatimContext: isVerbatim)
+  }
+}
+
+// MARK: - RangeReplaceableCollection
+//
+// The anchor of the result follows from whatever the path string is
+// after mutation. RRC operations splice bytes within the relative
+// region; the resulting path is then re-decomposed fresh, so its anchor,
+// resource fork status, and trailing-separator status are whatever the
+// resulting bytes parse as.
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.ComponentView: RangeReplaceableCollection {
+  @available(SwiftStdlib 9999, *)
+  public init() {
+    self.init(_path: _StdlibFilePath())
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public mutating func replaceSubrange<C>(
+    _ subrange: Range<Index>, with newElements: C
+  ) where C: Collection, C.Element == _StdlibFilePath.Component {
+    let touchesEnd = subrange.upperBound == endIndex &&
+                     !(subrange.isEmpty && newElements.isEmpty)
+
+    // Compute byte range to splice. When the subrange touches endIndex,
+    // we extend to _suffixEnd (end of storage including any suffix
+    // bytes), NOT just to _relEnd. RRC operations that touch the end
+    // affect the entire suffix region: `removeLast` strips a trailing
+    // separator OR a resource fork; `append` replaces the suffix bytes
+    // with the new component.
+    let byteLower = subrange.lowerBound._storage
+    let byteUpper = touchesEnd ? _suffixEnd : subrange.upperBound._storage
+
+    if newElements.isEmpty {
+      // Indices point to component starts. The range [byteLower, byteUpper)
+      // covers the removed component(s) plus the joining separator that
+      // follows them. The exception is `touchesEnd`: there is no following
+      // component to join to, so we instead back `adjLower` over the
+      // PRECEDING separator to keep the result well-formed (no dangling
+      // sep after the last surviving component).
+      var adjLower = byteLower
+      if touchesEnd && adjLower > _relStart
+         && _isSeparator(_path._storage[_path._storage.index(before: adjLower)]) {
+        _path._storage.formIndex(before: &adjLower)
+      }
+      _path._storage.removeSubrange(adjLower..<byteUpper)
+    } else {
+      // Boundary separators
+      let needLeadingSep: Bool
+      if byteLower > _relStart {
+        needLeadingSep = !_isSeparator(
+          _path._storage[_path._storage.index(before: byteLower)])
+      } else if _path._storage.startIndex < _relStart {
+        // Inserting at the start of the relative region. Add a gap
+        // separator if the anchor (plus any existing gap sep up to
+        // _relStart) needs one before component bytes.
+        needLeadingSep = _anchorNeedsGapSeparator(_path._storage[..<_relStart])
+      } else {
+        needLeadingSep = false
+      }
+
+      if touchesEnd {
+        // The splice runs to end-of-storage. Truncate, then append:
+        // no intermediary, no inserts. There's no trailing sep in
+        // this case (touchesEnd implies the splice consumes everything
+        // up to and including any existing suffix bytes).
+        _path._storage.removeSubrange(byteLower..<byteUpper)
+        if needLeadingSep { _path._storage.append(_platformSeparator) }
+        for (i, comp) in newElements.enumerated() {
+          if i > 0 { _path._storage.append(_platformSeparator) }
+          _path._storage.append(contentsOf: comp._slice)
+        }
+      } else {
+        // Middle splice: there's a tail after byteUpper that has to
+        // stay put. We need a single replaceSubrange to keep the
+        // tail's index arithmetic straight, which means an intermediary.
+        let needTrailingSep =
+          byteUpper < _relEnd && !_isSeparator(_path._storage[byteUpper])
+
+        var bytes = _SystemString()
+        if needLeadingSep { bytes.append(_platformSeparator) }
+        for (i, comp) in newElements.enumerated() {
+          if i > 0 { bytes.append(_platformSeparator) }
+          bytes.append(contentsOf: comp._slice)
+        }
+        if needTrailingSep { bytes.append(_platformSeparator) }
+
+        _path._storage.replaceSubrange(byteLower..<byteUpper, with: bytes)
+      }
+    }
+
+    // Recompute the mutable trio. _originalStart does NOT move: it
+    // marks where this view's contribution starts in storage, regardless
+    // of how the post-mutation bytes re-decompose.
+    _recomputeIndices()
+  }
+}
+
+// MARK: - Hashable, Comparable
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.ComponentView: Hashable {
+  @available(SwiftStdlib 9999, *)
+  public static func == (lhs: _StdlibFilePath.ComponentView, rhs: _StdlibFilePath.ComponentView) -> Bool {
+    lhs.elementsEqual(rhs)
+  }
+  @available(SwiftStdlib 9999, *)
+  public func hash(into hasher: inout Hasher) {
+    for c in self {
+      hasher.combine(c)
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.ComponentView: Comparable {
+  @available(SwiftStdlib 9999, *)
+  public static func < (lhs: _StdlibFilePath.ComponentView, rhs: _StdlibFilePath.ComponentView) -> Bool {
+    for (l, r) in zip(lhs, rhs) {
+      if l < r { return true }
+      if r < l { return false }
+    }
+    return lhs.count < rhs.count
+  }
+}

--- a/Sources/System/_StdlibFilePath/FilePathDarwin.swift
+++ b/Sources/System/_StdlibFilePath/FilePathDarwin.swift
@@ -1,0 +1,177 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+// MARK: - Darwin anchor parsing
+
+// Darwin extends the basic Unix root `/` with:
+// - Resolve flags: /.nofollow/, /.resolve/N/
+// - Volume references: /.vol/FSID/FILEID
+
+@available(SwiftStdlib 9999, *)
+internal struct _ParsedDarwinAnchor {
+  var anchorEnd: _SystemString.Index
+  var relativeBegin: _SystemString.Index
+}
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  // Try to parse a Darwin-specific anchor.
+  // Returns nil if this is just a plain `/` root.
+  internal func _parseDarwinAnchor() -> _ParsedDarwinAnchor? {
+    _internalInvariant(_isDarwin)
+    guard !isEmpty, self.first == ._slash else { return nil }
+
+    let afterSlash = index(after: startIndex)
+    guard afterSlash < endIndex, self[afterSlash] == ._dot else { return nil }
+
+    // Anchor grammar: /(flag)?(vol)?, where flag is .nofollow/ or .resolve/N/,
+    // vol is .vol/FSID/FILEID(/)?, at least one of the two must be present.
+    let flag = _parseNofollow(from: afterSlash) ?? _parseResolve(from: afterSlash)
+    let volStart = flag?.relativeBegin ?? afterSlash
+    return _parseVol(from: volStart) ?? flag
+  }
+
+  // MARK: - /.nofollow/
+
+  private func _parseNofollow(from dotIdx: Index) -> _ParsedDarwinAnchor? {
+    var s = self[dotIdx...]
+    guard s._eatSequence(".nofollow/"._asciiBytes) != nil else { return nil }
+    return _ParsedDarwinAnchor(
+      anchorEnd: s.startIndex, relativeBegin: s.startIndex)
+  }
+
+  // MARK: - /.resolve/<value>/
+
+  private func _parseResolve(from dotIdx: Index) -> _ParsedDarwinAnchor? {
+    var s = self[dotIdx...]
+    guard s._eatSequence(".resolve/"._asciiBytes) != nil,
+          s._eatWhile({ $0 != ._slash }) != nil,
+          s._eat(._slash) != nil else { return nil }
+    return _ParsedDarwinAnchor(
+      anchorEnd: s.startIndex, relativeBegin: s.startIndex)
+  }
+
+  // MARK: - /.vol/FSID/FILEID
+
+  private func _parseVol(from dotIdx: Index) -> _ParsedDarwinAnchor? {
+    guard let body = _parseVolBody(from: dotIdx) else { return nil }
+    return _ParsedDarwinAnchor(
+      anchorEnd: body.fileidRange.upperBound,
+      relativeBegin: body.relativeBegin)
+  }
+
+  // Shared parser for the `.vol/FSID/FILEID[/]` body. Returns the
+  // FILEID range and the relative-portion start (past the trailing
+  // `/` if any).
+  private func _parseVolBody(
+    from dotIdx: Index
+  ) -> (fileidRange: Range<Index>, relativeBegin: Index)? {
+    var s = self[dotIdx...]
+    guard s._eatSequence(".vol/"._asciiBytes) != nil,
+          s._eatWhile({ $0 != ._slash }) != nil,
+          s._eat(._slash) != nil else { return nil }
+    let fileidStart = s.startIndex
+    guard s._eatWhile({ $0 != ._slash }) != nil else { return nil }
+    let fileidEnd = s.startIndex
+    let relBegin = s._eat(._slash) != nil ? s.startIndex : fileidEnd
+    return (fileidStart..<fileidEnd, relBegin)
+  }
+}
+
+// MARK: - Darwin anchor canonicalization
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  // /.resolve/1/        -> /.nofollow/
+  // /.vol/NNNN/2/       -> /.vol/NNNN/@/
+  // /.nofollow/.vol/NNNN/2/   -> /.nofollow/.vol/NNNN/@/
+  // /.resolve/1/.vol/NNNN/2/  -> /.nofollow/.vol/NNNN/@/
+  // /.resolve/3/.vol/NNNN/2/  -> /.resolve/3/.vol/NNNN/@/
+  //
+  // Both replacements are independent and may both fire on a single
+  // combined anchor, so we don't return between them.
+  internal mutating func _canonicalizeDarwinAnchor() {
+    guard _isDarwin else { return }
+
+    // /.resolve/1/ (12 bytes) -> /.nofollow/ (11 bytes). Storage shrinks
+    // by one byte; any trailing .vol portion shifts accordingly. Step 2
+    // below re-finds positions on the post-replacement storage, so the
+    // shift is not load-bearing for callers.
+    let resolveOne = "/.resolve/1/"
+    if self.starts(with: resolveOne._asciiBytes) {
+      let prefixEnd = self.index(startIndex, offsetBy: resolveOne.utf8.count)
+      self.replaceSubrange(
+        startIndex..<prefixEnd, with: "/.nofollow/"._asciiBytes)
+      _internalInvariant(self.starts(with: "/.nofollow/"._asciiBytes))
+    }
+
+    // .vol/FSID/FILEID -> .vol/FSID/@. The vol portion may be at the
+    // start of storage (bare) or right after a leading nofollow/resolve
+    // flag (combined anchor).
+    guard let volDot = _findAnchorVolDotPosition(),
+          let body = _parseVolBody(from: volDot)
+    else { return }
+    let fileidSlice = self[body.fileidRange]
+    if fileidSlice.count == 1
+       && fileidSlice.first == _StdlibFilePath.CodeUnit(_ascii: "2") {
+      self.replaceSubrange(body.fileidRange, with: CollectionOfOne(._at))
+    }
+  }
+
+  // Returns the index of the leading `.` of `.vol/...` within the
+  // anchor, if present. Three valid positions:
+  // - at startIndex+1, when storage starts with `/.vol/`
+  // - just past a leading `/.nofollow/`
+  // - just past a leading `/.resolve/<value>/`
+  // Returns nil if the anchor has no `.vol/...` portion.
+  private func _findAnchorVolDotPosition() -> Index? {
+    // Bare /.vol/: the `.` is at startIndex+1.
+    if self.starts(with: "/.vol/"._asciiBytes) {
+      return self.index(after: startIndex)
+    }
+    // /.nofollow/.vol/: the `.` of `.vol` is right after `/.nofollow/`.
+    var s = self[...]
+    if s._eatSequence("/.nofollow/"._asciiBytes) != nil,
+       self[s.startIndex...].starts(with: ".vol"._asciiBytes) {
+      return s.startIndex
+    }
+    // /.resolve/<value>/.vol/: variable-length value.
+    s = self[...]
+    if s._eatSequence("/.resolve/"._asciiBytes) != nil,
+       s._eatWhile({ $0 != ._slash }) != nil,
+       s._eat(._slash) != nil,
+       self[s.startIndex...].starts(with: ".vol"._asciiBytes) {
+      return s.startIndex
+    }
+    return nil
+  }
+}
+
+// MARK: - Resource fork detection
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  // The resource fork suffix is exactly "/..namedfork/rsrc" (17 bytes)
+  internal static var _resourceForkSuffix: String { "/..namedfork/rsrc" }
+
+  internal var _resourceForkSuffixStart: _SystemString.Index? {
+    guard _isDarwin else { return nil }
+    let suffix = Self._resourceForkSuffix
+    let suffixCount = suffix.utf8.count
+    guard self.count >= suffixCount else { return nil }
+    let suffixStart = self.index(endIndex, offsetBy: -suffixCount)
+    return self[suffixStart...].elementsEqual(suffix._asciiBytes)
+      ? suffixStart : nil
+  }
+
+  internal func _hasResourceForkSuffix() -> Bool {
+    _resourceForkSuffixStart != nil
+  }
+}

--- a/Sources/System/_StdlibFilePath/FilePathDecomposition.swift
+++ b/Sources/System/_StdlibFilePath/FilePathDecomposition.swift
@@ -1,0 +1,274 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+// MARK: - Anchor property
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// The anchor of this path, if any.
+  @available(SwiftStdlib 9999, *)
+  public var anchor: Anchor? {
+    get {
+      let (rootEnd, _) = _storage._parseRoot()
+      guard rootEnd != _storage.startIndex else { return nil }
+      _internalInvariant(rootEnd <= _storage.endIndex)
+      return Anchor(_path: self, _end: rootEnd)
+    }
+    set {
+      let (rootEnd, relBegin) = _storage._parseRoot()
+      _internalInvariant(relBegin >= rootEnd)
+      if let newAnchor = newValue {
+        // Replace old root region (including gap separator) with new
+        // anchor bytes. If the new anchor's shape needs a gap
+        // separator before existing relative content, insert one
+        // afterwards rather than copying the bytes through an
+        // intermediate Array.
+        let hasRelativeContent = relBegin < _storage.endIndex
+        let needsSep = hasRelativeContent
+          && _anchorNeedsGapSeparator(newAnchor._slice)
+        _storage.replaceSubrange(
+          _storage.startIndex..<relBegin, with: newAnchor._slice)
+        if needsSep {
+          let after = _storage.index(
+            _storage.startIndex, offsetBy: newAnchor._slice.count)
+          _storage.insert(_platformSeparator, at: after)
+        }
+      } else {
+        _storage.removeSubrange(_storage.startIndex..<relBegin)
+      }
+    }
+  }
+}
+
+// MARK: - Components property
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// View the relative path components that make up this path.
+  @available(SwiftStdlib 9999, *)
+  public var components: ComponentView {
+    get { ComponentView(_path: self) }
+    set {
+      let (selfRootEnd, _) = _storage._parseRoot()
+      let cvBytes = newValue._path._storage[
+        newValue._originalStart..<newValue._suffixEnd]
+
+      // Truncate to just the anchor, then append the gap separator
+      // (if needed) and the contribution. No inserts, no intermediary
+      // every byte in `cvBytes` is copied exactly once.
+      let needsSep = !cvBytes.isEmpty
+        && _anchorNeedsGapSeparator(_storage[..<selfRootEnd])
+        && !_isSeparator(cvBytes.first!)
+      _storage.removeSubrange(selfRootEnd..<_storage.endIndex)
+      if needsSep { _storage.append(_platformSeparator) }
+      _storage.append(contentsOf: cvBytes)
+    }
+  }
+}
+
+// MARK: - Absolute / relative
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Returns true if this path uniquely identifies the location of
+  /// a file without reference to an additional starting location.
+  @available(SwiftStdlib 9999, *)
+  public var isAbsolute: Bool {
+    guard let anchor = anchor else { return false }
+    if !_isWindows { return true }
+    // On Windows, only fully qualified paths are absolute. The relative
+    // anchors are `\` (1 byte) and `C:` (2 bytes); 3+ bytes is absolute.
+    return anchor._slice.count >= 3
+  }
+
+}
+
+// MARK: - Trailing separator
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Whether this path ends with a directory separator that is
+  /// not structurally required by the path's anchor.
+  @available(SwiftStdlib 9999, *)
+  public var hasTrailingSeparator: Bool {
+    get {
+      guard !isEmpty else { return false }
+      if _storage._hasResourceForkSuffix() { return false }
+      let (rootEnd, relBegin) = _storage._parseRoot()
+      _internalInvariant(relBegin >= rootEnd)
+      if relBegin < _storage.endIndex {
+        // Has relative content; trailing sep is the last byte
+        return _isSeparator(_storage[_storage.index(before: _storage.endIndex)])
+      } else if relBegin > rootEnd {
+        // No relative content, but a gap separator exists between
+        // the anchor and the end of the string (e.g. `\\server\share\`
+        // or `/.vol/1234/5678/`). That gap separator IS the trailing
+        // separator.
+        _internalInvariant(relBegin == _storage.endIndex)
+        _internalInvariant(_isSeparator(_storage[rootEnd]))
+        return true
+      }
+      // Anchor-only or empty root, no trailing separator
+      return false
+    }
+    set {
+      if newValue == hasTrailingSeparator { return }
+      if !newValue {
+        // Remove the trailing separator. The getter returned true, so the
+        // last byte is a separator; drop it unless it's the structural gap
+        // separator (when relBegin > rootEnd, e.g. `\\server\share\`),
+        // which belongs to the anchor.
+        let (_, relBegin) = _storage._parseRoot()
+        if _storage.index(before: _storage.endIndex) >= relBegin {
+          _storage.removeLast()
+        }
+        return
+      }
+      // Add a trailing separator.
+      if isEmpty { return }
+      if let rsrcStart = _storage._resourceForkSuffixStart {
+        _storage.removeSubrange(rsrcStart..<_storage.endIndex)
+      }
+      if !_isSeparator(_storage.last!) {
+        _storage.append(_platformSeparator)
+      }
+    }
+  }
+
+  /// Returns a copy with a trailing separator added.
+  @available(SwiftStdlib 9999, *)
+  public func withTrailingSeparator() -> _StdlibFilePath {
+    var copy = self
+    copy.hasTrailingSeparator = true
+    return copy
+  }
+
+  /// Returns a copy with the trailing separator removed.
+  @available(SwiftStdlib 9999, *)
+  public func withoutTrailingSeparator() -> _StdlibFilePath {
+    var copy = self
+    copy.hasTrailingSeparator = false
+    return copy
+  }
+}
+
+// MARK: - Resource fork (Darwin)
+//
+// Implemented only on Darwin builds; the getter returns `false` on other
+// platforms and the setter is a no-op (the helpers in FilePathDarwin.swift
+// guard on `_isDarwin`, which folds to `false` at compile time elsewhere).
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Whether this path ends with a resource fork reference.
+  @available(SwiftStdlib 9999, *)
+  public var isResourceFork: Bool {
+    get { _storage._hasResourceForkSuffix() }
+    set {
+      if newValue == isResourceFork { return }
+      if !newValue {
+        // Remove the resource fork suffix.
+        if let rsrcStart = _storage._resourceForkSuffixStart {
+          _storage.removeSubrange(rsrcStart..<_storage.endIndex)
+        }
+        return
+      }
+      // Add the resource fork suffix. The literal starts with `/`, so
+      // when storage already ends in a separator we drop the leading `/`
+      // to avoid storing two in a row.
+      if hasTrailingSeparator {
+        hasTrailingSeparator = false
+      }
+      let suffix = _SystemString._resourceForkSuffix._asciiBytes
+      if !_storage.isEmpty && _isSeparator(_storage.last!) {
+        _storage.append(contentsOf: suffix.dropFirst())
+      } else {
+        _storage.append(contentsOf: suffix)
+      }
+    }
+  }
+
+  /// Returns a copy with resource fork suffix appended.
+  @available(SwiftStdlib 9999, *)
+  public func withResourceFork() -> _StdlibFilePath {
+    var copy = self
+    copy.isResourceFork = true
+    return copy
+  }
+
+  /// Returns a copy with resource fork suffix removed.
+  @available(SwiftStdlib 9999, *)
+  public func withoutResourceFork() -> _StdlibFilePath {
+    var copy = self
+    copy.isResourceFork = false
+    return copy
+  }
+}
+
+// MARK: - Reconstruction initializers
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Creates a file path from a decomposed form.
+  @available(SwiftStdlib 9999, *)
+  public init(
+    anchor: Anchor?,
+    _ components: some Sequence<Component>,
+    hasTrailingSeparator: Bool = false
+  ) {
+    var str = _SystemString()
+
+    if let anchor = anchor {
+      str.append(contentsOf: anchor._slice)
+    }
+    // Whether a separator is needed between the anchor and the first
+    // component, when one or more components follow.
+    let anchorNeedsSep = anchor.map {
+      _anchorNeedsGapSeparator($0._slice)
+    } ?? false
+
+    var hasComponents = false
+    for comp in components {
+      // First component: separator iff the anchor's shape needs one.
+      // Subsequent components: always a separator.
+      if hasComponents || anchorNeedsSep {
+        str.append(_platformSeparator)
+      }
+      str.append(contentsOf: comp._slice)
+      hasComponents = true
+    }
+
+    if hasTrailingSeparator {
+      if hasComponents {
+        str.append(_platformSeparator)
+      } else if let anchor = anchor, let last = anchor._slice.last,
+                !_isSeparator(last) {
+        // Trailing sep on an anchor-only path (e.g., `\\server\share\`):
+        // add a separator only if the anchor doesn't already end with one.
+        str.append(_platformSeparator)
+      }
+    }
+
+    self.init(_normalizing: str)
+  }
+
+  /// Creates a file path from a decomposed form with a resource fork suffix.
+  @available(SwiftStdlib 9999, *)
+  public init(
+    anchor: Anchor?,
+    _ components: some Sequence<Component>,
+    resourceFork: Bool
+  ) {
+    self.init(anchor: anchor, components, hasTrailingSeparator: false)
+    if resourceFork {
+      self.isResourceFork = true
+    }
+  }
+}

--- a/Sources/System/_StdlibFilePath/FilePathInternals.swift
+++ b/Sources/System/_StdlibFilePath/FilePathInternals.swift
@@ -1,0 +1,85 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+// MARK: - Internal invariants
+
+#if FILEPATH_PACKAGE
+@inline(__always)
+internal func _internalInvariant(
+  _ condition: @autoclosure () -> Bool,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #file,
+  line: UInt = #line
+) {
+  assert(condition(), message(), file: file, line: line)
+}
+#endif
+
+// MARK: - Slice helpers
+
+extension Slice where Element: Equatable {
+  internal mutating func _eat(if p: (Element) -> Bool) -> Element? {
+    guard let s = self.first, p(s) else { return nil }
+    self = self.dropFirst()
+    return s
+  }
+  internal mutating func _eat(_ e: Element) -> Element? {
+    _eat(if: { $0 == e })
+  }
+
+  internal mutating func _eat(count c: Int) -> Slice {
+    defer { self = self.dropFirst(c) }
+    return self.prefix(c)
+  }
+
+  internal mutating func _eatSequence<C: Collection>(
+    _ es: C
+  ) -> Slice? where C.Element == Element {
+    guard self.starts(with: es) else { return nil }
+    return _eat(count: es.count)
+  }
+
+  internal mutating func _eatUntil(_ idx: Index) -> Slice {
+    precondition(idx >= startIndex && idx <= endIndex)
+    defer { self = self[idx...] }
+    return self[..<idx]
+  }
+
+  internal mutating func _eatWhile(
+    _ p: (Element) -> Bool
+  ) -> Slice? {
+    let idx = firstIndex(where: { !p($0) }) ?? endIndex
+    guard idx != startIndex else { return nil }
+    return _eatUntil(idx)
+  }
+}
+
+extension MutableCollection where Element: Equatable {
+  mutating func _replaceAll(_ e: Element, with new: Element) {
+    for idx in self.indices {
+      if self[idx] == e { self[idx] = new }
+    }
+  }
+}
+
+// MARK: - ASCII byte conversion
+
+@available(SwiftStdlib 9999, *)
+extension String {
+  /// A view over the string's bytes as `_StdlibFilePath.CodeUnit`s, lazily mapped.
+  ///
+  /// Intended for ASCII string literals used as match/replace tokens: no
+  /// allocation, materialized only when iterated. Non-ASCII scalars trap.
+  internal var _asciiBytes: LazyMapCollection<
+    String.UnicodeScalarView, _StdlibFilePath.CodeUnit
+  > {
+    self.unicodeScalars.lazy.map { _StdlibFilePath.CodeUnit(_ascii: $0) }
+  }
+}

--- a/Sources/System/_StdlibFilePath/FilePathParsing.swift
+++ b/Sources/System/_StdlibFilePath/FilePathParsing.swift
@@ -1,0 +1,279 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+// MARK: - Platform predicates
+//
+// Compile-time platform selection. This reference implementation builds for a
+// single platform at a time, so these fold to constants.
+//
+// Path syntax falls into three families: Windows (backslash, drive letters,
+// UNC, \\?\ verbatim), Apple (slash, plus the /.vol/, /.nofollow/ and
+// /.resolve/ anchors), and plain POSIX. The last arm is a fallback rather
+// than an enumeration: a newly supported platform is almost certainly plain
+// POSIX, and should build without editing this chain.
+//
+// Cygwin is the one platform the fallback would get wrong. POSIX
+// (IEEE Std 1003.1 §4.13) lets a pathname beginning with exactly two slashes
+// be "interpreted in an implementation-defined manner", and Cygwin uses that
+// for UNC: //machine/share. Coalescing below is unconditional, so it would
+// silently rewrite that to /machine/share, a wrong path rather than a build
+// failure.
+#if os(Windows)
+internal var _isWindows: Bool { true }
+internal var _isDarwin:  Bool { false }
+internal var _isLinux:   Bool { false }
+#elseif os(anyAppleOS) || canImport(Darwin)
+internal var _isWindows: Bool { false }
+internal var _isDarwin:  Bool { true }
+internal var _isLinux:   Bool { false }
+#elseif os(Cygwin)
+#error("_StdlibFilePath: Cygwin's //machine/share UNC syntax is not modelled")
+#else
+// Generic POSIX. `_isLinux` keeps its name for continuity with
+// `_normalizeLinux`.
+internal var _isWindows: Bool { false }
+internal var _isDarwin:  Bool { false }
+internal var _isLinux:   Bool { true }
+#endif
+
+// The separator we use for slash-based platforms
+@available(SwiftStdlib 9999, *)
+private var _genericSeparator: _StdlibFilePath.CodeUnit { ._slash }
+
+@available(SwiftStdlib 9999, *)
+internal var _platformSeparator: _StdlibFilePath.CodeUnit {
+  _isWindows ? ._backslash : _genericSeparator
+}
+
+@available(SwiftStdlib 9999, *)
+internal func _isSeparator(_ c: _StdlibFilePath.CodeUnit) -> Bool {
+  c == _platformSeparator
+}
+
+// MARK: - Anchor shape classification
+
+/// Returns `true` if the given anchor bytes are the Windows
+/// drive-relative form `<letter>:` (e.g. `C:`).
+///
+/// **Precondition: caller is on Windows.** Drive-relative is a
+/// Windows-specific concept; this function asserts `_isWindows` and
+/// must not be called from cross-platform code without a `_isWindows`
+/// gate. (See `_anchorNeedsGapSeparator` for the canonical example.)
+///
+/// The `:` IS the boundary in this anchor: `C:foo` is valid
+/// (drive-relative with one component); `C:\foo` is a different
+/// anchor (drive-absolute). Drive-relative is the *only* 2-byte
+/// anchor on Windows: UNC (`\\server\share`) and verbatim variants
+/// are all longer; other anchor shapes that happen to end in `:`
+/// UNC with a colon-ending share name (`\\server\C:`), or volfs-style
+/// (FILEIDs on hypothetical cross-platform code) are NOT 2 bytes
+/// and don't match.
+@available(SwiftStdlib 9999, *)
+internal func _isDriveRelativeAnchor(
+  _ anchorBytes: some BidirectionalCollection<_StdlibFilePath.CodeUnit>
+) -> Bool {
+  _internalInvariant(_isWindows, "drive-relative anchor is Windows-specific")
+  return anchorBytes.count == 2 && anchorBytes.last == ._colon
+}
+
+/// Returns `true` if a separator must be inserted between the given
+/// anchor bytes and the first component byte that follows them.
+///
+/// No separator is needed when:
+/// - the anchor's last byte is already a separator (most cases:
+///   `/`, `C:\`, `\\?\C:\`, `\\server\share\`, `/.nofollow/`, etc.), or
+/// - the anchor is the Windows drive-relative form `<letter>:`, where
+///   the `:` itself IS the boundary (`C:foo` is valid; `C:\foo` is a
+///   different anchor: drive-absolute).
+///
+/// A separator IS needed for the other shapes whose last byte is a
+/// name byte: `\\server\share`, `\\?\UNC\server\share`, `\\?\name`,
+/// `/.vol/FSID/FILEID`, including degenerate cases where one of
+/// those name bytes happens to be `:` (e.g. UNC share `\\server\C:`
+/// or volfs FILEID ending in `:`). Those are NOT 2 bytes, so they
+/// don't match the drive-relative shape.
+@available(SwiftStdlib 9999, *)
+internal func _anchorNeedsGapSeparator(
+  _ anchorBytes: some BidirectionalCollection<_StdlibFilePath.CodeUnit>
+) -> Bool {
+  guard let last = anchorBytes.last else { return false }
+  if _isSeparator(last) { return false }
+  if _isWindows && _isDriveRelativeAnchor(anchorBytes) { return false }
+  return true
+}
+
+// MARK: - Root parsing
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  internal func _parseRoot() -> (
+    rootEnd: Index, relativeBegin: Index
+  ) {
+    let result: (rootEnd: Index, relativeBegin: Index)
+
+    if isEmpty {
+      result = (startIndex, startIndex)
+    } else if _isWindows {
+      result = _parseWindowsRoot()
+    } else if !_isSeparator(self.first!) {
+      result = (startIndex, startIndex)
+    } else if _isDarwin, let darwinAnchor = _parseDarwinAnchor() {
+      result = (darwinAnchor.anchorEnd, darwinAnchor.relativeBegin)
+    } else {
+      let next = self.index(after: startIndex)
+      result = (next, next)
+    }
+
+    _internalInvariant(result.rootEnd >= startIndex && result.rootEnd <= endIndex)
+    _internalInvariant(result.relativeBegin >= result.rootEnd)
+    _internalInvariant(result.relativeBegin <= endIndex)
+    // Gap between rootEnd and relativeBegin is at most one separator
+    _internalInvariant(distance(from: result.rootEnd, to: result.relativeBegin) <= 1)
+    return result
+  }
+}
+
+// MARK: - Separator normalization
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  // Coalesce repeated separators in place. On Windows, also convert `/`
+  // to `\` (verbatim-aware) and prenormalize roots before coalescing.
+  // Trailing separators are preserved.
+  //
+  // Off Windows the coalescing is unconditional, including a leading `//`,
+  // which POSIX §4.13 permits treating as distinct. No platform selected by
+  // the fallback arm above does, and the one that does (Cygwin) is rejected
+  // there. Pinned by `.unix("//", normalized: "/")` in FilePathParsingTest.
+  internal mutating func _normalizeSeparators() {
+    guard !isEmpty else { return }
+    var (writeIdx, readIdx) = (startIndex, startIndex)
+
+    if _isWindows {
+      // Detect exact \\?\ prefix on raw input before any conversion.
+      // Only exact backslashes trigger verbatim mode. Inside a verbatim
+      // anchor `/` is a legal component byte and we leave it alone; the
+      // anchor region itself is already all-backslash by definition.
+      if _findVerbatimAnchorEnd() == startIndex {
+        self._replaceAll(_genericSeparator, with: _platformSeparator)
+        // //?/ normalizes to \\?\ after conversion, but it's
+        // device-namespace, not verbatim. Demote ? → . sigil.
+        if _startsWithVerbatimPrefix() != nil {
+          self[index(startIndex, offsetBy: 2)] = ._dot
+        }
+      }
+      readIdx = _prenormalizeWindowsRoots()
+      writeIdx = readIdx
+
+      while readIdx < endIndex && _isSeparator(self[readIdx]) {
+        self.formIndex(after: &readIdx)
+      }
+    }
+
+    while readIdx < endIndex {
+      _internalInvariant(writeIdx <= readIdx)
+
+      let wasSeparator = _isSeparator(self[readIdx])
+      self.swapAt(writeIdx, readIdx)
+      self.formIndex(after: &writeIdx)
+      self.formIndex(after: &readIdx)
+
+      while wasSeparator, readIdx < endIndex, _isSeparator(self[readIdx]) {
+        self.formIndex(after: &readIdx)
+      }
+    }
+    _internalInvariant(readIdx == endIndex)
+    self.removeLast(self.distance(from: writeIdx, to: readIdx))
+  }
+}
+
+// MARK: - Dot normalization (new rules for SE-0529)
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  // Append the dot-normalized form of `self[range]` to `result`. Rules:
+  // - `.` is dropped unless it is the leading component of an unrooted path
+  // - Trailing `.` becomes a trailing separator (foo/. -> foo/)
+  // - `..` is always preserved
+  //
+  // `range` is the relative portion to normalize. Anchor and gap bytes
+  // if any, must already be in `result`. Verbatim Windows paths (where
+  // `.` and `..` are regular component names) skip this entirely; the
+  // caller copies bytes verbatim instead.
+  //
+  // `isRooted` controls leading-dot behavior: a leading `.` is dropped
+  // when the path is rooted, kept when not.
+  //
+  // Returns `true` iff at least one component byte was appended. Callers
+  // use this to roll back a speculatively-inserted anchor/relative
+  // separator when the relative portion dot-normalizes to empty.
+  internal func _normalizeDots(
+    over range: Range<Index>,
+    isRooted: Bool,
+    into result: inout _SystemString
+  ) -> Bool {
+    // Precondition: the caller has already placed any anchor + gap bytes
+    // into `result`, so the range covers the relative portion only, never
+    // starts on a separator. (For Windows UNC, this is the difference
+    // between `rootEnd` and `relativeBegin`.)
+    _internalInvariant(
+      range.lowerBound >= startIndex && range.upperBound <= endIndex)
+    _internalInvariant(
+      range.isEmpty || !_isSeparator(self[range.lowerBound]),
+      "_normalizeDots range must start past any gap separator")
+
+    var readIdx = range.lowerBound
+    let end = range.upperBound
+    var componentIndex = 0
+    var emittedAny = false
+    var lastDroppedADot = false
+    var sourceHadTrailingSep = false
+
+    while readIdx < end {
+      // Skip a separator. If it is the last byte of the range, remember
+      // that the source had a trailing separator.
+      if _isSeparator(self[readIdx]) {
+        let next = index(after: readIdx)
+        if next >= end {
+          sourceHadTrailingSep = true
+        }
+        readIdx = next
+        continue
+      }
+      // Read one component span.
+      let compStart = readIdx
+      while readIdx < end && !_isSeparator(self[readIdx]) {
+        readIdx = index(after: readIdx)
+      }
+      let compEnd = readIdx
+      let compLen = distance(from: compStart, to: compEnd)
+      let isDot = compLen == 1 && self[compStart] == ._dot
+
+      // Drop a `.` unless it is the leading component of an unrooted path.
+      let drop = isDot && !(componentIndex == 0 && !isRooted)
+      if drop {
+        lastDroppedADot = true
+      } else {
+        if emittedAny {
+          result.append(_platformSeparator)
+        }
+        result.append(contentsOf: self[compStart..<compEnd])
+        emittedAny = true
+        lastDroppedADot = false
+      }
+      componentIndex += 1
+    }
+
+    if (sourceHadTrailingSep || lastDroppedADot) && emittedAny {
+      result.append(_platformSeparator)
+    }
+    return emittedAny
+  }
+}

--- a/Sources/System/_StdlibFilePath/FilePathResolve.swift
+++ b/Sources/System/_StdlibFilePath/FilePathResolve.swift
@@ -1,0 +1,311 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+#if FILEPATH_PACKAGE
+#if os(Windows)
+import WinSDK
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#elseif canImport(Android)
+import Android
+#else
+#error("Unsupported Platform")
+#endif
+#else
+// Stdlib build: SwiftShims supplies `_swift_stdlib_FilePath_resolve` (the
+// platform-specific resolve syscall, in stubs/FilePathStubs.cpp),
+// `_swift_stdlib_free`, and `__swift_size_t`.
+import SwiftShims
+#endif
+
+// MARK: - Internal error type
+//
+// Carries a platform error code (`errno` on POSIX, `GetLastError()` on
+// Windows) so callers can introspect via `as? _FilePathResolveError` while
+// `resolve()`'s public surface stays untyped (`throws`).
+
+@available(SwiftStdlib 9999, *)
+internal struct _FilePathResolveError: Error {
+  internal var code: CInt
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  /// Resolve this path against the filesystem, producing an absolute
+  /// path with all symbolic links and `.`/`..` components resolved.
+  ///
+  /// All intermediate components must exist. Throws if the path
+  /// cannot be resolved.
+  ///
+  /// This operation is synchronous and may block.
+  @available(*, noasync)
+  @available(SwiftStdlib 9999, *)
+  public func resolve() throws -> _StdlibFilePath {
+#if FILEPATH_PACKAGE
+#if os(Windows)
+    return try _resolveWindows()
+#elseif canImport(Darwin)
+    return try _resolveDarwin()
+#elseif os(WASI)
+    return try _resolveWASI()
+#else
+    return try _resolveLinux()
+#endif
+#else
+    // Stdlib port: dispatch to the runtime stub, which is the only place in
+    // the stdlib build that imports platform headers. See
+    // `swift/stdlib/public/SwiftShims/swift/shims/_StdlibFilePath.h` and
+    // `swift/stdlib/public/stubs/FilePathStubs.cpp`.
+    return try _resolveViaStdlibStub()
+#endif
+  }
+}
+
+#if !FILEPATH_PACKAGE
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  fileprivate func _resolveViaStdlibStub() throws -> _StdlibFilePath {
+    var outBuf: UnsafeMutablePointer<_StdlibFilePath.CodeUnit>? = nil
+    var outCount: __swift_size_t = 0
+    let err: CInt = unsafe self.withCodeUnits { ptr, count in
+      unsafe _swift_stdlib_FilePath_resolve(
+        ptr, __swift_size_t(count), &outBuf, &outCount)
+    }
+    guard err == 0, let resultBuf = unsafe outBuf else {
+      throw _FilePathResolveError(code: err)
+    }
+    defer { unsafe _swift_stdlib_free(resultBuf) }
+    return unsafe _StdlibFilePath(
+      _normalizingRawCodeUnits: UnsafeRawPointer(resultBuf),
+      count: Int(outCount))
+  }
+}
+
+#endif // !FILEPATH_PACKAGE
+
+// Build a _StdlibFilePath from `count` platform code units starting at `ptr`.
+// The bytes must already be a valid path (no embedded NUL); the result
+// is fed through `_normalizing`, which canonicalizes whatever
+// per-platform anchor / suffix the bytes happen to express. One
+// allocation (the `_SystemString` storage) plus one bulk copy: the
+// backing `Array` is sized exactly and filled in place rather than via
+// per-element `append`.
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  fileprivate init(
+    _normalizingRawCodeUnits ptr: UnsafeRawPointer,
+    count: Int
+  ) {
+    _internalInvariant(count >= 0)
+    let chars = unsafe Array<_StdlibFilePath.CodeUnit>(
+      unsafeUninitializedCapacity: count + 1
+    ) { buf, initializedCount in
+      if count > 0 {
+        let byteCount = count * MemoryLayout<_StdlibFilePath.CodeUnit>.stride
+        unsafe UnsafeMutableRawPointer(buf.baseAddress!)
+          .copyMemory(from: ptr, byteCount: byteCount)
+      }
+      unsafe buf[count] = ._null
+      initializedCount = count + 1
+    }
+    self.init(_normalizing: _SystemString(nullTerminated: chars))
+  }
+}
+
+#if FILEPATH_PACKAGE
+
+// MARK: - Per-platform implementation
+
+#if os(Windows)
+
+// MARK: Windows
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  fileprivate func _resolveWindows() throws -> _StdlibFilePath {
+    let shareMode: DWORD =
+      DWORD(FILE_SHARE_READ) | DWORD(FILE_SHARE_WRITE) | DWORD(FILE_SHARE_DELETE)
+
+    let handle: HANDLE = self._storage.withNullTerminatedCodeUnits { p in
+      unsafe CreateFileW(
+        p.baseAddress,
+        0,
+        shareMode,
+        nil,
+        DWORD(OPEN_EXISTING),
+        DWORD(FILE_FLAG_BACKUP_SEMANTICS),
+        nil)
+    }
+    if handle == INVALID_HANDLE_VALUE {
+      throw _FilePathResolveError(code: CInt(GetLastError()))
+    }
+    defer { unsafe _ = CloseHandle(handle) }
+
+    let flags: DWORD = DWORD(FILE_NAME_NORMALIZED) | DWORD(VOLUME_NAME_DOS)
+    var capacity: Int = 1024
+    while true {
+      var buf = [WCHAR](repeating: 0, count: capacity)
+      let needed: DWORD = unsafe buf.withUnsafeMutableBufferPointer { ptr in
+        unsafe GetFinalPathNameByHandleW(
+          handle, ptr.baseAddress, DWORD(ptr.count), flags)
+      }
+      if needed == 0 {
+        throw _FilePathResolveError(code: CInt(GetLastError()))
+      }
+      // On success `needed` is the length WITHOUT the NUL (so it fits with
+      // room to spare). On buffer-too-small it's the required size INCLUDING
+      // the NUL, so grow and retry.
+      if Int(needed) < capacity {
+        return unsafe buf.withUnsafeBufferPointer { ptr in
+          unsafe _StdlibFilePath(
+            _normalizingRawCodeUnits: UnsafeRawPointer(ptr.baseAddress!),
+            count: Int(needed))
+        }
+      }
+      capacity = Int(needed) + 1
+    }
+  }
+}
+
+#elseif canImport(Darwin)
+
+// MARK: Darwin
+//
+// realpath(3) returns the un-firmlinked underlay (e.g.
+// `/System/Volumes/Data/Users/foo`) for paths whose components live on the
+// data volume but are exposed via firmlinks (the typical case for `/Users`
+// on macOS Big Sur+). The kernel's *default* behavior for
+// `ATTR_CMN_FULLPATH` returns the firmlinked path instead, pinned for
+// this build by `ResolveTests.firmlinkedHomeRealPath`. So we use
+// `getattrlistat` directly with `ATTR_CMN_FULLPATH` and avoid `realpath`
+// entirely.
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  fileprivate func _resolveDarwin() throws -> _StdlibFilePath {
+    // Two attempts: 8 KiB suits any normal path, 32 KiB covers
+    // long-path-enabled processes. Past that, the path is genuinely
+    // too long.
+    for size in [8192, 32768] {
+      if let resolved = try _resolveDarwinAttempt(bufferSize: size) {
+        return resolved
+      }
+    }
+    throw _FilePathResolveError(code: ENAMETOOLONG)
+  }
+
+  // Returns nil ONLY when the buffer was too small and the caller should
+  // retry with a larger one (ERANGE / ENAMETOOLONG). Other errors throw.
+  private func _resolveDarwinAttempt(
+    bufferSize: Int
+  ) throws -> _StdlibFilePath? {
+    var attrs = attrlist()
+    attrs.bitmapcount = UInt16(ATTR_BIT_MAP_COUNT)
+    attrs.commonattr = attrgroup_t(ATTR_CMN_FULLPATH)
+
+    let options: CUnsignedLong =
+      CUnsignedLong(FSOPT_ATTR_CMN_EXTENDED) |
+      CUnsignedLong(FSOPT_RETURN_REALDEV)
+
+    let bufRaw = UnsafeMutableRawPointer.allocate(
+      byteCount: bufferSize,
+      alignment: MemoryLayout<UInt32>.alignment)
+    defer { unsafe bufRaw.deallocate() }
+
+    let rc: CInt = unsafe self._storage.withNullTerminatedCodeUnits { pathBuf in
+      unsafe withUnsafeMutablePointer(to: &attrs) { attrsPtr in
+        unsafe getattrlistat(
+          AT_FDCWD,
+          pathBuf.baseAddress,
+          attrsPtr,
+          bufRaw,
+          bufferSize,
+          options)
+      }
+    }
+    if rc != 0 {
+      let err = errno
+      if err == ERANGE || err == ENAMETOOLONG {
+        return nil
+      }
+      throw _FilePathResolveError(code: err)
+    }
+
+    // Buffer layout when ATTR_CMN_FULLPATH is the only attribute requested:
+    //   buf[0..4]   u_int32_t total bytes used (we ignore this header)
+    //   buf[4..12]  attrreference_t for the FULLPATH attribute
+    //                 .attr_dataoffset  offset relative to the start of
+    //                                   the attrreference_t struct itself
+    //                 .attr_length      bytes (includes trailing NUL)
+    //   buf[4 + .attr_dataoffset ..]    the resolved C-string path
+    let attrrefOffset = MemoryLayout<UInt32>.size
+    let attrref: attrreference_t = unsafe bufRaw
+      .advanced(by: attrrefOffset)
+      .load(as: attrreference_t.self)
+    let stringStart = unsafe bufRaw
+      .advanced(by: attrrefOffset + Int(attrref.attr_dataoffset))
+    let storedLength = Int(attrref.attr_length)
+
+    // ATTR_CMN_FULLPATH is documented as a null-terminated string and
+    // attr_length includes the NUL. Both are kernel guarantees; assert them
+    // rather than handling a "no trailing NUL" branch that can't fire.
+    _internalInvariant(storedLength > 0)
+    _internalInvariant(
+      unsafe stringStart.load(
+        fromByteOffset: storedLength - 1, as: UInt8.self) == 0,
+      "ATTR_CMN_FULLPATH must be null-terminated")
+
+    return unsafe _StdlibFilePath(
+      _normalizingRawCodeUnits: stringStart, count: storedLength - 1)
+  }
+}
+
+#elseif os(WASI)
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  fileprivate func _resolveWASI() throws -> _StdlibFilePath {
+    throw _FilePathResolveError(code: ENOTSUP)
+  }
+}
+
+#else
+
+// MARK: Linux (and other POSIX)
+//
+// Linux has neither firmlinks nor Darwin-style anchor prefixes, so the
+// portable POSIX call is correct.
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath {
+  fileprivate func _resolveLinux() throws -> _StdlibFilePath {
+    let resolved = self._storage.withNullTerminatedCodeUnits { p in
+      unsafe realpath(p.baseAddress, nil)
+    }
+    guard let resolved = resolved else {
+      throw _FilePathResolveError(code: errno)
+    }
+    defer { unsafe free(resolved) }
+
+    let length = unsafe strlen(resolved)
+    return unsafe _StdlibFilePath(_normalizingRawCodeUnits: resolved, count: length)
+  }
+}
+
+#endif
+
+#endif // FILEPATH_PACKAGE

--- a/Sources/System/_StdlibFilePath/FilePathStringBridging.swift
+++ b/Sources/System/_StdlibFilePath/FilePathStringBridging.swift
@@ -1,0 +1,135 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+// MARK: - _StdlibFilePath String bridging
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath: Hashable {
+  @available(SwiftStdlib 9999, *)
+  public static func == (lhs: _StdlibFilePath, rhs: _StdlibFilePath) -> Bool {
+    lhs._storage == rhs._storage
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_storage)
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath: Comparable {
+  @available(SwiftStdlib 9999, *)
+  public static func < (lhs: _StdlibFilePath, rhs: _StdlibFilePath) -> Bool {
+    lhs._storage.lexicographicallyPrecedes(rhs._storage)
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath: CustomStringConvertible, CustomDebugStringConvertible {
+  /// A textual representation of the file path.
+  @available(SwiftStdlib 9999, *)
+  public var description: String {
+    unsafe _storage.withCodeUnits { codeUnits in
+      unsafe codeUnits.withMemoryRebound(to: _StdlibFilePath._Encoding.CodeUnit.self) {
+        unsafe String(decoding: $0, as: _StdlibFilePath._Encoding.self)
+      }
+    }
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public var debugDescription: String {
+    description.debugDescription
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath: ExpressibleByStringLiteral {
+  /// Creates a file path from a string literal.
+  ///
+  /// Traps if the literal contains `NUL` or is otherwise ill-formed.
+  @available(SwiftStdlib 9999, *)
+  public init(stringLiteral: String) {
+    guard let path = _StdlibFilePath(_nulValidating: stringLiteral) else {
+      fatalError(
+        "_StdlibFilePath string literal must not contain NUL")
+    }
+    self = path
+  }
+
+#if !FILEPATH_SYSTEM_STRING_COMPAT
+  /// Creates a file path from a string.
+  ///
+  /// Returns `nil` if `string` contains `NUL`, which is not a valid
+  /// path byte on any supported platform.
+  @available(SwiftStdlib 9999, *)
+  public init?(_ string: String) {
+    self.init(_nulValidating: string)
+  }
+#endif
+
+  /// NUL-validating construction from a `String`, shared by the failable
+  /// initializer and the `ExpressibleByStringLiteral` conformance. Always
+  /// present: when a consumer defines `FILEPATH_SYSTEM_STRING_COMPAT` and
+  /// replaces the public failable `init?(_:)` with a non-failable `init(_:)`,
+  /// the internal callers below still have a validating entry point.
+  @available(SwiftStdlib 9999, *)
+  internal init?(_nulValidating string: String) {
+    guard !string.utf8.contains(0) else { return nil }
+    self.init(_normalizing: _SystemString(string))
+  }
+}
+
+// MARK: - String decoding/validating
+
+extension String {
+  @available(SwiftStdlib 9999, *)
+  public init(decoding path: _StdlibFilePath) {
+    self = path.description
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public init?(validating path: _StdlibFilePath) {
+    guard let str = String(validating: path._storage) else { return nil }
+    self = str
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public init(decoding anchor: _StdlibFilePath.Anchor) {
+    self = anchor.description
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public init?(validating anchor: _StdlibFilePath.Anchor) {
+    // Mirror the _StdlibFilePath overload: decode, re-encode, and compare (via
+    // String(validating: _SystemString)), so ill-formed content yields nil
+    // instead of a lossy U+FFFD decode.
+    guard let str = String(validating: _SystemString(anchor._slice)) else {
+      return nil
+    }
+    self = str
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public init(decoding component: _StdlibFilePath.Component) {
+    self = component.description
+  }
+
+  @available(SwiftStdlib 9999, *)
+  public init?(validating component: _StdlibFilePath.Component) {
+    // Mirror the _StdlibFilePath overload: decode, re-encode, and compare (via
+    // String(validating: _SystemString)), so ill-formed content yields nil
+    // instead of a lossy U+FFFD decode.
+    guard let str = String(validating: _SystemString(component._slice)) else {
+      return nil
+    }
+    self = str
+  }
+}
+

--- a/Sources/System/_StdlibFilePath/FilePathSystemString.swift
+++ b/Sources/System/_StdlibFilePath/FilePathSystemString.swift
@@ -1,0 +1,240 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+// MARK: - _StdlibFilePath.CodeUnit helpers
+//
+// `_StdlibFilePath.CodeUnit` is the storage element type used throughout this
+// implementation: `CChar` on Unix, `UInt16` on Windows. The underscored
+// extension members below are _StdlibFilePath-internal helpers; they extend
+// the underlying `CChar` / `UInt16` type with names a reader can
+// recognise as path-byte constants.
+
+@available(SwiftStdlib 9999, *)
+extension _StdlibFilePath.CodeUnit {
+  internal static var _null: Self { 0 }
+  internal static var _slash: Self { Self(_ascii: "/") }
+  internal static var _backslash: Self { Self(_ascii: #"\"#) }
+  internal static var _dot: Self { Self(_ascii: ".") }
+  internal static var _colon: Self { Self(_ascii: ":") }
+  internal static var _question: Self { Self(_ascii: "?") }
+  internal static var _at: Self { Self(_ascii: "@") }
+
+  internal init(_ascii s: Unicode.Scalar) {
+    self = numericCast(UInt8(ascii: s))
+  }
+
+  /// Interpret this code unit as a drive-letter scalar, presented as
+  /// written (no case normalization). On Windows, code units are
+  /// UTF-16 and an unpaired surrogate yields `U+FFFD`.
+  internal var _driveLetterScalar: Unicode.Scalar {
+    #if os(Windows)
+    return Unicode.Scalar(self) ?? "\u{FFFD}"
+    #else
+    return Unicode.Scalar(UInt8(bitPattern: self))
+    #endif
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+internal struct _SystemString: Sendable {
+  internal typealias _Storage = [_StdlibFilePath.CodeUnit]
+  internal var nullTerminatedStorage: _Storage
+}
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  internal init() {
+    self.nullTerminatedStorage = [._null]
+    _invariantCheck()
+  }
+
+  internal var length: Int {
+    let len = nullTerminatedStorage.count - 1
+    _internalInvariant(len == self.count)
+    return len
+  }
+
+  internal init(nullTerminated storage: _Storage) {
+    self.nullTerminatedStorage = storage
+    _invariantCheck()
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  fileprivate func _invariantsSatisfied() -> Bool {
+    guard !nullTerminatedStorage.isEmpty else { return false }
+    guard nullTerminatedStorage.last! == ._null else { return false }
+    guard nullTerminatedStorage.firstIndex(of: ._null) == nullTerminatedStorage.count - 1 else {
+      return false
+    }
+    return true
+  }
+
+  fileprivate func _invariantCheck() {
+    #if DEBUG
+    precondition(_invariantsSatisfied())
+    #endif
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString: RandomAccessCollection, MutableCollection {
+  internal typealias Element = _StdlibFilePath.CodeUnit
+  internal typealias Index = _Storage.Index
+  internal typealias Indices = Range<Index>
+
+  internal var startIndex: Index {
+    nullTerminatedStorage.startIndex
+  }
+
+  internal var endIndex: Index {
+    nullTerminatedStorage.index(before: nullTerminatedStorage.endIndex)
+  }
+
+  internal subscript(position: Index) -> _StdlibFilePath.CodeUnit {
+    _read {
+      precondition(position >= startIndex && position <= endIndex)
+      yield nullTerminatedStorage[position]
+    }
+    set(newValue) {
+      precondition(position >= startIndex && position <= endIndex)
+      nullTerminatedStorage[position] = newValue
+      _invariantCheck()
+    }
+  }
+}
+@available(SwiftStdlib 9999, *)
+extension _SystemString: RangeReplaceableCollection {
+  internal mutating func replaceSubrange<C: Collection>(
+    _ subrange: Range<Index>, with newElements: C
+  ) where C.Element == _StdlibFilePath.CodeUnit {
+    defer { _invariantCheck() }
+    nullTerminatedStorage.replaceSubrange(subrange, with: newElements)
+  }
+
+  internal mutating func reserveCapacity(_ n: Int) {
+    defer { _invariantCheck() }
+    nullTerminatedStorage.reserveCapacity(1 + n)
+  }
+
+  internal func withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<_StdlibFilePath.CodeUnit>) throws -> R
+  ) rethrows -> R? {
+    try unsafe nullTerminatedStorage.withContiguousStorageIfAvailable {
+      try unsafe body(.init(start: $0.baseAddress, count: $0.count-1))
+    }
+  }
+
+  internal mutating func withContiguousMutableStorageIfAvailable<R>(
+    _ body: (inout UnsafeMutableBufferPointer<_StdlibFilePath.CodeUnit>) throws -> R
+  ) rethrows -> R? {
+    defer { _invariantCheck() }
+    return try unsafe nullTerminatedStorage.withContiguousMutableStorageIfAvailable {
+      var buffer = unsafe UnsafeMutableBufferPointer<_StdlibFilePath.CodeUnit>(
+        start: $0.baseAddress, count: $0.count-1
+      )
+      return try unsafe body(&buffer)
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString: Hashable {}
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  // _Storage backing; includes the trailing null byte.
+  internal func withNullTerminatedCodeUnits<T>(
+    _ f: (UnsafeBufferPointer<_StdlibFilePath.CodeUnit>) throws -> T
+  ) rethrows -> T {
+    try unsafe nullTerminatedStorage.withUnsafeBufferPointer(f)
+  }
+
+  // Code units excluding the null terminator.
+  internal func withCodeUnits<T>(
+    _ f: (UnsafeBufferPointer<_StdlibFilePath.CodeUnit>) throws -> T
+  ) rethrows -> T {
+    try unsafe withNullTerminatedCodeUnits {
+      unsafe _internalInvariant($0.last == ._null)
+      return try unsafe f(.init(start: $0.baseAddress, count: $0.count &- 1))
+    }
+  }
+}
+
+// MARK: - Span access
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  // The backing array INCLUDING the trailing null terminator. Per-subtype
+  // spans extract their slice range from this base.
+  internal var _nullTerminatedSpan: Span<_StdlibFilePath.CodeUnit> {
+    nullTerminatedStorage.span
+  }
+
+  // The backing array EXCLUDING the trailing null terminator.
+  internal var _span: Span<_StdlibFilePath.CodeUnit> {
+    nullTerminatedStorage.span.extracting(0..<length)
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension Slice<_SystemString> {
+  internal func withCodeUnits<T>(
+    _ f: (UnsafeBufferPointer<_StdlibFilePath.CodeUnit>) throws -> T
+  ) rethrows -> T {
+    try unsafe base.nullTerminatedStorage.withUnsafeBufferPointer { fullBuf in
+      let count = self.count
+      _internalInvariant(startIndex >= 0 && startIndex + count <= fullBuf.count)
+      let p = unsafe fullBuf.baseAddress.map { unsafe $0.advanced(by: startIndex) }
+      return try unsafe f(UnsafeBufferPointer(start: p, count: count))
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension String {
+  internal init?(validating str: _SystemString) {
+    let decoded = str.string
+    guard _SystemString(decoded) == str else { return nil }
+    self = decoded
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString: ExpressibleByStringLiteral {
+  internal init(stringLiteral: String) {
+    self.init(stringLiteral)
+  }
+
+  internal init(_ string: String) {
+    #if os(Windows)
+    var chars = string.utf16.map { _StdlibFilePath.CodeUnit($0) }
+    #else
+    var chars = string.utf8.map { _StdlibFilePath.CodeUnit(bitPattern: $0) }
+    #endif
+    chars.append(._null)
+    self.init(nullTerminated: chars)
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString: CustomStringConvertible, CustomDebugStringConvertible {
+  internal var string: String {
+    unsafe self.withCodeUnits { codeUnits in
+      unsafe codeUnits.withMemoryRebound(to: _StdlibFilePath._Encoding.CodeUnit.self) {
+        unsafe String(decoding: $0, as: _StdlibFilePath._Encoding.self)
+      }
+    }
+  }
+
+  internal var description: String { string }
+  internal var debugDescription: String { description.debugDescription }
+}

--- a/Sources/System/_StdlibFilePath/FilePathWindows.swift
+++ b/Sources/System/_StdlibFilePath/FilePathWindows.swift
@@ -1,0 +1,391 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+// MARK: - Parsed Windows root
+
+@available(SwiftStdlib 9999, *)
+internal struct _ParsedWindowsRoot {
+  var rootEnd: _SystemString.Index
+  var relativeBegin: _SystemString.Index
+  var drive: _StdlibFilePath.CodeUnit?
+  var deviceSigil: _StdlibFilePath.CodeUnit?
+}
+
+@available(SwiftStdlib 9999, *)
+extension _ParsedWindowsRoot {
+  static func traditional(
+    drive: _StdlibFilePath.CodeUnit?,
+    endingAt idx: _SystemString.Index
+  ) -> _ParsedWindowsRoot {
+    _ParsedWindowsRoot(
+      rootEnd: idx,
+      relativeBegin: idx,
+      drive: drive,
+      deviceSigil: nil)
+  }
+
+  static func unc(
+    deviceSigil: _StdlibFilePath.CodeUnit?,
+    endingAt end: _SystemString.Index,
+    relativeBegin relBegin: _SystemString.Index
+  ) -> _ParsedWindowsRoot {
+    _ParsedWindowsRoot(
+      rootEnd: end,
+      relativeBegin: relBegin,
+      drive: nil,
+      deviceSigil: deviceSigil)
+  }
+
+  static func device(
+    deviceSigil: _StdlibFilePath.CodeUnit,
+    drive: _StdlibFilePath.CodeUnit?,
+    endingAt end: _SystemString.Index,
+    relativeBegin relBegin: _SystemString.Index
+  ) -> _ParsedWindowsRoot {
+    _ParsedWindowsRoot(
+      rootEnd: end,
+      relativeBegin: relBegin,
+      drive: drive,
+      deviceSigil: deviceSigil)
+  }
+
+  var isVerbatimComponent: Bool {
+    deviceSigil == ._question
+  }
+}
+
+// MARK: - Lexer
+
+@available(SwiftStdlib 9999, *)
+struct _Lexer {
+  var slice: Slice<_SystemString>
+
+  init(_ str: _SystemString) {
+    self.slice = str[...]
+  }
+
+  var backslash: _StdlibFilePath.CodeUnit { ._backslash }
+
+  mutating func eatBackslash() -> Bool {
+    slice._eat(._backslash) != nil
+  }
+
+  // A drive letter is any single non-separator code unit immediately
+  // followed by a colon. This matches Windows' own
+  // RtlDetermineDosPathNameType_U, which keys on the second character
+  // being a colon and does not validate the first: `1:`, `::`, etc. are
+  // all drives. (A colon is itself a non-separator, so `::foo` parses as
+  // drive `:`, the documented basis for the `=::` environment variable
+  // Windows creates.)
+  //
+  // The non-separator requirement is what keeps leading-separator paths
+  // out: `\:x` (and `/:x`, which `_normalizeSeparators` has already
+  // rewritten to `\:x` by this point) are classified as rooted/UNC, not
+  // drives. Because `/`→`\` conversion has already run, `isSeparator`
+  // (which tests `\` only) is exactly the right predicate here.
+  mutating func eatDrive() -> _StdlibFilePath.CodeUnit? {
+    let copy = slice
+    if let d = slice._eat(if: { !_isSeparator($0) }),
+       slice._eat(._colon) != nil {
+      return d
+    }
+    slice = copy
+    return nil
+  }
+
+  mutating func eatSigil() -> _StdlibFilePath.CodeUnit? {
+    let copy = slice
+    guard let sigil = slice._eat(._question) ?? slice._eat(._dot) else {
+      return nil
+    }
+    guard isEmpty || slice.first == backslash else {
+      slice = copy
+      return nil
+    }
+    return sigil
+  }
+
+  mutating func eatUNC() -> Bool {
+    slice._eatSequence("UNC"._asciiBytes) != nil
+  }
+
+  mutating func eatComponent() -> Range<_SystemString.Index> {
+    let backslash = self.backslash
+    let component = slice._eatWhile({ $0 != backslash })
+      ?? slice[slice.startIndex ..< slice.startIndex]
+    return component.indices
+  }
+
+  var isEmpty: Bool {
+    return slice.isEmpty
+  }
+
+  var current: _SystemString.Index { slice.startIndex }
+
+  mutating func clear() {
+    self = _Lexer(_SystemString())
+  }
+
+  mutating func reset(to str: _SystemString, at idx: _SystemString.Index) {
+    self.slice = str[idx...]
+  }
+}
+
+// MARK: - Verbatim prefix detection (pre-normalization)
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  // Check if this string starts with the exact verbatim prefix \\?\
+  // (four backslashes, no forward slashes). Returns the index past
+  // the prefix, or nil.
+  internal func _startsWithVerbatimPrefix() -> Index? {
+    var s = self[...]
+    guard s._eatSequence(#"\\?\"#._asciiBytes) != nil else { return nil }
+    return s.startIndex
+  }
+
+  // For a verbatim path (exact \\?\ prefix), find where the anchor
+  // ends. Only backslash is a separator in verbatim context.
+  // Returns the index where component content begins.
+  internal func _findVerbatimAnchorEnd() -> Index {
+    guard let afterPrefix = _startsWithVerbatimPrefix() else {
+      return startIndex
+    }
+
+    func skipToSep(from start: Index) -> Index {
+      var i = start
+      while i < endIndex && !_isSeparator(self[i]) {
+        formIndex(after: &i)
+      }
+      return i
+    }
+
+    func skipPastSep(from idx: Index) -> Index {
+      idx < endIndex && _isSeparator(self[idx]) ? index(after: idx) : idx
+    }
+
+    // \\?\UNC\server\share[\]
+    var s = self[afterPrefix...]
+    if s._eatSequence("UNC"._asciiBytes) != nil,
+       s._eat(._backslash) != nil {
+      let serverEnd = skipToSep(from: s.startIndex)
+      let shareStart = skipPastSep(from: serverEnd)
+      let shareEnd = skipToSep(from: shareStart)
+      return skipPastSep(from: shareEnd)
+    }
+
+    // \\?\<drive>:[\]. A drive letter is any single non-separator code
+    // unit before the colon (matching eatDrive). In verbatim paths
+    // separators are not normalized and `/` is a legal component byte,
+    // so `!isSeparator` accepts it: `\\?\/:` parses with drive `/`,
+    // taking the bytes as written.
+    s = self[afterPrefix...]
+    if s._eat(if: { !_isSeparator($0) }) != nil,
+       s._eat(._colon) != nil {
+      return skipPastSep(from: s.startIndex)
+    }
+
+    // \\?\device[\]
+    let deviceEnd = skipToSep(from: afterPrefix)
+    return skipPastSep(from: deviceEnd)
+  }
+}
+
+// MARK: - Windows root parsing
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  internal func _parseWindowsRootInternal() -> _ParsedWindowsRoot? {
+    _internalInvariant(_isWindows)
+
+    var lexer = _Lexer(self)
+
+    func parseUNC(
+      deviceSigil: _StdlibFilePath.CodeUnit?
+    ) -> _ParsedWindowsRoot {
+      _ = lexer.eatComponent()
+      guard lexer.eatBackslash() else {
+        let end = lexer.current
+        return .unc(
+          deviceSigil: deviceSigil,
+          endingAt: end,
+          relativeBegin: end)
+      }
+      _ = lexer.eatComponent()
+      let rootEnd = lexer.current
+      _ = lexer.eatBackslash()
+      return .unc(
+        deviceSigil: deviceSigil,
+        endingAt: rootEnd, relativeBegin: lexer.current)
+    }
+
+    // `C:` or `C:\`
+    if let d = lexer.eatDrive() {
+      _ = lexer.eatBackslash()
+      return .traditional(
+        drive: d,
+        endingAt: lexer.current)
+    }
+
+    guard lexer.eatBackslash() else { return nil }
+    guard lexer.eatBackslash() else {
+      return .traditional(
+        drive: nil,
+        endingAt: lexer.current)
+    }
+
+    guard let sigil = lexer.eatSigil() else {
+      return parseUNC(deviceSigil: nil)
+    }
+
+    guard lexer.eatBackslash() else {
+      return .device(
+        deviceSigil: sigil,
+        drive: nil,
+        endingAt: lexer.current,
+        relativeBegin: lexer.current)
+    }
+
+    // UNC sub-form only applies to verbatim paths (\\?\UNC\...).
+    // For device-namespace (\\.\), UNC is just a device name.
+    if sigil == ._question, lexer.eatUNC() {
+      guard lexer.eatBackslash() else {
+        let end = lexer.current
+        return .device(
+          deviceSigil: sigil,
+          drive: nil,
+          endingAt: end,
+          relativeBegin: end)
+      }
+      return parseUNC(deviceSigil: sigil)
+    }
+
+    // Check for device drive: \\.\C:\ or \\?\C:\
+    let deviceRange = lexer.eatComponent()
+    let rootEnd = lexer.current
+
+    // A drive letter is any single non-separator code unit before the
+    // colon (matching `eatDrive`). In verbatim paths `/` is a non-separator
+    // and legal, so `\\?\/:` parses with drive `/`.
+    let drive = _driveLetter(of: self[deviceRange])
+    if drive != nil, lexer.eatBackslash() {
+      // \\?\C:\  or \\.\C:\
+      let newEnd = lexer.current
+      return .device(
+        deviceSigil: sigil,
+        drive: drive,
+        endingAt: newEnd,
+        relativeBegin: newEnd)
+    }
+
+    _ = lexer.eatBackslash()
+
+    return .device(
+      deviceSigil: sigil,
+      drive: drive,
+      endingAt: rootEnd, relativeBegin: lexer.current)
+  }
+
+  internal func _parseWindowsRoot() -> (
+    rootEnd: _SystemString.Index,
+    relativeBegin: _SystemString.Index
+  ) {
+    guard let parsed = _parseWindowsRootInternal() else {
+      return (startIndex, startIndex)
+    }
+    return (parsed.rootEnd, parsed.relativeBegin)
+  }
+}
+
+// Returns the drive letter if `slice` is exactly the 2-byte drive form
+// `<non-separator><colon>`, else nil. Intended for testing already-
+// extracted device slices; for parsing-from-stream, see `_Lexer.eatDrive`.
+@available(SwiftStdlib 9999, *)
+private func _driveLetter(
+  of slice: Slice<_SystemString>
+) -> _StdlibFilePath.CodeUnit? {
+  var s = slice
+  guard let first = s._eat(if: { !_isSeparator($0) }),
+        s._eat(._colon) != nil,
+        s.isEmpty
+  else { return nil }
+  return first
+}
+
+// MARK: - Windows root prenormalization
+
+@available(SwiftStdlib 9999, *)
+extension _SystemString {
+  internal mutating func _prenormalizeWindowsRoots() -> Index {
+    _internalInvariant(_isWindows)
+
+    var lexer = _Lexer(self)
+
+    guard lexer.eatBackslash(), lexer.eatBackslash() else {
+      return lexer.current
+    }
+
+    // Three or more leading backslashes: NOT a UNC/device path.
+    // Return after the first backslash; coalescing handles the rest.
+    if !lexer.isEmpty && lexer.slice.first == ._backslash {
+      return self.index(after: self.startIndex)
+    }
+
+    func expectBackslash() {
+      if lexer.eatBackslash() { return }
+      let idx = lexer.current
+      lexer.clear()
+      self.insert(._backslash, at: idx)
+      lexer.reset(to: self, at: idx)
+      let p = lexer.eatBackslash()
+      _internalInvariant(p)
+    }
+    func expectComponent() {
+      _ = lexer.eatComponent()
+      expectBackslash()
+    }
+
+    if let sigil = lexer.eatSigil() {
+      expectBackslash()
+      // UNC sub-form only for verbatim (\\?\UNC\...), not device (\\.\UNC\...)
+      if sigil == ._question, lexer.eatUNC() {
+        expectBackslash()
+        expectComponent()          // server: its separator is structural
+        // Share: consume a trailing separator only if one is actually
+        // present, never synthesize one. The share can be the final
+        // element of a verbatim-UNC root with no trailing separator
+        // (\\?\UNC\s\h); forcing a backslash here would store a phantom
+        // trailing separator and make it compare equal to \\?\UNC\s\h\.
+        // Mirrors parseUNC's `_ = lexer.eatBackslash()` and the
+        // `!lexer.isEmpty`-guarded device path.
+        _ = lexer.eatComponent()
+        _ = lexer.eatBackslash()
+        return lexer.current
+      }
+      // Check for drive letter device: \\.\C:\ or \\?\C:\. A drive
+      // letter is any single non-separator code unit before the colon.
+      let deviceRange = lexer.eatComponent()
+      if _driveLetter(of: self[deviceRange]) != nil {
+        // Eat the trailing backslash if present (both branches return
+        // `lexer.current`).
+        _ = lexer.eatBackslash()
+        return lexer.current
+      }
+      // Only expect trailing backslash if there's more content
+      if !deviceRange.isEmpty && !lexer.isEmpty {
+        expectBackslash()
+      }
+      return lexer.current
+    }
+
+    expectComponent()
+    return lexer.current
+  }
+}

--- a/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePath.swift
+++ b/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePath.swift
@@ -15,16 +15,16 @@
 /// defines how the content is interpreted; for example, by its choice of string
 /// encoding.
 ///
-/// On construction, `FilePath` will normalize separators by removing
+/// On construction, `_SwiftSystemFilePath` will normalize separators by removing
 /// redundant intermediary separators and stripping any trailing separators.
-/// On Windows, `FilePath` will also normalize forward slashes `/` into
+/// On Windows, `_SwiftSystemFilePath` will also normalize forward slashes `/` into
 /// backslashes `\`, as preferred by the platform.
 ///
 /// The code below creates a file path from a string literal,
 /// and then uses it to open and append to a log file:
 ///
 ///     let message: String = "This is a log message."
-///     let path: FilePath = "/tmp/log"
+///     let path: _SwiftSystemFilePath = "/tmp/log"
 ///     let fd = try FileDescriptor.open(path, .writeOnly, options: .append)
 ///     try fd.closeAfter { try fd.writeAll(message.utf8) }
 ///
@@ -38,7 +38,7 @@
 /// are file-system–specific and have additional considerations
 /// like case insensitivity, Unicode normalization, and symbolic links.
 @available(System 0.0.1, *)
-public struct FilePath: Sendable {
+public struct _SwiftSystemFilePath: Sendable {
   // TODO(docs): Section on all the new syntactic operations, lexical normalization, decomposition,
   // components, etc.
   internal var _storage: SystemString
@@ -60,16 +60,16 @@ public struct FilePath: Sendable {
 }
 
 @available(System 0.0.1, *)
-extension FilePath {
+extension _SwiftSystemFilePath {
   /// The length of the file path, excluding the null terminator.
   public var length: Int { _storage.length }
 }
 
 @available(System 0.0.1, *)
-extension FilePath: Hashable {}
+extension _SwiftSystemFilePath: Hashable {}
 
 @available(System 0.0.1, *)
-extension FilePath: Codable {
+extension _SwiftSystemFilePath: Codable {
   // Encoder is synthesized; it probably should have been explicit and used
   // a single-value container, but making that change now is somewhat risky.
 
@@ -83,7 +83,7 @@ extension FilePath: Codable {
         forKey: ._storage,
         in: container,
         debugDescription:
-          "Encoding does not satisfy the invariants of FilePath"
+          "Encoding does not satisfy the invariants of _SwiftSystemFilePath"
       )
     }
   }

--- a/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathComponentView.swift
+++ b/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathComponentView.swift
@@ -10,7 +10,7 @@
 // MARK: - API
 
 @available(System 0.0.2, *)
-extension FilePath {
+extension _SwiftSystemFilePath {
   /// A bidirectional, range replaceable collection of the non-root components
   /// that make up a file path.
   ///
@@ -21,7 +21,7 @@ extension FilePath {
   ///
   /// Example:
   ///
-  ///     var path: FilePath = "/./home/./username/scripts/./tree"
+  ///     var path: _SwiftSystemFilePath = "/./home/./username/scripts/./tree"
   ///     let scriptIdx = path.components.lastIndex(of: "scripts")!
   ///     path.components.insert("bin", at: scriptIdx)
   ///     // path is "/./home/./username/bin/scripts/./tree"
@@ -30,10 +30,10 @@ extension FilePath {
   ///     // path is "/home/username/bin/scripts/tree"
   @available(System 0.0.2, *)
   public struct ComponentView: Sendable {
-    internal var _path: FilePath
+    internal var _path: _SwiftSystemFilePath
     internal var _start: SystemString.Index
 
-    internal init(_ path: FilePath) {
+    internal init(_ path: _SwiftSystemFilePath) {
       self._path = path
       self._start = path._relativeStart
       _invariantCheck()
@@ -52,7 +52,7 @@ extension FilePath {
       // not needlessly sliding values around or triggering a COW
       let rootStr = self.root?._systemString ?? SystemString()
       var comp = ComponentView(self)
-      self = FilePath()
+      self = _SwiftSystemFilePath()
       defer {
         self = comp._path
         if root?._slice.elementsEqual(rootStr) != true {
@@ -65,8 +65,8 @@ extension FilePath {
 }
 
 @available(System 0.0.2, *)
-extension FilePath.ComponentView: BidirectionalCollection {
-  public typealias Element = FilePath.Component
+extension _SwiftSystemFilePath.ComponentView: BidirectionalCollection {
+  public typealias Element = _SwiftSystemFilePath.Component
 
   @available(System 0.0.2, *)
   public struct Index: Sendable, Comparable, Hashable {
@@ -94,16 +94,16 @@ extension FilePath.ComponentView: BidirectionalCollection {
     Index(_path._parseComponent(priorTo: i._storage).lowerBound)
   }
 
-  public subscript(position: Index) -> FilePath.Component {
+  public subscript(position: Index) -> _SwiftSystemFilePath.Component {
     let end = _path._parseComponent(startingAt: position._storage).componentEnd
-    return FilePath.Component(_path, position._storage ..< end)
+    return _SwiftSystemFilePath.Component(_path, position._storage ..< end)
   }
 }
 
 @available(System 0.0.2, *)
-extension FilePath.ComponentView: RangeReplaceableCollection {
+extension _SwiftSystemFilePath.ComponentView: RangeReplaceableCollection {
   public init() {
-    self.init(FilePath())
+    self.init(_SwiftSystemFilePath())
   }
 
   // TODO(perf): We probably want to have concrete overrides or generic
@@ -120,7 +120,7 @@ extension FilePath.ComponentView: RangeReplaceableCollection {
       _invariantCheck()
     }
     if isEmpty {
-      _path = FilePath(root: _path.root, newElements)
+      _path = _SwiftSystemFilePath(root: _path.root, newElements)
       return
     }
     let range = subrange.lowerBound._storage ..< subrange.upperBound._storage
@@ -151,7 +151,7 @@ extension FilePath.ComponentView: RangeReplaceableCollection {
 }
 
 @available(System 0.0.2, *)
-extension FilePath {
+extension _SwiftSystemFilePath {
   /// Create a file path from a root and a collection of components.
   public init<C: Collection>(
     root: Root?, _ components: C
@@ -180,7 +180,7 @@ extension FilePath {
 // MARK: - Internals
 
 @available(System 0.0.2, *)
-extension FilePath.ComponentView: _PathSlice {
+extension _SwiftSystemFilePath.ComponentView: _PathSlice {
   internal var _range: Range<SystemString.Index> {
     _start ..< _path._storage.endIndex
   }
@@ -193,7 +193,7 @@ extension FilePath.ComponentView: _PathSlice {
 // MARK: - Invariants
 
 @available(System 0.0.2, *)
-extension FilePath.ComponentView {
+extension _SwiftSystemFilePath.ComponentView {
   internal func _invariantCheck() {
     #if DEBUG
     if isEmpty {
@@ -213,7 +213,7 @@ extension FilePath.ComponentView {
       precondition(base._slice.endIndex == _path._storage.endIndex)
     }
 
-    precondition(FilePath(root: _path.root, self) == _path)
+    precondition(_SwiftSystemFilePath(root: _path.root, self) == _path)
     #endif // DEBUG
   }
 }

--- a/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathComponents.swift
+++ b/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathComponents.swift
@@ -1,0 +1,287 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2020 - 2024 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// MARK: - API
+
+@available(System 0.0.2, *)
+extension _SwiftSystemFilePath {
+  /// Represents a root of a file path.
+  ///
+  /// On Unix, a root is simply the directory separator `/`.
+  ///
+  /// On Windows, a root contains the entire path prefix up to and including
+  /// the final separator.
+  ///
+  /// Examples:
+  /// * Unix:
+  ///   * `/`
+  /// * Windows:
+  ///   * `C:\`
+  ///   * `C:`
+  ///   * `\`
+  ///   * `\\server\share\`
+  ///   * `\\?\UNC\server\share\`
+  ///   * `\\?\Volume{12345678-abcd-1111-2222-123445789abc}\`
+  @available(System 0.0.2, *)
+  public struct Root: Sendable {
+    internal var _path: _SwiftSystemFilePath
+    internal var _rootEnd: SystemString.Index
+
+    internal init(_ path: _SwiftSystemFilePath, rootEnd: SystemString.Index) {
+      self._path = path
+      self._rootEnd = rootEnd
+      _invariantCheck()
+    }
+    // TODO: Definitely want a small form for this on Windows,
+    // and intern "/" for Unix.
+  }
+
+  /// Represents an individual, non-root component of a file path.
+  ///
+  /// Components can be one of the special directory components (`.` or `..`)
+  /// or a file or directory name. Components are never empty and never
+  /// contain the directory separator.
+  ///
+  /// Example:
+  ///
+  ///     var path: _SwiftSystemFilePath = "/tmp"
+  ///     let file: _SwiftSystemFilePath.Component = "foo.txt"
+  ///     file.kind == .regular           // true
+  ///     file.extension                  // "txt"
+  ///     path.append(file)               // path is "/tmp/foo.txt"
+  @available(System 0.0.2, *)
+  public struct Component: Sendable {
+    internal var _path: _SwiftSystemFilePath
+    internal var _range: Range<SystemString.Index>
+
+    // TODO: Make a small-component form to save on ARC overhead when
+    // extracted from a path, and especially to save on allocation overhead
+    // when constructing one from a String literal.
+
+    internal init<RE: RangeExpression>(_ path: _SwiftSystemFilePath, _ range: RE)
+    where RE.Bound == SystemString.Index {
+      self._path = path
+      self._range = range.relative(to: path._storage)
+      precondition(!self._range.isEmpty, "_SwiftSystemFilePath components cannot be empty")
+      self._invariantCheck()
+    }
+  }
+}
+
+@available(System 0.0.2, *)
+extension _SwiftSystemFilePath.Component {
+
+  /// Whether a component is a regular file or directory name, or a special
+  /// directory `.` or `..`
+  @frozen
+  @available(System 0.0.2, *)
+  public enum Kind: Sendable {
+    /// The special directory `.`, representing the current directory.
+    case currentDirectory
+
+    /// The special directory `..`, representing the parent directory.
+    case parentDirectory
+
+    /// A file or directory name
+    case regular
+  }
+
+  /// The kind of this component
+  public var kind: Kind {
+    if _path._isCurrentDirectory(_range) { return .currentDirectory }
+    if _path._isParentDirectory(_range) { return .parentDirectory }
+    return .regular
+  }
+}
+
+@available(System 0.0.2, *)
+extension _SwiftSystemFilePath.Root {
+  // TODO: Windows analysis APIs
+}
+
+// MARK: - Internals
+
+extension SystemString {
+  // TODO: take insertLeadingSlash: Bool
+  // TODO: turn into an insert operation with slide
+  internal mutating func appendComponents<C: Collection>(
+    components: C
+  ) where C.Element == _SwiftSystemFilePath.Component {
+    // TODO(perf): Consider pre-pass to count capacity, slide
+
+    defer {
+      _removeTrailingSeparator()
+      _SwiftSystemFilePath(self)._invariantCheck()
+    }
+
+    for idx in components.indices {
+      let component = components[idx]
+      component._withSystemChars { self.append(contentsOf: $0) }
+      self.append(platformSeparator)
+    }
+  }
+}
+
+// Unifying protocol for common functionality between roots, components,
+// and views onto SystemString and _SwiftSystemFilePath.
+internal protocol _SwiftSystemStrSlice: _PlatformStringable, Hashable, Codable {
+  var _storage: SystemString { get }
+  var _range: Range<SystemString.Index> { get }
+
+  init?(_ str: SystemString)
+
+  func _invariantCheck()
+}
+extension _SwiftSystemStrSlice {
+  internal var _slice: Slice<SystemString> {
+    Slice(base: _storage, bounds: _range)
+  }
+
+  internal func _withSystemChars<T>(
+    _ f: (UnsafeBufferPointer<SystemChar>) throws -> T
+  ) rethrows -> T {
+    try _storage.withNullTerminatedSystemChars {
+      try f(UnsafeBufferPointer(rebasing: $0[_range]))
+    }
+  }
+  internal func _withCodeUnits<T>(
+    _ f: (UnsafeBufferPointer<CInterop.PlatformUnicodeEncoding.CodeUnit>) throws -> T
+  ) rethrows -> T {
+    try _slice.withCodeUnits(f)
+  }
+
+  internal init?(_platformString s: UnsafePointer<CInterop.PlatformChar>) {
+    self.init(SystemString(platformString: s))
+  }
+
+  internal func _withPlatformString<Result>(
+    _ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result
+  ) rethrows -> Result {
+    try _slice.withPlatformString(body)
+  }
+
+  internal var _systemString: SystemString { SystemString(_slice) }
+}
+extension _SwiftSystemStrSlice {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs._slice.elementsEqual(rhs._slice)
+  }
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_slice.count) // discriminator
+    for element in _slice {
+      hasher.combine(element)
+    }
+  }
+}
+internal protocol _PathSlice: _SwiftSystemStrSlice {
+  var _path: _SwiftSystemFilePath { get }
+}
+extension _PathSlice {
+  internal var _storage: SystemString { _path._storage }
+}
+
+@available(System 0.0.2, *)
+extension _SwiftSystemFilePath.Component: _PathSlice {
+}
+@available(System 0.0.2, *)
+extension _SwiftSystemFilePath.Root: _PathSlice {
+  internal var _range: Range<SystemString.Index> {
+    (..<_rootEnd).relative(to: _path._storage)
+  }
+}
+
+@available(System 0.0.1, *)
+extension _SwiftSystemFilePath: _PlatformStringable {
+  func _withPlatformString<Result>(_ body: (UnsafePointer<CInterop.PlatformChar>) throws -> Result) rethrows -> Result {
+    try _storage.withPlatformString(body)
+  }
+
+  init(_platformString: UnsafePointer<CInterop.PlatformChar>) {
+    self.init(SystemString(platformString: _platformString))
+  }
+
+}
+
+@available(System 0.0.2, *)
+extension _SwiftSystemFilePath.Component {
+  // The index of the `.` denoting an extension
+  internal func _extensionIndex() -> SystemString.Index? {
+    guard kind == .regular,
+          let idx = _slice.lastIndex(of: .dot),
+          idx != _slice.startIndex
+    else { return nil }
+
+    return idx
+  }
+
+  internal func _extensionRange() -> Range<SystemString.Index>? {
+    guard let idx = _extensionIndex() else { return nil }
+    return _slice.index(after: idx) ..< _slice.endIndex
+  }
+
+  internal func _stemRange() -> Range<SystemString.Index> {
+    _slice.startIndex ..< (_extensionIndex() ?? _slice.endIndex)
+  }
+}
+
+// `_makeExtension` was byte-identical to the compat layer's copy in
+// FilePath/FilePathComponents.swift, so the definition is dropped here and the
+// call sites in this folder use that shared internal one.
+
+@available(System 0.0.2, *)
+extension _SwiftSystemFilePath.Component {
+  internal init?(_ str: SystemString) {
+    // FIXME: explicit null root? Or something else?
+    let path = _SwiftSystemFilePath(str)
+    guard path.root == nil, path.components.count == 1 else {
+      return nil
+    }
+    self = path.components.first!
+    self._invariantCheck()
+  }
+}
+
+@available(System 0.0.2, *)
+extension _SwiftSystemFilePath.Root {
+  internal init?(_ str: SystemString) {
+    // FIXME: explicit null root? Or something else?
+    let path = _SwiftSystemFilePath(str)
+    guard path.root != nil, path.components.isEmpty else {
+      return nil
+    }
+    self = path.root!
+    self._invariantCheck()
+  }
+}
+
+// MARK: - Invariants
+
+@available(System 0.0.2, *)
+extension _SwiftSystemFilePath.Component {
+  // TODO: ensure this all gets easily optimized away in release...
+  internal func _invariantCheck() {
+    #if DEBUG
+    precondition(!_slice.isEmpty)
+    precondition(_slice.last != .null)
+    precondition(_slice.allSatisfy { !isSeparator($0) } )
+    precondition(_path._relativeStart <= _slice.startIndex)
+    #endif // DEBUG
+  }
+}
+
+@available(System 0.0.2, *)
+extension _SwiftSystemFilePath.Root {
+  internal func _invariantCheck() {
+    #if DEBUG
+    precondition(self._rootEnd > _path._storage.startIndex)
+
+    // TODO: Windows root invariants
+    #endif
+  }
+}

--- a/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathParsing.swift
+++ b/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathParsing.swift
@@ -117,7 +117,7 @@ extension SystemString {
 }
 
 @available(System 0.0.1, *)
-extension FilePath {
+extension _SwiftSystemFilePath {
   internal mutating func _removeTrailingSeparator() {
     _storage._removeTrailingSeparator()
   }
@@ -198,7 +198,7 @@ extension SystemString {
 }
 
 @available(System 0.0.1, *)
-extension FilePath {
+extension _SwiftSystemFilePath {
   internal var _relativeStart: SystemString.Index {
     _storage._relativePathStart
   }
@@ -210,7 +210,7 @@ extension FilePath {
 // Parse separators
 
 @available(System 0.0.1, *)
-extension FilePath {
+extension _SwiftSystemFilePath {
   internal typealias _Index = SystemString.Index
 
   // Parse a component that starts at `i`. Returns the end
@@ -274,7 +274,7 @@ extension FilePath {
 }
 
 @available(System 0.0.2, *)
-extension FilePath.ComponentView {
+extension _SwiftSystemFilePath.ComponentView {
   // TODO: Store this...
   internal var _relativeStart: SystemString.Index {
     _path._relativeStart
@@ -299,7 +299,7 @@ extension SystemString {
 }
 
 @available(System 0.0.2, *)
-extension FilePath.Root {
+extension _SwiftSystemFilePath.Root {
   // Asserting self is a root, returns whether this is an
   // absolute root.
   //
@@ -308,7 +308,7 @@ extension FilePath.Root {
   //
   // TODO: public
   internal var isAbsolute: Bool {
-    assert(FilePath(SystemString(self._slice)).root == self, "not a root")
+    assert(_SwiftSystemFilePath(SystemString(self._slice)).root == self, "not a root")
 
     guard _windowsPaths else { return true }
 
@@ -324,7 +324,7 @@ extension FilePath.Root {
 }
 
 @available(System 0.0.1, *)
-extension FilePath {
+extension _SwiftSystemFilePath {
   internal var _portableDescription: String {
     guard _windowsPaths else { return description }
     let utf8 = description.utf8.map { $0 == UInt8(ascii: #"\"#) ? UInt8(ascii: "/") : $0 }
@@ -346,7 +346,7 @@ internal var _windowsPaths: Bool {
 }
 
 @available(System 0.0.1, *)
-extension FilePath {
+extension _SwiftSystemFilePath {
   // Whether we should add a separator when doing an append
   internal var _needsSeparatorForAppend: Bool {
     guard let last = _storage.last, !isSeparator(last) else { return false }
@@ -363,7 +363,7 @@ extension FilePath {
   // Perform an append, inseting a separator if needed.
   // Note that this will not check whether `content` is a root
   internal mutating func _append(unchecked content: Slice<SystemString>) {
-    assert(FilePath(SystemString(content)).root == nil)
+    assert(_SwiftSystemFilePath(SystemString(content)).root == nil)
     if content.isEmpty { return }
     if _needsSeparatorForAppend {
       _storage.append(platformSeparator)
@@ -374,7 +374,7 @@ extension FilePath {
 
 // MARK: - Invariants
 @available(System 0.0.1, *)
-extension FilePath {
+extension _SwiftSystemFilePath {
   internal func _invariantsSatisfied() -> Bool {
     var normal = self
     normal._normalizeSeparators()

--- a/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathString.swift
+++ b/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathString.swift
@@ -7,11 +7,10 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-
 // MARK: - Platform string
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath {
+extension _SwiftSystemFilePath {
   /// Creates a file path by copying bytes from a null-terminated platform
   /// string.
   ///
@@ -33,37 +32,34 @@ extension _StdlibFilePath {
   public init(platformString: [CInterop.PlatformChar]) {
     guard let _ = platformString.firstIndex(of: 0) else {
       fatalError(
-        "input of _StdlibFilePath.init(platformString:) must be null-terminated"
+        "input of _SwiftSystemFilePath.init(platformString:) must be null-terminated"
       )
     }
     self = platformString.withUnsafeBufferPointer {
-      _StdlibFilePath(platformString: $0.baseAddress!)
+      _SwiftSystemFilePath(platformString: $0.baseAddress!)
     }
   }
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use _StdlibFilePath.init(_ scalar: Unicode.Scalar)")
+  @available(*, deprecated, message: "Use _SwiftSystemFilePath.init(_ scalar: Unicode.Scalar)")
   public init(platformString: inout CInterop.PlatformChar) {
     guard platformString == 0 else {
       fatalError(
-        "input of _StdlibFilePath.init(platformString:) must be null-terminated"
+        "input of _SwiftSystemFilePath.init(platformString:) must be null-terminated"
       )
     }
-    self = _StdlibFilePath()
+    self = _SwiftSystemFilePath()
   }
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use _StdlibFilePath(_: String) to create a path from a String")
+  @available(*, deprecated, message: "Use _SwiftSystemFilePath(_: String) to create a path from a String")
   public init(platformString: String) {
-    // `_ssString:` is the parked spelling of swift-system's non-failable
-    // `_StdlibFilePath(_: String)`; see its declaration below for why. Bare
-    // `_StdlibFilePath(_:)` now resolves to the base's failable initializer.
     if let nullLoc = platformString.firstIndex(of: "\0") {
-      self = _StdlibFilePath(_ssString: String(platformString[..<nullLoc]))
+      self = _SwiftSystemFilePath(String(platformString[..<nullLoc]))
     } else {
-      self = _StdlibFilePath(_ssString: platformString)
+      self = _SwiftSystemFilePath(platformString)
     }
   }
 
@@ -114,7 +110,7 @@ extension _StdlibFilePath {
 }
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath.Component {
+extension _SwiftSystemFilePath.Component {
   /// Creates a file path component by copying bytes from a null-terminated
   /// platform string.
   ///
@@ -143,11 +139,11 @@ extension _StdlibFilePath.Component {
   public init?(platformString: [CInterop.PlatformChar]) {
     guard let _ = platformString.firstIndex(of: 0) else {
       fatalError(
-        "input of _StdlibFilePath.Component.init?(platformString:) must be null-terminated"
+        "input of _SwiftSystemFilePath.Component.init?(platformString:) must be null-terminated"
       )
     }
     guard let component = platformString.withUnsafeBufferPointer({
-      _StdlibFilePath.Component(platformString: $0.baseAddress!)
+      _SwiftSystemFilePath.Component(platformString: $0.baseAddress!)
     }) else {
       return nil
     }
@@ -156,11 +152,11 @@ extension _StdlibFilePath.Component {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use _StdlibFilePath.Component.init(_ scalar: Unicode.Scalar)")
+  @available(*, deprecated, message: "Use _SwiftSystemFilePath.Component.init(_ scalar: Unicode.Scalar)")
   public init?(platformString: inout CInterop.PlatformChar) {
     guard platformString == 0 else {
       fatalError(
-        "input of _StdlibFilePath.Component.init?(platformString:) must be null-terminated"
+        "input of _SwiftSystemFilePath.Component.init?(platformString:) must be null-terminated"
       )
     }
     return nil
@@ -168,7 +164,7 @@ extension _StdlibFilePath.Component {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use _StdlibFilePath.Component.init(_: String)")
+  @available(*, deprecated, message: "Use _SwiftSystemFilePath.Component.init(_: String)")
   public init?(platformString: String) {
     let string: String
     if let nullLoc = platformString.firstIndex(of: "\0") {
@@ -176,7 +172,7 @@ extension _StdlibFilePath.Component {
     } else {
       string = platformString
     }
-    guard let component = _StdlibFilePath.Component(string) else { return nil }
+    guard let component = _SwiftSystemFilePath.Component(string) else { return nil }
     self = component
   }
 
@@ -203,7 +199,7 @@ extension _StdlibFilePath.Component {
 }
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath.Root {
+extension _SwiftSystemFilePath.Root {
   /// Creates a file path root by copying bytes from a null-terminated platform
   /// string.
   ///
@@ -230,11 +226,11 @@ extension _StdlibFilePath.Root {
   public init?(platformString: [CInterop.PlatformChar]) {
     guard let _ = platformString.firstIndex(of: 0) else {
       fatalError(
-        "input of _StdlibFilePath.Root.init?(platformString:) must be null-terminated"
+        "input of _SwiftSystemFilePath.Root.init?(platformString:) must be null-terminated"
       )
     }
     guard let component = platformString.withUnsafeBufferPointer({
-      _StdlibFilePath.Root(platformString: $0.baseAddress!)
+      _SwiftSystemFilePath.Root(platformString: $0.baseAddress!)
     }) else {
       return nil
     }
@@ -243,11 +239,11 @@ extension _StdlibFilePath.Root {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use _StdlibFilePath.Root.init(_ scalar: Unicode.Scalar)")
+  @available(*, deprecated, message: "Use _SwiftSystemFilePath.Root.init(_ scalar: Unicode.Scalar)")
   public init?(platformString: inout CInterop.PlatformChar) {
     guard platformString == 0 else {
       fatalError(
-        "input of _StdlibFilePath.Root.init?(platformString:) must be null-terminated"
+        "input of _SwiftSystemFilePath.Root.init?(platformString:) must be null-terminated"
       )
     }
     return nil
@@ -255,7 +251,7 @@ extension _StdlibFilePath.Root {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Use _StdlibFilePath.Root.init(_: String)")
+  @available(*, deprecated, message: "Use _SwiftSystemFilePath.Root.init(_: String)")
   public init?(platformString: String) {
     let string: String
     if let nullLoc = platformString.firstIndex(of: "\0") {
@@ -263,7 +259,7 @@ extension _StdlibFilePath.Root {
     } else {
       string = platformString
     }
-    guard let root = _StdlibFilePath.Root(string) else { return nil }
+    guard let root = _SwiftSystemFilePath.Root(string) else { return nil }
     self = root
   }
 
@@ -291,9 +287,8 @@ extension _StdlibFilePath.Root {
 
 // MARK: - String literals
 
-#if false // PORT-CLOBBERED: superseded by stdlib copy
 @available(System 0.0.1, *)
-extension _StdlibFilePath: ExpressibleByStringLiteral {
+extension _SwiftSystemFilePath: ExpressibleByStringLiteral {
   /// Creates a file path from a string literal.
   ///
   /// - Parameter stringLiteral: A string literal
@@ -312,16 +307,16 @@ extension _StdlibFilePath: ExpressibleByStringLiteral {
 }
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath.Component: ExpressibleByStringLiteral {
+extension _SwiftSystemFilePath.Component: ExpressibleByStringLiteral {
   /// Create a file path component from a string literal.
   ///
   /// Precondition: `stringLiteral` is non-empty, is not a root,
   /// and has only one component in it.
   public init(stringLiteral: String) {
-    guard let s = _StdlibFilePath.Component(stringLiteral) else {
+    guard let s = _SwiftSystemFilePath.Component(stringLiteral) else {
       // TODO: static assert
       fatalError("""
-        _StdlibFilePath.Component must be created from exactly one non-root component
+        _SwiftSystemFilePath.Component must be created from exactly one non-root component
         """)
     }
     self = s
@@ -335,49 +330,17 @@ extension _StdlibFilePath.Component: ExpressibleByStringLiteral {
     self.init(SystemString(string))
   }
 }
-#endif
-
-// PORT: swift-system historically shipped a non-failable _StdlibFilePath(_: String).
-// The stdlib copy's String init is failable, and the two cannot coexist on one
-// type (initializers ignore optionality for redeclaration/overload). With
-// FILEPATH_SYSTEM_STRING_COMPAT set, the copy drops its public failable init,
-// so this is the sole _StdlibFilePath(_: String). It force-unwraps the validating
-// entry point: an embedded NUL traps here (the copy rejects NUL) where old
-// swift-system truncated at the first NUL.
-@available(System 0.0.1, *)
-extension _StdlibFilePath {
-  /// Creates a file path from a string.
-  ///
-  /// - Parameter string: A string whose Unicode encoded contents to use as the
-  ///   contents of the path.
-  ///
-  /// PARKED (`_ss` prefix) for the one-module merge. This is swift-system's
-  /// non-failable `_StdlibFilePath(_: String)`, which truncates at an embedded NUL.
-  /// The base declares a public *failable* `init?(_ String)` that rejects NUL
-  /// instead, and the two are the same signature, so they cannot both sit on
-  /// the type that `_StdlibFilePath` currently aliases. They are genuinely divergent,
-  /// so neither may be deduped into the other, and the base is sacrosanct.
-  /// Parking this one keeps the base's initializer intact and keeps base
-  /// consumers validating the base. The wrapper struct in the next task is the
-  /// real fix: it can host this spelling non-failably while the base keeps its
-  /// failable one, at which point the `_ss` label comes off.
-  public init(_ssString string: String) {
-    // Route through the substrate (which truncates at an embedded NUL,
-    // matching historical swift-system) and the public `_normalizing` funnel.
-    self = _StdlibFilePath(SystemString(string))
-  }
-}
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath.Root: ExpressibleByStringLiteral {
+extension _SwiftSystemFilePath.Root: ExpressibleByStringLiteral {
   /// Create a file path root from a string literal.
   ///
   /// Precondition: `stringLiteral` is non-empty and is a root.
   public init(stringLiteral: String) {
-    guard let s = _StdlibFilePath.Root(stringLiteral) else {
+    guard let s = _SwiftSystemFilePath.Root(stringLiteral) else {
       // TODO: static assert
       fatalError("""
-        _StdlibFilePath.Root must be created from a root
+        _SwiftSystemFilePath.Root must be created from a root
         """)
     }
     self = s
@@ -387,16 +350,14 @@ extension _StdlibFilePath.Root: ExpressibleByStringLiteral {
   ///
   /// Returns `nil` if `string` is empty or is not a root.
   public init?(_ string: String) {
-    // Truncates at the first NUL, matching historical behavior.
-    self.init(SystemString(string).map { $0.rawValue })
+    self.init(SystemString(string))
   }
 }
 
 // MARK: - Printing and dumping
 
-#if false // PORT-CLOBBERED: superseded by stdlib copy
 @available(System 0.0.1, *)
-extension _StdlibFilePath: CustomStringConvertible, CustomDebugStringConvertible {
+extension _SwiftSystemFilePath: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the file path.
   ///
   /// If the content of the path isn't a well-formed Unicode string,
@@ -412,7 +373,7 @@ extension _StdlibFilePath: CustomStringConvertible, CustomDebugStringConvertible
 }
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath.Component: CustomStringConvertible, CustomDebugStringConvertible {
+extension _SwiftSystemFilePath.Component: CustomStringConvertible, CustomDebugStringConvertible {
 
   /// A textual representation of the path component.
   ///
@@ -427,10 +388,9 @@ extension _StdlibFilePath.Component: CustomStringConvertible, CustomDebugStringC
   /// this replaces invalid bytes with U+FFFD. See `String.init(decoding:)`.
   public var debugDescription: String { description.debugDescription }
 }
-#endif
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath.Root: CustomStringConvertible, CustomDebugStringConvertible {
+extension _SwiftSystemFilePath.Root: CustomStringConvertible, CustomDebugStringConvertible {
 
   /// A textual representation of the path root.
   ///
@@ -450,7 +410,7 @@ extension _StdlibFilePath.Root: CustomStringConvertible, CustomDebugStringConver
 
 // Convenience helpers
 @available(System 0.0.2, *)
-extension _StdlibFilePath {
+extension _SwiftSystemFilePath {
   /// Creates a string by interpreting the path’s content as UTF-8 on Unix
   /// and UTF-16 on Windows.
   ///
@@ -458,15 +418,10 @@ extension _StdlibFilePath {
   public var string: String {
     String(decoding: self)
   }
-
-  /// The length of the file path, measured in platform code units and
-  /// excluding the null terminator. swift-system public API, re-expressed on
-  /// the stdlib copy's public code-unit access.
-  public var length: Int { _cuArray.count }
 }
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath.Component {
+extension _SwiftSystemFilePath.Component {
   /// Creates a string by interpreting the component’s content as UTF-8 on Unix
   /// and UTF-16 on Windows.
   ///
@@ -477,7 +432,7 @@ extension _StdlibFilePath.Component {
 }
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath.Root {
+extension _SwiftSystemFilePath.Root {
   /// On Unix, this returns `"/"`.
   ///
   /// On Windows, interprets the root's content as UTF-16 on Windows.
@@ -490,7 +445,6 @@ extension _StdlibFilePath.Root {
 
 // MARK: - Decoding and validating
 
-#if false // PORT-CLOBBERED: superseded by stdlib copy
 @available(System 0.0.1, *)
 extension String {
   /// Creates a string by interpreting the file path's content as UTF-8 on Unix
@@ -504,10 +458,13 @@ extension String {
   /// This means that, depending on the semantics of the specific file system,
   /// conversion to a string and back to a path
   /// might result in a value that's different from the original path.
-  public init(decoding path: _StdlibFilePath) {
+  public init(decoding path: _SwiftSystemFilePath) {
     self.init(_decoding: path)
   }
+}
 
+@available(System 0.0.2, *)
+extension String {
   /// Creates a string from a file path, validating its contents as UTF-8 on
   /// Unix and UTF-16 on Windows.
   ///
@@ -516,13 +473,12 @@ extension String {
   ///
   /// If the contents of the file path isn't a well-formed Unicode string,
   /// this initializer returns `nil`.
-  public init?(validating path: _StdlibFilePath) {
+  @available(System 0.0.2, *)
+  public init?(validating path: _SwiftSystemFilePath) {
     self.init(_validating: path)
   }
 }
-#endif
 
-#if false // PORT-CLOBBERED: superseded by stdlib copy
 @available(System 0.0.2, *)
 extension String {
   /// Creates a string by interpreting the path component's content as UTF-8 on
@@ -536,7 +492,7 @@ extension String {
   /// This means that, depending on the semantics of the specific file system,
   /// conversion to a string and back to a path component
   /// might result in a value that's different from the original path component.
-  public init(decoding component: _StdlibFilePath.Component) {
+  public init(decoding component: _SwiftSystemFilePath.Component) {
     self.init(_decoding: component)
   }
 
@@ -548,11 +504,10 @@ extension String {
   ///
   /// If the contents of the path component isn't a well-formed Unicode string,
   /// this initializer returns `nil`.
-  public init?(validating component: _StdlibFilePath.Component) {
+  public init?(validating component: _SwiftSystemFilePath.Component) {
     self.init(_validating: component)
   }
 }
-#endif
 
 @available(System 0.0.2, *)
 extension String {
@@ -569,7 +524,7 @@ extension String {
   /// This means that on Windows,
   /// conversion to a string and back to a path root
   /// might result in a value that's different from the original path root.
-  public init(decoding root: _StdlibFilePath.Root) {
+  public init(decoding root: _SwiftSystemFilePath.Root) {
     self.init(_decoding: root)
   }
 
@@ -583,7 +538,7 @@ extension String {
   ///
   /// On Windows, if the contents of the path root isn't a well-formed Unicode
   /// string, this initializer returns `nil`.
-  public init?(validating root: _StdlibFilePath.Root) {
+  public init?(validating root: _SwiftSystemFilePath.Root) {
     self.init(_validating: root)
   }
 }
@@ -610,17 +565,17 @@ extension String {
 @available(System 0.0.1, *)
 extension String {
   @available(*, deprecated, renamed: "init(decoding:)")
-  public init(_ path: _StdlibFilePath) { self.init(decoding: path) }
+  public init(_ path: _SwiftSystemFilePath) { self.init(decoding: path) }
 
   @available(*, deprecated, renamed: "init(validating:)")
-  public init?(validatingUTF8 path: _StdlibFilePath) { self.init(validating: path) }
+  public init?(validatingUTF8 path: _SwiftSystemFilePath) { self.init(validating: path) }
 }
 
 #if !os(Windows)
 @available(System 0.0.1, *)
-extension _StdlibFilePath {
+extension _SwiftSystemFilePath {
   /// For backwards compatibility only. This initializer is equivalent to
-  /// the preferred `_StdlibFilePath(platformString:)`.
+  /// the preferred `_SwiftSystemFilePath(platformString:)`.
   @available(*, deprecated, renamed: "init(platformString:)")
   public init(cString: UnsafePointer<CChar>) {
     self.init(platformString: cString)

--- a/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathSyntax.swift
+++ b/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathSyntax.swift
@@ -7,11 +7,10 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-
 // MARK: - Query API
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath {
+extension _SwiftSystemFilePath {
   /// Returns true if this path uniquely identifies the location of
   /// a file without reference to an additional starting location.
   ///
@@ -37,11 +36,9 @@ extension _StdlibFilePath {
   ///   * `C:\Users\`
   ///   * `\\?\UNC\server\share\bar.exe`
   ///   * `\\server\share\bar.exe`
-#if false // PORT-CLOBBERED: superseded by stdlib copy
   public var isAbsolute: Bool {
     self.root?.isAbsolute ?? false
   }
-#endif
 
   /// Returns true if this path is not absolute (see `isAbsolute`).
   ///
@@ -62,13 +59,13 @@ extension _StdlibFilePath {
   ///
   /// Example:
   ///
-  ///     let path: _StdlibFilePath = "/usr/bin/ls"
+  ///     let path: _SwiftSystemFilePath = "/usr/bin/ls"
   ///     path.starts(with: "/")              // true
   ///     path.starts(with: "/usr/bin")       // true
   ///     path.starts(with: "/usr/bin/ls")    // true
   ///     path.starts(with: "/usr/bin/ls///") // true
   ///     path.starts(with: "/us")            // false
-  public func starts(with other: _StdlibFilePath) -> Bool {
+  public func starts(with other: _SwiftSystemFilePath) -> Bool {
     guard !other.isEmpty else { return true }
     return self.root == other.root && components.starts(
       with: other.components)
@@ -81,13 +78,13 @@ extension _StdlibFilePath {
   ///
   /// Example:
   ///
-  ///     let path: _StdlibFilePath = "/usr/bin/ls"
+  ///     let path: _SwiftSystemFilePath = "/usr/bin/ls"
   ///     path.ends(with: "ls")             // true
   ///     path.ends(with: "bin/ls")         // true
   ///     path.ends(with: "usr/bin/ls")     // true
   ///     path.ends(with: "/usr/bin/ls///") // true
   ///     path.ends(with: "/ls")            // false
-  public func ends(with other: _StdlibFilePath) -> Bool {
+  public func ends(with other: _SwiftSystemFilePath) -> Bool {
     if other.root != nil {
       // TODO: anything tricky here for Windows?
       return self == other
@@ -98,14 +95,12 @@ extension _StdlibFilePath {
   }
 
   /// Whether this path is empty
-#if false // PORT-CLOBBERED: superseded by stdlib copy
   public var isEmpty: Bool { _storage.isEmpty }
-#endif
 }
 
 // MARK: - Decompose a path
 @available(System 0.0.2, *)
-extension _StdlibFilePath {
+extension _SwiftSystemFilePath {
   /// Returns the root of a path if there is one, otherwise `nil`.
   ///
   /// On Unix, this will return the leading `/` if the path is absolute
@@ -138,24 +133,28 @@ extension _StdlibFilePath {
   ///
   /// Example:
   ///
-  ///     var path: _StdlibFilePath = "/foo/bar"
+  ///     var path: _SwiftSystemFilePath = "/foo/bar"
   ///     path.root = nil // path is "foo/bar"
   ///     path.root = "/" // path is "/foo/bar"
   ///
   /// Example (Windows):
   ///
-  ///     var path: _StdlibFilePath = #"\foo\bar"#
+  ///     var path: _SwiftSystemFilePath = #"\foo\bar"#
   ///     path.root = nil         // path is #"foo\bar"#
   ///     path.root = "C:"        // path is #"C:foo\bar"#
   ///     path.root = #"C:\"#     // path is #"C:\foo\bar"#
-  public var root: _StdlibFilePath.Root? {
+  public var root: _SwiftSystemFilePath.Root? {
     get {
-      guard let anchor = anchor else { return nil }
-      return Root(anchor)
+      guard _hasRoot else { return nil }
+      return Root(self, rootEnd: _relativeStart)
     }
     set {
       defer { _invariantCheck() }
-      self.anchor = newValue?._anchor
+      guard let r = newValue else {
+        _storage.removeSubrange(..<_relativeStart)
+        return
+      }
+      _storage.replaceSubrange(..<_relativeStart, with: r._slice)
     }
   }
 
@@ -176,7 +175,7 @@ extension _StdlibFilePath {
   ///   * `\\?\device\folder\file.exe  => folder\file.exe`
   ///   * `\\server\share\file         => file`
   ///   * `\                           => ""`
-  public __consuming func removingRoot() -> _StdlibFilePath {
+  public __consuming func removingRoot() -> _SwiftSystemFilePath {
     var copy = self
     copy.root = nil
     return copy
@@ -184,7 +183,7 @@ extension _StdlibFilePath {
 }
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath {
+extension _SwiftSystemFilePath {
   /// Returns the final component of the path.
   /// Returns `nil` if the path is empty or only contains a root.
   ///
@@ -213,7 +212,7 @@ extension _StdlibFilePath {
   ///
   /// If the path only contains a root, returns `self`.
   /// If the path has no root and only includes a single component,
-  /// returns an empty _StdlibFilePath.
+  /// returns an empty _SwiftSystemFilePath.
   ///
   /// Examples:
   /// * Unix:
@@ -226,7 +225,7 @@ extension _StdlibFilePath {
   ///   * `C:\                            => C:\`
   ///   * `\\server\share\folder\file.txt => \\server\share\folder`
   ///   * `\\server\share\                => \\server\share\`
-  public __consuming func removingLastComponent() -> _StdlibFilePath {
+  public __consuming func removingLastComponent() -> _SwiftSystemFilePath {
     var copy = self
     copy.removeLastComponent()
     return copy
@@ -246,16 +245,15 @@ extension _StdlibFilePath {
   @discardableResult
   public mutating func removeLastComponent() -> Bool {
     defer { _invariantCheck() }
-    guard !components.isEmpty else { return false }
-    // The component view's RRC handles the joining separator and any
-    // trailing-separator / resource-fork suffix.
-    self.components.removeLast()
+    guard let lastRel = lastComponent else { return false }
+    _storage.removeSubrange(lastRel._slice.indices)
+    _removeTrailingSeparator()
     return true
   }
 }
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath.Component {
+extension _SwiftSystemFilePath.Component {
   /// The extension of this file or directory component.
   ///
   /// If `self` does not contain a `.` anywhere, or only
@@ -268,9 +266,8 @@ extension _StdlibFilePath.Component {
   ///   * `.hidden    => nil`
   ///   * `..         => nil`
   public var `extension`: String? {
-    let bytes = _codeUnits
-    guard let idx = _extensionIndex(bytes) else { return nil }
-    return Array(bytes[bytes.index(after: idx)...])._decodedString
+    guard let range = _extensionRange() else { return nil }
+    return _slice[range].string
   }
 
   /// The non-extension portion of this file or directory  component.
@@ -282,14 +279,12 @@ extension _StdlibFilePath.Component {
   ///   * `.hidden => .hidden`
   ///   * `..      => ..`
   public var stem: String {
-    let bytes = _codeUnits
-    let end = _extensionIndex(bytes) ?? bytes.endIndex
-    return Array(bytes[..<end])._decodedString
+    _slice[_stemRange()].string
   }
 }
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath {
+extension _SwiftSystemFilePath {
 
   /// The extension of the file or directory last component.
   ///
@@ -325,20 +320,18 @@ extension _StdlibFilePath {
       defer { _invariantCheck() }
       guard let base = lastComponent, base.kind == .regular else { return }
 
-      // Rebuild the last component's bytes (stem + new extension), then
-      // reconstruct the path from anchor + components with the last replaced.
-      let baseBytes = base._codeUnits
-      let stemEnd = base._extensionIndex(baseBytes) ?? baseBytes.endIndex
-      var newComp = Array(baseBytes[..<stemEnd])
+      let suffix: SystemString
       if let ext = newValue {
-        newComp.append(contentsOf: _makeExtension(ext).map { $0.rawValue })
+        suffix = _makeExtension(ext)
+      } else {
+        suffix = SystemString()
       }
-      guard let comp = _StdlibFilePath.Component(newComp) else { return }
-      var comps = Array(components)
-      comps.removeLast()
-      comps.append(comp)
-      self = _StdlibFilePath(
-        anchor: anchor, comps, hasTrailingSeparator: hasTrailingSeparator)
+
+      let extRange = (
+        base._extensionIndex() ?? base._slice.endIndex
+      ) ..< base._slice.endIndex
+
+      _storage.replaceSubrange(extRange, with: suffix)
     }
   }
 
@@ -357,7 +350,7 @@ extension _StdlibFilePath {
 }
 
 @available(System 0.0.2, *)
-extension _StdlibFilePath {
+extension _SwiftSystemFilePath {
   /// Whether the path is in lexical-normal form, that is `.` and `..`
   /// components have been collapsed lexically (i.e. without following
   /// symlinks).
@@ -367,18 +360,12 @@ extension _StdlibFilePath {
   /// * `"../local/bin".isLexicallyNormal   == true`
   /// * `"local/bin/..".isLexicallyNormal   == false`
   public var isLexicallyNormal: Bool {
-    // Must agree with `lexicallyNormalize()`: a path is lexically normal iff
-    // normalizing is a no-op. `lexicallyNormalize()` strips a trailing
-    // separator, so a path carrying one is not normal even when its component
-    // kinds are all fine, e.g. `/tmp/` -> `/tmp`.
-    //
     // `..` components are permitted at the front of a
     // relative path, otherwise there should be no special directories
     //
     // FIXME: Windows `C:..\foo\bar` should probably be lexically normal, but
     // `\..\foo\bar` should not.
-    if hasTrailingSeparator { return false }
-    return components.drop(
+    components.drop(
       while: { root == nil && $0.kind == .parentDirectory }
     ).allSatisfy { $0.kind == .regular }
   }
@@ -398,13 +385,13 @@ extension _StdlibFilePath {
   /// Returns a copy of `self` in lexical-normal form, that is `.` and `..`
   /// components have been collapsed lexically (i.e. without following
   /// symlinks). See `lexicallyNormalize`
-  public __consuming func lexicallyNormalized() -> _StdlibFilePath {
+  public __consuming func lexicallyNormalized() -> _SwiftSystemFilePath {
     var copy = self
     copy.lexicallyNormalize()
     return copy
   }
 
-  /// Create a new `_StdlibFilePath` by resolving `subpath` relative to `self`,
+  /// Create a new `_SwiftSystemFilePath` by resolving `subpath` relative to `self`,
   /// ensuring that the result is lexically contained within `self`.
   ///
   /// `subpath` will be lexically normalized (see `lexicallyNormalize`) as
@@ -423,16 +410,16 @@ extension _StdlibFilePath {
   ///
   /// Example:
   ///
-  ///     let staticContent: _StdlibFilePath = "/var/www/my-website/static"
-  ///     let links: [_StdlibFilePath] =
+  ///     let staticContent: _SwiftSystemFilePath = "/var/www/my-website/static"
+  ///     let links: [_SwiftSystemFilePath] =
   ///       ["index.html", "/assets/main.css", "../../../../etc/passwd"]
   ///     links.map { staticContent.lexicallyResolving($0) }
   ///       // ["/var/www/my-website/static/index.html",
   ///       //  "/var/www/my-website/static/assets/main.css",
   ///       //  nil]
   public __consuming func lexicallyResolving(
-    _ subpath: __owned _StdlibFilePath
-  ) -> _StdlibFilePath? {
+    _ subpath: __owned _SwiftSystemFilePath
+  ) -> _SwiftSystemFilePath? {
     let subpath = subpath.removingRoot().lexicallyNormalized()
     guard !subpath.isEmpty else { return self }
     guard subpath.components.first?.kind != .parentDirectory else {
@@ -444,25 +431,24 @@ extension _StdlibFilePath {
 
 // Modification and concatenation API
 @available(System 0.0.2, *)
-extension _StdlibFilePath {
+extension _SwiftSystemFilePath {
   // TODO(Windows docs): example with roots
   /// If `prefix` is a prefix of `self`, removes it and returns `true`.
   /// Otherwise returns `false`.
   ///
   /// Example:
   ///
-  ///     var path: _StdlibFilePath = "/usr/local/bin"
+  ///     var path: _SwiftSystemFilePath = "/usr/local/bin"
   ///     path.removePrefix("/usr/bin")   // false
   ///     path.removePrefix("/us")        // false
   ///     path.removePrefix("/usr/local") // true, path is "bin"
-  public mutating func removePrefix(_ prefix: _StdlibFilePath) -> Bool {
+  public mutating func removePrefix(_ prefix: _SwiftSystemFilePath) -> Bool {
     defer { _invariantCheck() }
     // FIXME: Should Windows have more nuanced semantics?
     guard root == prefix.root else { return false }
     let (tail, remainder) = _dropCommonPrefix(components, prefix.components)
     guard remainder.isEmpty else { return false }
-    // What remains is the tail components with no anchor.
-    self = _StdlibFilePath(anchor: nil, Array(tail))
+    self._storage.removeSubrange(..<tail.startIndex._storage)
     return true
   }
 
@@ -471,15 +457,15 @@ extension _StdlibFilePath {
   ///
   /// Example:
   ///
-  ///     var path: _StdlibFilePath = "/tmp"
-  ///     let sub: _StdlibFilePath = "foo/./bar/../baz/."
+  ///     var path: _SwiftSystemFilePath = "/tmp"
+  ///     let sub: _SwiftSystemFilePath = "foo/./bar/../baz/."
   ///     for comp in sub.components.filter({ $0.kind != .currentDirectory }) {
   ///       path.append(comp)
   ///     }
   ///     // path is "/tmp/foo/bar/../baz"
-  public mutating func append(_ component: __owned _StdlibFilePath.Component) {
+  public mutating func append(_ component: __owned _SwiftSystemFilePath.Component) {
     defer { _invariantCheck() }
-    _append(unchecked: _copyToArray(component.codeUnits))
+    _append(unchecked: component._slice)
   }
 
   // TODO(Windows docs): example with roots
@@ -487,16 +473,16 @@ extension _StdlibFilePath {
   ///
   /// Example:
   ///
-  ///     var path: _StdlibFilePath = "/"
+  ///     var path: _SwiftSystemFilePath = "/"
   ///     path.append(["usr", "local"])     // path is "/usr/local"
-  ///     let otherPath: _StdlibFilePath = "/bin/ls"
+  ///     let otherPath: _SwiftSystemFilePath = "/bin/ls"
   ///     path.append(otherPath.components) // path is "/usr/local/bin/ls"
   public mutating func append<C: Collection>(
     _ components: __owned C
-  ) where C.Element == _StdlibFilePath.Component {
+  ) where C.Element == _SwiftSystemFilePath.Component {
     defer { _invariantCheck() }
     for c in components {
-      _append(unchecked: _copyToArray(c.codeUnits))
+      _append(unchecked: c._slice)
     }
   }
 
@@ -508,7 +494,7 @@ extension _StdlibFilePath {
   ///
   /// Example:
   ///
-  ///     var path: _StdlibFilePath = ""
+  ///     var path: _SwiftSystemFilePath = ""
   ///     path.append("/var/www/website") // "/var/www/website"
   ///     path.append("static/assets") // "/var/www/website/static/assets"
   ///     path.append("/main.css") // "/var/www/website/static/assets/main.css"
@@ -516,16 +502,16 @@ extension _StdlibFilePath {
     defer { _invariantCheck() }
     guard !other.utf8.isEmpty else { return }
     guard !isEmpty else {
-      self = _StdlibFilePath(SystemString(other))
+      self = _SwiftSystemFilePath(other)
       return
     }
-    let otherPath = _StdlibFilePath(SystemString(other))
-    _append(unchecked: _copyToArray(otherPath.components.codeUnits))
+    let otherPath = _SwiftSystemFilePath(other)
+    _append(unchecked: otherPath._storage[otherPath._relativeStart...])
   }
 
   // TODO(Windows docs): example with roots
   /// Non-mutating version of `append(_:Component)`.
-  public __consuming func appending(_ other: __owned Component) -> _StdlibFilePath {
+  public __consuming func appending(_ other: __owned Component) -> _SwiftSystemFilePath {
     var copy = self
     copy.append(other)
     return copy
@@ -535,7 +521,7 @@ extension _StdlibFilePath {
   /// Non-mutating version of `append(_:C)`.
   public __consuming func appending<C: Collection>(
     _ components: __owned C
-  ) -> _StdlibFilePath where C.Element == _StdlibFilePath.Component {
+  ) -> _SwiftSystemFilePath where C.Element == _SwiftSystemFilePath.Component {
     var copy = self
     copy.append(components)
     return copy
@@ -543,7 +529,7 @@ extension _StdlibFilePath {
 
   // TODO(Windows docs): example with roots
   /// Non-mutating version of `append(_:String)`.
-  public __consuming func appending(_ other: __owned String) -> _StdlibFilePath {
+  public __consuming func appending(_ other: __owned String) -> _SwiftSystemFilePath {
     var copy = self
     copy.append(other)
     return copy
@@ -561,22 +547,22 @@ extension _StdlibFilePath {
   ///
   /// Example:
   ///
-  ///     var path: _StdlibFilePath = "/tmp"
+  ///     var path: _SwiftSystemFilePath = "/tmp"
   ///     path.push("dir/file.txt") // path is "/tmp/dir/file.txt"
   ///     path.push("/bin")         // path is "/bin"
-  public mutating func push(_ other: __owned _StdlibFilePath) {
+  public mutating func push(_ other: __owned _SwiftSystemFilePath) {
     defer { _invariantCheck() }
     guard other.root == nil else {
       self = other
       return
     }
     // FIXME: Windows drive-relative roots, etc?
-    _append(unchecked: other._cuArray)
+    _append(unchecked: other._storage[...])
   }
 
   // TODO(Windows docs): examples and docs with roots
   /// Non-mutating version of `push()`.
-  public __consuming func pushing(_ other: __owned _StdlibFilePath) -> _StdlibFilePath {
+  public __consuming func pushing(_ other: __owned _SwiftSystemFilePath) -> _SwiftSystemFilePath {
     var copy = self
     copy.push(other)
     return copy
@@ -585,25 +571,22 @@ extension _StdlibFilePath {
   /// Remove the contents of the path, keeping the null terminator.
   public mutating func removeAll(keepingCapacity: Bool = false) {
     defer { _invariantCheck() }
-    // No public storage-capacity primitive across the module boundary, so
-    // `keepingCapacity` cannot be honored; reconstruct an empty path.
-    self = _StdlibFilePath()
+    _storage.removeAll(keepingCapacity: keepingCapacity)
   }
 
   /// Reserve enough storage space to store `minimumCapacity` platform
   /// characters.
   public mutating func reserveCapacity(_ minimumCapacity: Int) {
-    // No public storage-capacity primitive across the module boundary; this
-    // reservation hint is dropped. Correctness is unaffected.
-    _ = minimumCapacity
+    defer { _invariantCheck() }
+    self._storage.reserveCapacity(minimumCapacity)
   }
 }
 
 // MARK - Renamed
 @available(System 0.0.2, *)
-extension _StdlibFilePath {
+extension _SwiftSystemFilePath {
   @available(*, unavailable, renamed: "removingLastComponent()")
-  public var dirname: _StdlibFilePath { removingLastComponent() }
+  public var dirname: _SwiftSystemFilePath { removingLastComponent() }
 
   @available(*, unavailable, renamed: "lastComponent")
   public var basename: Component? { lastComponent }

--- a/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathWindows.swift
+++ b/Sources/System/_SwiftSystemFilePath/_SwiftSystemFilePathWindows.swift
@@ -7,7 +7,7 @@
  See https://swift.org/LICENSE.txt for license information
 */
 
-internal struct _ParsedWindowsRoot {
+internal struct _SwiftSystemParsedWindowsRoot {
   var rootEnd: SystemString.Index
 
   // TODO: Remove when I normalize to always (except `C:`)
@@ -23,11 +23,11 @@ internal struct _ParsedWindowsRoot {
   var volume: Range<SystemString.Index>?
 }
 
-extension _ParsedWindowsRoot {
+extension _SwiftSystemParsedWindowsRoot {
   static func traditional(
     drive: SystemChar?, fullQualified: Bool, endingAt idx: SystemString.Index
-  ) -> _ParsedWindowsRoot {
-    _ParsedWindowsRoot(
+  ) -> _SwiftSystemParsedWindowsRoot {
+    _SwiftSystemParsedWindowsRoot(
       rootEnd: idx,
       relativeBegin: idx,
       drive: drive,
@@ -43,8 +43,8 @@ extension _ParsedWindowsRoot {
     share: Range<SystemString.Index>,
     endingAt end: SystemString.Index,
     relativeBegin relBegin: SystemString.Index
-  ) -> _ParsedWindowsRoot {
-    _ParsedWindowsRoot(
+  ) -> _SwiftSystemParsedWindowsRoot {
+    _SwiftSystemParsedWindowsRoot(
       rootEnd: end,
       relativeBegin: relBegin,
       drive: nil,
@@ -59,8 +59,8 @@ extension _ParsedWindowsRoot {
     volume: Range<SystemString.Index>,
     endingAt end: SystemString.Index,
     relativeBegin relBegin: SystemString.Index
-  ) -> _ParsedWindowsRoot {
-    _ParsedWindowsRoot(
+  ) -> _SwiftSystemParsedWindowsRoot {
+    _SwiftSystemParsedWindowsRoot(
       rootEnd: end,
       relativeBegin: relBegin,
       drive: nil,
@@ -71,7 +71,7 @@ extension _ParsedWindowsRoot {
   }
 }
 
-struct _Lexer {
+struct _SwiftSystemLexer {
   var slice: Slice<SystemString>
 
   init(_ str: SystemString) {
@@ -133,7 +133,7 @@ struct _Lexer {
 
   mutating func clear() {
     // TODO: Intern empty system string
-    self = _Lexer(SystemString())
+    self = _SwiftSystemLexer(SystemString())
   }
 
   mutating func reset(to: SystemString, at: SystemString.Index) {
@@ -208,7 +208,7 @@ internal struct WindowsRootInfo {
   }
 }
 
-extension _ParsedWindowsRoot {
+extension _SwiftSystemParsedWindowsRoot {
   fileprivate func volumeInfo(_ root: SystemString) -> WindowsRootInfo.Volume {
     if let d = self.drive {
       return .drive(Character(d.asciiScalar!))
@@ -223,7 +223,7 @@ extension _ParsedWindowsRoot {
 }
 
 extension WindowsRootInfo {
-  internal init(_ root: SystemString, _ parsed: _ParsedWindowsRoot) {
+  internal init(_ root: SystemString, _ parsed: _SwiftSystemParsedWindowsRoot) {
     self.volume = parsed.volumeInfo(root)
 
     if let host = parsed.host {
@@ -271,7 +271,7 @@ extension WindowsRootInfo {
   }
 
   // TODO: Should this be component?
-  func formPath() -> FilePath {
+  func formPath() -> _SwiftSystemFilePath {
     fatalError("Unimplemented")
   }
 
@@ -310,7 +310,7 @@ extension WindowsRootInfo {
 
 extension SystemString {
   // TODO: Or, should I always inline this to remove some of the bookeeping?
-  private func _parseWindowsRootInternal() -> _ParsedWindowsRoot? {
+  private func _parseWindowsRootInternal() -> _SwiftSystemParsedWindowsRoot? {
     assert(_windowsPaths)
 
     /*
@@ -331,10 +331,10 @@ extension SystemString {
      are deferred to the relevant syscalls.
     */
 
-    var lexer = _Lexer(self)
+    var lexer = _SwiftSystemLexer(self)
 
     // Helper to parse a UNC root
-    func parseUNC(deviceSigil: SystemChar?) -> _ParsedWindowsRoot {
+    func parseUNC(deviceSigil: SystemChar?) -> _SwiftSystemParsedWindowsRoot {
       let serverRange = lexer.eatComponent()
       guard lexer.eatBackslash() else {
         fatalError("expected normalized root to contain backslash")
@@ -413,7 +413,7 @@ extension SystemString {
     assert(_windowsPaths)
     assert(!self.contains(.slash), "only valid after separator conversion")
 
-    var lexer = _Lexer(self)
+    var lexer = _SwiftSystemLexer(self)
 
     // Only relevant for UNC or device paths
     guard lexer.eatBackslash(), lexer.eatBackslash() else {

--- a/Tests/SystemTests/FilePathTests/FilePathLexicalNormalizeTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathLexicalNormalizeTest.swift
@@ -1,0 +1,97 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import XCTest
+import Foundation
+
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// Direct coverage for `lexicallyNormalize()` / `_normalizeSpecialDirectories`.
+//
+// The existing table in FilePathSyntaxTest.testPathSyntax has a
+// `lexicallyNormalized` column, but that whole file is behind
+// `#if ENABLE_MOCKING` (it drives `withWindowsPaths`), which is off in the
+// default test run, so none of it exercises `_normalizeSpecialDirectories`.
+// These POSIX cases run unconditionally. Expectations are taken from that
+// table's unix rows, plus underflow / leading-`..`-run edges that pin the
+// rooted-vs-rootless behavior.
+@available(System 0.0.2, *)
+final class FilePathLexicalNormalizeTest: XCTestCase {
+  func testLexicallyNormalized() {
+    let cases: [(String, String)] = [
+      // From FilePathSyntaxTest.testPathSyntax unix rows:
+      ("/..", "/"),
+      ("/.", "/"),
+      ("/../.", "/"),
+      (".", ""),
+      ("..", ".."),
+      ("./..", ".."),
+      ("../.", ".."),
+      ("../..", "../.."),
+      ("a/../..", ".."),
+      ("a/.././.././../b", "../../b"),
+      ("/a/.././.././../b", "/b"),
+      ("./.", ""),
+      ("a/foo/bar/../..", "a"),
+      ("a/./foo/bar/.././../.", "a"),
+      ("a/../b", "b"),
+      ("/a/../b/../c/../../d", "/d"),
+      ("/tmp/.", "/tmp"),
+      ("/tmp/..", "/"),
+      ("/tmp/../", "/"),
+      ("/tmp/./a/../b", "/tmp/b"),
+
+      // Edges pinning the rooted/rootless `..` rule: rooted underflow keeps
+      // swallowing `..`; rootless underflow preserves it.
+      ("/../../..", "/"),
+      ("../../..", "../../.."),
+      ("a/../../..", "../.."),
+      ("/a/b/c/../../..", "/"),
+      ("/a/b/c/../../../..", "/"),
+      ("foo/..", ""),
+      ("foo/bar/../..", ""),
+      ("./foo/../..", ".."),
+
+      // Already-normal inputs are unchanged (fast path).
+      ("/usr/local/bin", "/usr/local/bin"),
+      ("../local/bin", "../local/bin"),
+      ("", ""),
+      ("/", "/"),
+    ]
+
+    for (input, expected) in cases {
+      let path = FilePath(input)
+
+      var mutated = path
+      mutated.lexicallyNormalize()
+      XCTAssertEqual(
+        FilePath(expected), mutated,
+        "lexicallyNormalize(): \(input) -> \(mutated) (expected \(expected))")
+
+      XCTAssertEqual(
+        FilePath(expected), path.lexicallyNormalized(),
+        "lexicallyNormalized(): \(input)")
+
+      XCTAssertTrue(
+        mutated.isLexicallyNormal,
+        "result not lexically normal: \(input) -> \(mutated)")
+      XCTAssertEqual(
+        mutated, mutated.lexicallyNormalized(),
+        "not idempotent: \(input)")
+
+      XCTAssertEqual(
+        path.isLexicallyNormal, (path == mutated),
+        "isLexicallyNormal disagrees with normalization for \(input)")
+    }
+  }
+}

--- a/Tests/SystemTests/FilePathTests/FilePathSliceCodableTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathSliceCodableTest.swift
@@ -1,0 +1,206 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import XCTest
+import Foundation
+
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// Component and Root Codable. The wire format is the historical synthesized
+// shape over their old stored properties:
+//
+//   Component: { "_path": <FilePath>, "_range": [lower, upper] }
+//   Root:      { "_path": <FilePath>, "_rootEnd": N }
+//
+// The nested `_path` follows the ACTIVE backing, so under the SE-0529 backing it
+// additionally carries the `_v2` side channel. See FilePathConformances.swift for
+// why decoding must slice `_path`'s raw storage before normalizing, and why
+// decode needs no era switch while encode does.
+@available(System 0.0.2, *)
+final class FilePathSliceCodableTest: XCTestCase {
+
+  // MARK: - Wire shape
+
+  func testComponentWireShape() throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .sortedKeys
+    let c: FilePath.Component = "foo"
+    // ERA: the nested `_path` is whichever backing is active (see
+    // FilePathConformances.swift `_SlicePathPayload`). The historical backing
+    // emits `_storage` alone; `_StdlibFilePath` also emits the `_v2`
+    // forward-compat side channel carrying the now-significant trailing
+    // separator.
+    let expected = usingStdlibFilePath
+      ? #"{"_path":{"_storage":{"nullTerminatedStorage":[102,111,111,0]},"_v2":{"hasTrailingSeparator":false}},"_range":[0,3]}"#
+      : #"{"_path":{"_storage":{"nullTerminatedStorage":[102,111,111,0]}},"_range":[0,3]}"#
+    XCTAssertEqual(
+      String(decoding: try encoder.encode(c), as: UTF8.self),
+      expected
+    )
+  }
+
+#if !os(Windows)
+  func testRootWireShape() throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .sortedKeys
+    let r: FilePath.Root = "/"
+    // ERA: `Root` is a thin wrapper over whichever backing is active, so its
+    // `_path` sub-object is that backing's own Codable output. The historical
+    // backing emits `_storage` alone; `_StdlibFilePath` always also emits the
+    // `_v2` forward-compat side channel (see FilePathConformances.swift), which
+    // is what carries the now-significant trailing separator.
+    let expected = usingStdlibFilePath
+      ? #"{"_path":{"_storage":{"nullTerminatedStorage":[47,0]},"_v2":{"hasTrailingSeparator":false}},"_rootEnd":1}"#
+      : #"{"_path":{"_storage":{"nullTerminatedStorage":[47,0]}},"_rootEnd":1}"#
+    XCTAssertEqual(
+      String(decoding: try encoder.encode(r), as: UTF8.self),
+      expected
+    )
+  }
+#endif
+
+  // MARK: - Round trip
+
+  func testComponentRoundTrip() throws {
+    let components: [FilePath.Component] = [
+      "foo", "foo.txt", "foo.tar.gz", ".hidden", "a", ".", "..", "...",
+      "..bar", "\u{3042}",
+    ]
+    for c in components {
+      let data = try JSONEncoder().encode(c)
+      let back = try JSONDecoder().decode(FilePath.Component.self, from: data)
+      XCTAssertEqual(c, back)
+    }
+  }
+
+  func testRootRoundTrip() throws {
+    let r: FilePath.Root = "/"
+    let data = try JSONEncoder().encode(r)
+    let back = try JSONDecoder().decode(FilePath.Root.self, from: data)
+    XCTAssertEqual(r, back)
+  }
+
+  // MARK: - Decoding the old format
+
+  func testComponentDecodeOffsetsIntoUnnormalizedPath() throws {
+    // THE trap. Old swift-system's normalization touched separators only,
+    // never dots, so it stored "/./foo" verbatim and gave the "foo"
+    // component a _range of 3..<6. The copy normalizes "/./foo" to "/foo",
+    // where 3..<6 is out of bounds. Decoding _path as a FilePath and slicing
+    // after would read the wrong bytes; the raw storage has to be sliced
+    // first.
+    //
+    // / . / f o o \0
+    let json = #"""
+      {"_path":{"_storage":{"nullTerminatedStorage":[47,46,47,102,111,111,0]}},"_range":[3,6]}
+      """#
+    let c = try JSONDecoder().decode(
+      FilePath.Component.self, from: Data(json.utf8))
+    XCTAssertEqual(c, "foo")
+  }
+
+  func testComponentDecodeSlicesFromLongerPath() throws {
+    // Old always encoded the whole originating path, not just the component:
+    // "/usr/bin" with _range 5..<8 is the component "bin".
+    //
+    // / u s r / b i n \0
+    let json = #"""
+      {"_path":{"_storage":{"nullTerminatedStorage":[47,117,115,114,47,98,105,110,0]}},"_range":[5,8]}
+      """#
+    let c = try JSONDecoder().decode(
+      FilePath.Component.self, from: Data(json.utf8))
+    XCTAssertEqual(c, "bin")
+  }
+
+#if !os(Windows)
+  func testRootDecodeSlicesFromLongerPath() throws {
+    // "/usr/bin" with _rootEnd 1 is the root "/".
+    let json = #"""
+      {"_path":{"_storage":{"nullTerminatedStorage":[47,117,115,114,47,98,105,110,0]}},"_rootEnd":1}
+      """#
+    let r = try JSONDecoder().decode(FilePath.Root.self, from: Data(json.utf8))
+    XCTAssertEqual(r, "/")
+  }
+#endif
+
+  // MARK: - Rejections
+
+  func testComponentDecodeRejectsRangeSpanningSeparator() {
+    // "/usr/bin"[1..<8] is "usr/bin": two components, not one.
+    let json = #"""
+      {"_path":{"_storage":{"nullTerminatedStorage":[47,117,115,114,47,98,105,110,0]}},"_range":[1,8]}
+      """#
+    XCTAssertThrowsError(try JSONDecoder().decode(
+      FilePath.Component.self, from: Data(json.utf8)))
+  }
+
+  func testComponentDecodeRejectsOutOfBoundsRange() {
+    // endIndex excludes the null terminator, so 3 is the end of "foo".
+    let json = #"""
+      {"_path":{"_storage":{"nullTerminatedStorage":[102,111,111,0]}},"_range":[0,4]}
+      """#
+    XCTAssertThrowsError(try JSONDecoder().decode(
+      FilePath.Component.self, from: Data(json.utf8)))
+  }
+
+  func testComponentDecodeRejectsEmptyRange() {
+    let json = #"""
+      {"_path":{"_storage":{"nullTerminatedStorage":[102,111,111,0]}},"_range":[1,1]}
+      """#
+    XCTAssertThrowsError(try JSONDecoder().decode(
+      FilePath.Component.self, from: Data(json.utf8)))
+  }
+
+  // Root decode validation is SE-0529-only, so the next two tests are guarded
+  // rather than made backing-aware. swift-system got `Root`'s Codable
+  // synthesized off its stored `_path` / `_rootEnd` via the internal
+  // `_StrSlice: Codable` conformance (swift-system 8ac955b: no `init(from:)`
+  // anywhere in FilePathComponents.swift), so it validated nothing beyond what
+  // `_path` itself checked. Neither test existed pre-port. Under the
+  // swiftSystem backing these archives decode into `Root`s that violate the
+  // old type's own invariants, faithfully reproducing history, but there is
+  // no historical expectation to assert, so there is nothing to pin.
+
+  func testRootDecodeRejectsZeroRootEnd() throws {
+    try XCTSkipUnless(
+      usingStdlibFilePath,
+      "Root decode validation is SE-0529-only")
+    // Mirrors the old Root invariant `_rootEnd > _path._storage.startIndex`.
+    let json = #"""
+      {"_path":{"_storage":{"nullTerminatedStorage":[47,0]}},"_rootEnd":0}
+      """#
+    XCTAssertThrowsError(try JSONDecoder().decode(
+      FilePath.Root.self, from: Data(json.utf8)))
+  }
+
+  func testRootDecodeRejectsNonRoot() throws {
+    try XCTSkipUnless(
+      usingStdlibFilePath,
+      "Root decode validation is SE-0529-only")
+    // "foo"[0..<3] is a component, not a root.
+    let json = #"""
+      {"_path":{"_storage":{"nullTerminatedStorage":[102,111,111,0]}},"_rootEnd":3}
+      """#
+    XCTAssertThrowsError(try JSONDecoder().decode(
+      FilePath.Root.self, from: Data(json.utf8)))
+  }
+
+  func testSliceDecodeRejectsCorruptSystemString() {
+    // SystemString's own decoder still validates: interior NUL.
+    let json = #"""
+      {"_path":{"_storage":{"nullTerminatedStorage":[102,0,111,0]}},"_range":[0,1]}
+      """#
+    XCTAssertThrowsError(try JSONDecoder().decode(
+      FilePath.Component.self, from: Data(json.utf8)))
+  }
+}

--- a/Tests/SystemTests/FilePathTests/FilePathV2CodableTest.swift
+++ b/Tests/SystemTests/FilePathTests/FilePathV2CodableTest.swift
@@ -1,0 +1,148 @@
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import XCTest
+import Foundation
+
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// Coverage for the `_v2` forward-compat side channel on _StdlibFilePath Codable.
+// See FilePathConformances.swift for the contract.
+//
+// Exercises the SE-0529 core directly rather than through the wrapper, so it is
+// backing-independent: these expectations hold whichever backing is active.
+@available(System 0.0.2, *)
+final class FilePathV2CodableTest: XCTestCase {
+
+  // MARK: - Round trip (new -> new)
+
+  func testRoundTripPreservesTrailingSeparator() throws {
+    // The whole point: a trailing separator survives encode+decode.
+    let paths: [_StdlibFilePath] = [
+      "/tmp/foo/",
+      "foo/bar/",
+      "/a/",
+      "./",
+    ]
+    for path in paths {
+      XCTAssertTrue(
+        path.hasTrailingSeparator, "test precondition: \(path)")
+      let data = try JSONEncoder().encode(path)
+      let back = try JSONDecoder().decode(_StdlibFilePath.self, from: data)
+      XCTAssertEqual(path, back, "round trip: \(path)")
+      XCTAssertTrue(
+        back.hasTrailingSeparator, "trailing sep lost: \(path)")
+    }
+  }
+
+  func testRoundTripWithoutTrailingSeparator() throws {
+    let paths: [_StdlibFilePath] = ["/tmp/foo", "foo/bar", "/", "", "a"]
+    for path in paths {
+      let data = try JSONEncoder().encode(path)
+      let back = try JSONDecoder().decode(_StdlibFilePath.self, from: data)
+      XCTAssertEqual(path, back, "round trip: \(path)")
+    }
+  }
+
+  // MARK: - `_storage` stays old-normal (new -> old compatibility)
+
+  func testStorageIsStrippedForOldDecoders() throws {
+    // `_storage` must not carry the trailing separator, so an old decoder
+    // (which rejects non-normal storage) can still read it. We can't run the
+    // old decoder here, but we can assert the encoded `_storage` equals what
+    // the stripped path encodes, i.e. no trailing separator in `_storage`.
+    let path: _StdlibFilePath = "/tmp/foo/"
+    let stripped: _StdlibFilePath = "/tmp/foo"
+
+    let obj = try JSONSerialization.jsonObject(
+      with: try JSONEncoder().encode(path)) as! [String: Any]
+    let strippedObj = try JSONSerialization.jsonObject(
+      with: try JSONEncoder().encode(stripped)) as! [String: Any]
+
+    // `_storage` sub-object is byte-for-byte what the stripped path emits.
+    let storageJSON = try JSONSerialization.data(
+      withJSONObject: obj["_storage"]!, options: [.sortedKeys])
+    let strippedStorageJSON = try JSONSerialization.data(
+      withJSONObject: strippedObj["_storage"]!, options: [.sortedKeys])
+    XCTAssertEqual(storageJSON, strippedStorageJSON)
+  }
+
+  func testV2IsAlwaysEmitted() throws {
+    // Even a default (no trailing separator) path carries `_v2`.
+    for path in [_StdlibFilePath("/tmp/foo"), _StdlibFilePath("/tmp/foo/")] {
+      let obj = try JSONSerialization.jsonObject(
+        with: try JSONEncoder().encode(path)) as! [String: Any]
+      XCTAssertNotNil(obj["_v2"], "_v2 missing for \(path)")
+      let v2 = obj["_v2"] as! [String: Any]
+      XCTAssertNotNil(
+        v2["hasTrailingSeparator"],
+        "hasTrailingSeparator missing for \(path)")
+    }
+  }
+
+  func testV2FlagMatchesTrailingSeparator() throws {
+    let cases: [(_StdlibFilePath, Bool)] = [
+      ("/tmp/foo/", true),
+      ("/tmp/foo", false),
+      ("foo/", true),
+      ("foo", false),
+      ("/", false),
+    ]
+    for (path, expected) in cases {
+      let obj = try JSONSerialization.jsonObject(
+        with: try JSONEncoder().encode(path)) as! [String: Any]
+      let v2 = obj["_v2"] as! [String: Any]
+      XCTAssertEqual(
+        v2["hasTrailingSeparator"] as? Bool, expected,
+        "flag wrong for \(path)")
+    }
+  }
+
+  // MARK: - Decoding old / v1 archives (no `_v2`)
+
+  func testDecodeWithoutV2DefaultsToNoTrailingSeparator() throws {
+    // An archive with only `_storage` (old / v1) must decode, defaulting the
+    // trailing separator off. `/tmp/foo` in old-normal bytes.
+    //
+    // / t m p / f o o \0
+    let json = #"""
+      {"_storage":{"nullTerminatedStorage":[47,116,109,112,47,102,111,111,0]}}
+      """#
+    let path = try JSONDecoder().decode(
+      _StdlibFilePath.self, from: Data(json.utf8))
+    XCTAssertEqual(path, "/tmp/foo")
+    XCTAssertFalse(path.hasTrailingSeparator)
+  }
+
+  func testDecodeWithEmptyV2DefaultsFields() throws {
+    // `_v2` present but empty: append-only contract says default every field.
+    let json = #"""
+      {"_storage":{"nullTerminatedStorage":[47,116,109,112,47,102,111,111,0]},"_v2":{}}
+      """#
+    let path = try JSONDecoder().decode(
+      _StdlibFilePath.self, from: Data(json.utf8))
+    XCTAssertEqual(path, "/tmp/foo")
+    XCTAssertFalse(path.hasTrailingSeparator)
+  }
+
+  func testDecodeWithUnknownV2FieldIsIgnored() throws {
+    // A future field this version doesn't know is ignored, not fatal.
+    let json = #"""
+      {"_storage":{"nullTerminatedStorage":[47,116,109,112,0]},"_v2":{"hasTrailingSeparator":true,"somethingNewer":42}}
+      """#
+    let path = try JSONDecoder().decode(
+      _StdlibFilePath.self, from: Data(json.utf8))
+    XCTAssertEqual(path, "/tmp/")
+    XCTAssertTrue(path.hasTrailingSeparator)
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/AllTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/AllTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SystemTests/StdlibFilePathTests/AllTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/AllTests.swift
@@ -1,0 +1,33 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// These suites historically ran under `@Suite(.serialized)` so the runner
+// never interleaved tests that mutated a shared mutable platform global.
+// That global is gone — platform selection is now compile-time
+// (see FilePathParsing.swift `_isWindows` / `_isDarwin` / `_isLinux`,
+// and TestSupport.swift `_builtPlatform`) — so serialization is no
+// longer strictly required. Kept as harmless and to preserve a stable
+// run order.
+@Suite(.serialized)
+struct AllTests {
+  struct DecompositionTests {}
+  struct ComponentViewTests {}
+  struct ValidationTests {}
+  // New coverage (see TestSupport.swift for the framework/platform seam).
+  struct EqualityTests {}
+  struct StringBridgingTests {}
+  struct ReconstructionTests {}
+}

--- a/Tests/SystemTests/StdlibFilePathTests/AllTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/AllTests.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,19 +14,15 @@ import Testing
 @testable import System
 #endif
 
-// These suites historically ran under `@Suite(.serialized)` so the runner
-// never interleaved tests that mutated a shared mutable platform global.
-// That global is gone — platform selection is now compile-time
-// (see FilePathParsing.swift `_isWindows` / `_isDarwin` / `_isLinux`,
-// and TestSupport.swift `_builtPlatform`) — so serialization is no
-// longer strictly required. Kept as harmless and to preserve a stable
-// run order.
+// `.serialized` fixes the run order across the nested suites. Nothing here
+// shares mutable state to protect: the platform is selected at compile time
+// (`_isWindows` / `_isDarwin` / `_isLinux` in FilePathParsing.swift,
+// `_builtPlatform` in TestSupport.swift).
 @Suite(.serialized)
 struct AllTests {
   struct DecompositionTests {}
   struct ComponentViewTests {}
   struct ValidationTests {}
-  // New coverage (see TestSupport.swift for the framework/platform seam).
   struct EqualityTests {}
   struct StringBridgingTests {}
   struct ReconstructionTests {}

--- a/Tests/SystemTests/StdlibFilePathTests/ComponentViewTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ComponentViewTests.swift
@@ -1,0 +1,1428 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// Migrated onto the TestSupport seam: assertions go through the `expect*`
+// helpers and platform-specific bodies are wrapped in
+// `withPlatform(.windows)` / `withPlatform(.darwin)`. Platform-INDEPENDENT
+// tests assert through `universal(...)` (TestSupport.swift), which spells an
+// expected path in the built platform's separator, so each runs unchanged on
+// whatever platform is built.
+
+extension AllTests.ComponentViewTests {
+
+  // MARK: - Basic collection properties
+
+  @Test
+  func emptyPath() {
+    let path = _StdlibFilePath("")
+    expectTrue(path.components.isEmpty)
+    expectEqual(path.components.count, 0)
+    expectEqual(path.components.startIndex, path.components.endIndex)
+  }
+
+  @Test
+  func rootOnlyHasNoComponents() {
+    let root = _StdlibFilePath("/")
+    expectTrue(root.components.isEmpty)
+    expectNotNil(root.anchor)
+  }
+
+  @Test
+  func rootOnlyHasNoComponentsWindows() {
+    withPlatform(.windows) {
+      let winRoot = _StdlibFilePath(#"C:\"#)
+      expectTrue(winRoot.components.isEmpty)
+      expectNotNil(winRoot.anchor)
+    }
+  }
+
+  @Test
+  func indexTraversal() {
+    let path = _StdlibFilePath("/usr/local/bin")
+    let cv = path.components
+    expectEqual(cv.count, 3)
+
+    var idx = cv.startIndex
+    expectEqual(cv[idx].description, "usr")
+    idx = cv.index(after: idx)
+    expectEqual(cv[idx].description, "local")
+    idx = cv.index(after: idx)
+    expectEqual(cv[idx].description, "bin")
+    idx = cv.index(after: idx)
+    expectEqual(idx, cv.endIndex)
+
+    // Reverse traversal
+    idx = cv.index(before: cv.endIndex)
+    expectEqual(cv[idx].description, "bin")
+    idx = cv.index(before: idx)
+    expectEqual(cv[idx].description, "local")
+  }
+
+  // MARK: - append
+
+  @Test
+  func appendToRelative() {
+    var path = _StdlibFilePath("a/b")
+    path.components.append("c")
+
+    expectEqual(path.description, universal("a/b/c"))
+    expectEqual(path.components.map(\.description), ["a", "b", "c"])
+  }
+
+  @Test
+  func appendToAbsolute() {
+    var path = _StdlibFilePath("/usr")
+    path.components.append("local")
+
+    expectEqual(path.description, universal("/usr/local"))
+    expectEqual(path.anchor?.description, universal("/"))
+  }
+
+  @Test
+  func appendToEmpty() {
+    var path = _StdlibFilePath("")
+    path.components.append("hello")
+
+    expectEqual(path.description, "hello")
+  }
+
+  @Test
+  func appendToRootOnly() {
+    var path = _StdlibFilePath("/")
+    path.components.append("usr")
+
+    expectEqual(path.description, universal("/usr"))
+    expectEqual(path.anchor?.description, universal("/"))
+  }
+
+  @Test
+  func appendContentsOf() {
+    var path = _StdlibFilePath("/usr")
+    path.components.append(contentsOf: ["local", "bin"] as [_StdlibFilePath.Component])
+
+    expectEqual(path.description, universal("/usr/local/bin"))
+  }
+
+  // MARK: - insert
+
+  @Test
+  func insertAtBeginning() {
+    var path = _StdlibFilePath("/local/bin")
+    path.components.insert("usr", at: path.components.idx(0))
+
+    expectEqual(path.description, universal("/usr/local/bin"))
+  }
+
+  @Test
+  func insertInMiddle() {
+    var path = _StdlibFilePath("/usr/bin")
+    path.components.insert("local", at: path.components.idx(1))
+
+    expectEqual(path.description, universal("/usr/local/bin"))
+  }
+
+  @Test
+  func insertAtEnd() {
+    var path = _StdlibFilePath("/usr/local")
+    path.components.insert("bin", at: path.components.endIndex)
+
+    expectEqual(path.description, universal("/usr/local/bin"))
+  }
+
+  // MARK: - remove
+
+  @Test
+  func removeFirst() {
+    var path = _StdlibFilePath("/usr/local/bin")
+    path.components.removeFirst()
+
+    expectEqual(path.description, universal("/local/bin"))
+    expectEqual(path.anchor?.description, universal("/"))
+  }
+
+  @Test
+  func removeLast() {
+    var path = _StdlibFilePath("/usr/local/bin")
+    path.components.removeLast()
+
+    expectEqual(path.description, universal("/usr/local"))
+  }
+
+  @Test
+  func removeAtIndex() {
+    var path = _StdlibFilePath("/usr/local/bin")
+    path.components.remove(at: path.components.idx(1))
+
+    expectEqual(path.description, universal("/usr/bin"))
+  }
+
+  @Test
+  func removeAllComponents() {
+    var path = _StdlibFilePath("/usr/local")
+    var cv = path.components
+    cv.removeAll()
+    path.components = cv
+
+    // Anchor is preserved, components are gone
+    expectEqual(path.description, universal("/"))
+    expectEqual(path.anchor?.description, universal("/"))
+    expectTrue(path.components.isEmpty)
+  }
+
+  @Test
+  func removeAllFromRelative() {
+    var path = _StdlibFilePath("a/b/c")
+    path.components.removeAll()
+
+    expectEqual(path.description, "")
+    expectTrue(path.isEmpty)
+  }
+
+  // MARK: - replaceSubrange
+
+  @Test
+  func replaceMiddle() {
+    var path = _StdlibFilePath("/usr/local/bin")
+    path.components.replaceSubrange(
+      path.components.range(1..<2),
+      with: ["share", "man"] as [_StdlibFilePath.Component])
+
+    expectEqual(path.description, universal("/usr/share/man/bin"))
+  }
+
+  @Test
+  func replaceAll() {
+    var path = _StdlibFilePath("/old/path")
+    path.components.replaceSubrange(
+      path.components.startIndex..<path.components.endIndex,
+      with: ["new", "path"] as [_StdlibFilePath.Component])
+
+    expectEqual(path.description, universal("/new/path"))
+    expectEqual(path.anchor?.description, universal("/"))
+  }
+
+  @Test
+  func replaceWithEmpty() {
+    var path = _StdlibFilePath("/usr/local/bin")
+    path.components.replaceSubrange(
+      path.components.range(1..<3), with: [] as [_StdlibFilePath.Component])
+
+    expectEqual(path.description, universal("/usr"))
+  }
+
+  @Test
+  func replaceEmptyRange() {
+    var path = _StdlibFilePath("/usr/bin")
+    path.components.replaceSubrange(
+      path.components.range(1..<1),
+      with: ["local"] as [_StdlibFilePath.Component])
+
+    expectEqual(path.description, universal("/usr/local/bin"))
+  }
+
+  // MARK: - Normalization interactions
+
+  @Test
+  func dotComponentInsertion() {
+    // Component.init normalizes through _StdlibFilePath, so "." as a
+    // single component is `.currentDirectory` kind
+    let dot: _StdlibFilePath.Component = "."
+    expectEqual(dot.kind, .currentDirectory)
+
+    let dotdot: _StdlibFilePath.Component = ".."
+    expectEqual(dotdot.kind, .parentDirectory)
+  }
+
+  @Test
+  func appendDotDot() {
+    var path = _StdlibFilePath("/usr/local")
+    var cv = path.components
+    cv.append("..")
+    path.components = cv
+
+    // ".." is preserved as a component (no lexical collapsing)
+    expectEqual(path.components.map(\.description), ["usr", "local", ".."])
+    expectEqual(path.description, universal("/usr/local/.."))
+  }
+
+  @Test
+  func appendDotToRelative() {
+    // With the view-on-storage architecture, appending a "." component
+    // directly mutates storage without renormalization. The dot persists.
+    var path = _StdlibFilePath("a/b")
+    path.components.append(".")
+
+    expectEqual(path.components.map(\.description), ["a", "b", "."])
+    expectEqual(path.description, universal("a/b/."))
+  }
+
+  @Test
+  func componentInitNormalizesInput() {
+    // Component.init?(_:) goes through _StdlibFilePath, which normalizes.
+    // So Component("a//b") is nil (normalizes to multi-component path)
+    let str1: String = "a//b"
+    let multiComp: _StdlibFilePath.Component? = .init(str1)
+    expectNil(multiComp)
+    let str2: String = "a/b"
+    let withSlash: _StdlibFilePath.Component? = .init(str2)
+    expectNil(withSlash)
+    let str3: String = "/"
+    let rootOnly: _StdlibFilePath.Component? = .init(str3)
+    expectNil(rootOnly)
+    let str4: String = ""
+    let empty: _StdlibFilePath.Component? = .init(str4)
+    expectNil(empty)
+    let str5: String = "hello"
+    let valid: _StdlibFilePath.Component? = .init(str5)
+    expectNotNil(valid)
+    expectEqual(valid?.description, "hello")
+  }
+
+  // MARK: - Windows platform
+
+  @Test
+  func windowsAppend() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"C:\Users"#)
+      path.components.append("Admin")
+
+      expectEqual(path.description, #"C:\Users\Admin"#)
+      expectEqual(path.anchor?.description, #"C:\"#)
+    }
+  }
+
+  @Test
+  func windowsDriveRelativeAppend() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath("C:src")
+      var cv = path.components
+      cv.append("main.swift")
+      path.components = cv
+
+      // C: anchor (no backslash) — components follow directly
+      expectEqual(path.description, #"C:src\main.swift"#)
+      expectEqual(path.anchor?.description, "C:")
+    }
+  }
+
+  @Test
+  func windowsRemoveComponent() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"C:\Users\Admin\file.txt"#)
+      path.components.removeLast()
+
+      expectEqual(path.description, #"C:\Users\Admin"#)
+    }
+  }
+
+  @Test
+  func windowsUNCAppend() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\server\share"#)
+      path.components.append("folder")
+
+      expectEqual(path.description, #"\\server\share\folder"#)
+    }
+  }
+
+  @Test
+  func windowsReplaceComponents() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"C:\old\stuff"#)
+      path.components.replaceSubrange(
+        path.components.startIndex..<path.components.endIndex,
+        with: ["new", "things"] as [_StdlibFilePath.Component])
+
+      expectEqual(path.description, #"C:\new\things"#)
+    }
+  }
+
+  // MARK: - Anchor preservation
+
+  @Test
+  func anchorSurvivesMutation() {
+    var path = _StdlibFilePath("/usr/local/bin")
+    let originalAnchor = path.anchor
+
+    var cv = path.components
+    cv.removeAll()
+    cv.append("etc")
+    path.components = cv
+
+    expectEqual(path.anchor, originalAnchor)
+    expectEqual(path.description, universal("/etc"))
+  }
+
+  @Test
+  func noAnchorSurvivesMutation() {
+    var path = _StdlibFilePath("a/b/c")
+
+    var cv = path.components
+    cv.replaceSubrange(cv.startIndex..<cv.endIndex, with: ["x", "y"] as [_StdlibFilePath.Component])
+    path.components = cv
+
+    expectNil(path.anchor)
+    expectEqual(path.description, universal("x/y"))
+  }
+
+  @Test
+  func windowsAnchorSurvivesMutation() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\server\share\old\path"#)
+      let originalAnchor = path.anchor
+
+      var cv = path.components
+      cv.removeAll()
+      cv.append("new")
+      path.components = cv
+
+      expectEqual(path.anchor, originalAnchor)
+      expectEqual(path.description, #"\\server\share\new"#)
+    }
+  }
+
+  // MARK: - Hashable / Equatable
+
+  @Test
+  func componentViewEquality() {
+    let a = _StdlibFilePath("/usr/local/bin")
+    let b = _StdlibFilePath("/usr/local/bin")
+    expectEqual(a.components, b.components)
+
+    let c = _StdlibFilePath("/usr/local")
+    expectNotEqual(a.components, c.components)
+  }
+
+  @Test
+  func componentViewOrdering() {
+    let a = _StdlibFilePath("a/b").components
+    let b = _StdlibFilePath("a/c").components
+    let c = _StdlibFilePath("a/b/c").components
+    expectTrue(a < b)
+    expectTrue(a < c) // prefix is less
+  }
+
+  // MARK: - Derived Collection operations
+
+  @Test
+  func filter() {
+    let path = _StdlibFilePath("a/b/c/d")
+    let even = path.components.enumerated()
+      .filter { $0.offset % 2 == 0 }
+      .map(\.element)
+    expectEqual(even.map(\.description), ["a", "c"])
+  }
+
+  @Test
+  func map() {
+    let path = _StdlibFilePath("/usr/local/bin")
+    let names = path.components.map(\.description)
+    expectEqual(names, ["usr", "local", "bin"])
+  }
+
+  @Test
+  func reversed() {
+    let path = _StdlibFilePath("a/b/c")
+    let rev = path.components.reversed().map(\.description)
+    expectEqual(rev, ["c", "b", "a"])
+  }
+
+  @Test
+  func prefix() {
+    var path = _StdlibFilePath("/usr/local/bin/tool")
+    let first2 = Array(path.components.prefix(2))
+    path.components.replaceSubrange(
+      path.components.startIndex..<path.components.endIndex, with: first2)
+
+    expectEqual(path.description, universal("/usr/local"))
+  }
+
+  @Test
+  func dropFirst() {
+    var path = _StdlibFilePath("/usr/local/bin")
+    let tail = Array(path.components.dropFirst())
+    path.components.replaceSubrange(
+      path.components.startIndex..<path.components.endIndex, with: tail)
+
+    expectEqual(path.description, universal("/local/bin"))
+  }
+
+  // MARK: - Round-trip through ComponentView init()
+
+  @Test
+  func buildFromScratch() {
+    var cv = _StdlibFilePath.ComponentView()
+    cv.append("usr")
+    cv.append("local")
+    cv.append("bin")
+
+    var path = _StdlibFilePath("/")
+    path.components = cv
+    expectEqual(path.description, universal("/usr/local/bin"))
+  }
+
+  @Test
+  func buildRelativeFromScratch() {
+    var cv = _StdlibFilePath.ComponentView()
+    cv.append("src")
+    cv.append("main.swift")
+
+    var path = _StdlibFilePath()
+    path.components = cv
+    expectEqual(path.description, universal("src/main.swift"))
+  }
+
+  @Test
+  func windowsBuildFromScratch() {
+    withPlatform(.windows) {
+      var cv = _StdlibFilePath.ComponentView()
+      cv.append("Users")
+      cv.append("Admin")
+      cv.append("Documents")
+
+      var path = _StdlibFilePath(#"C:\"#)
+      path.components = cv
+      expectEqual(path.description, #"C:\Users\Admin\Documents"#)
+    }
+  }
+
+  // MARK: - Edge cases
+
+  @Test
+  func singleComponentPath() {
+    var path = _StdlibFilePath("hello")
+    expectEqual(path.components.count, 1)
+    expectEqual(path.components.first?.description, "hello")
+
+    path.components.removeLast()
+    expectTrue(path.isEmpty)
+  }
+
+  @Test
+  func multipleAppends() {
+    var path = _StdlibFilePath("/")
+
+    for name: String in ["a", "b", "c", "d", "e"] {
+      path.components.append(_StdlibFilePath.Component(name)!)
+    }
+
+    expectEqual(path.components.count, 5)
+    expectEqual(path.description, universal("/a/b/c/d/e"))
+  }
+
+  @Test
+  func replaceEntireRelativeKeepsAnchor() {
+    var path = _StdlibFilePath("/old/path/here")
+    let anchor = path.anchor
+
+    path.components.replaceSubrange(
+      path.components.startIndex..<path.components.endIndex, with: [
+        "completely" as _StdlibFilePath.Component,
+        "new" as _StdlibFilePath.Component,
+      ])
+
+    expectEqual(path.anchor, anchor)
+    expectEqual(path.components.map(\.description), ["completely", "new"])
+  }
+
+  // MARK: - Suffix semantics on mutation
+
+  // -- Trailing separator: strip on remove/replace --
+
+  @Test
+  func trailingSepStrippedOnRemoveLast() {
+    var path = _StdlibFilePath("a/b/c/")
+    expectTrue(path.hasTrailingSeparator)
+
+    path.components.removeLast()
+
+    expectFalse(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("a/b"))
+  }
+
+  @Test
+  func trailingSepStrippedOnReplaceLast() {
+    var path = _StdlibFilePath("a/b/c/")
+    expectTrue(path.hasTrailingSeparator)
+
+    path.components.replaceSubrange(
+      path.components.index(before: path.components.endIndex) ..< path.components.endIndex,
+      with: ["d" as _StdlibFilePath.Component])
+
+    expectFalse(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("a/b/d"))
+  }
+
+  @Test
+  func trailingSepStrippedOnRemoveAll() {
+    var path = _StdlibFilePath("a/b/c/")
+    expectTrue(path.hasTrailingSeparator)
+
+    path.components.removeAll()
+
+    expectFalse(path.hasTrailingSeparator)
+    expectEqual(path.description, "")
+  }
+
+  @Test
+  func trailingSepStrippedOnRemoveAllAbsolute() {
+    var path = _StdlibFilePath("/a/b/c/")
+    expectTrue(path.hasTrailingSeparator)
+
+    path.components.removeAll()
+
+    expectFalse(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("/"))
+  }
+
+  @Test
+  func windowsTrailingSepStrippedOnRemoveLast() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"C:\Users\Admin\"#)
+      expectTrue(path.hasTrailingSeparator)
+
+      path.components.removeLast()
+
+      expectFalse(path.hasTrailingSeparator)
+      expectEqual(path.description, #"C:\Users"#)
+    }
+  }
+
+  // -- Trailing separator: preserve when last unchanged --
+
+  @Test
+  func trailingSepPreservedOnInsertFirst() {
+    var path = _StdlibFilePath("a/b/c/")
+    expectTrue(path.hasTrailingSeparator)
+
+    path.components.insert("z", at: path.components.idx(0))
+
+    expectTrue(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("z/a/b/c/"))
+  }
+
+  @Test
+  func trailingSepPreservedOnReplaceNonLast() {
+    var path = _StdlibFilePath("a/b/c/")
+
+    path.components.replaceSubrange(
+      path.components.range(0..<1),
+      with: ["x" as _StdlibFilePath.Component])
+
+    expectTrue(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("x/b/c/"))
+  }
+
+  @Test
+  func trailingSepPreservedOnRemoveFirst() {
+    var path = _StdlibFilePath("a/b/c/")
+
+    path.components.removeFirst()
+
+    expectTrue(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("b/c/"))
+  }
+
+  @Test
+  func trailingSepPreservedOnInsertMiddle() {
+    var path = _StdlibFilePath("/a/c/")
+
+    path.components.insert("b", at: path.components.idx(1))
+
+    expectTrue(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("/a/b/c/"))
+  }
+
+  @Test
+  func trailingSepPreservedOnNoChange() {
+    var path = _StdlibFilePath("a/b/c/")
+    let cv = path.components
+    path.components = cv
+
+    expectTrue(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("a/b/c/"))
+  }
+
+  @Test
+  func trailingSepPreservedEmptyToEmpty() {
+    // \\server\share\ decomposes with empty components and
+    // trailing sep. Setting empty components back preserves it.
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\server\share\"#)
+      expectTrue(path.hasTrailingSeparator)
+      expectTrue(path.components.isEmpty)
+
+      let cv = path.components
+      path.components = cv
+
+      expectTrue(path.hasTrailingSeparator)
+    }
+  }
+
+  // -- Trailing separator: strip on append --
+
+  @Test
+  func trailingSepOnAppend() {
+    var path = _StdlibFilePath("a/b/")
+    expectTrue(path.hasTrailingSeparator)
+
+    path.components.append("c")
+
+    expectFalse(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("a/b/c"))
+  }
+
+  @Test
+  func trailingSepOnAppendContentsOf() {
+    var path = _StdlibFilePath("/dir/")
+    expectTrue(path.hasTrailingSeparator)
+
+    path.components.append(contentsOf: ["sub", "file"] as [_StdlibFilePath.Component])
+
+    expectFalse(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("/dir/sub/file"))
+  }
+
+  // -- Resource fork: strip on remove/replace (Darwin) --
+
+  @Test
+  func resourceForkStrippedOnRemoveLast() {
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/dir/file/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+      expectEqual(path.components.map(\.description), ["dir", "file"])
+
+      path.components.removeLast()
+
+      expectFalse(path.isResourceFork)
+      expectEqual(path.description, "/dir")
+    }
+  }
+
+  @Test
+  func resourceForkStrippedOnReplaceLast() {
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/file/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+      expectEqual(path.components.map(\.description), ["file"])
+
+      path.components.replaceSubrange(
+        path.components.range(0..<1),
+        with: ["other" as _StdlibFilePath.Component])
+
+      expectFalse(path.isResourceFork)
+      expectEqual(path.description, "/other")
+    }
+  }
+
+  @Test
+  func resourceForkStrippedOnRemoveAll() {
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/file/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+
+      path.components.removeAll()
+
+      expectFalse(path.isResourceFork)
+      expectEqual(path.description, "/")
+    }
+  }
+
+  // -- Resource fork: preserve when last unchanged --
+
+  @Test
+  func resourceForkPreservedOnInsert() {
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/file/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+      expectEqual(path.components.map(\.description), ["file"])
+
+      path.components.insert("dir", at: path.components.idx(0))
+
+      expectTrue(path.isResourceFork)
+      expectEqual(path.components.map(\.description), ["dir", "file"])
+    }
+  }
+
+  @Test
+  func resourceForkPreservedOnNoChange() {
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/file/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+
+      let cv = path.components
+      path.components = cv
+
+      expectTrue(path.isResourceFork)
+    }
+  }
+
+  // -- Resource fork: strip on append --
+
+  @Test
+  func resourceForkOnAppend() {
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/file/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+
+      path.components.append("extra")
+
+      expectFalse(path.isResourceFork)
+      expectEqual(path.description, "/file/extra")
+    }
+  }
+
+  // MARK: - Re-decomposition after component mutation
+  //
+  // When a component mutation produces a string that re-parses to a
+  // different decomposition (e.g. inserting `.nofollow` at the front
+  // of an absolute Darwin path causes anchor absorption), we honor
+  // the new decomposition rather than masking it. The string IS what
+  // the kernel sees; pretending otherwise would be a lie.
+
+  // MARK: - Structural suffix rule corner cases
+
+  @Test
+  func trailingSepStrippedOnRemoveLastEvenWithEqualNeighbor() {
+    var path = _StdlibFilePath("/a/b/b/")
+    path.components.removeLast()
+    expectFalse(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("/a/b"))
+  }
+
+  @Test
+  func replaceAllDropsSuffixEvenWhenLastByteEqual() {
+    var path = _StdlibFilePath("/a/b/c/")
+    path.components.replaceSubrange(
+      path.components.startIndex..<path.components.endIndex,
+      with: ["x", "y", "c"] as [_StdlibFilePath.Component])
+    expectFalse(path.hasTrailingSeparator)
+    expectEqual(path.description, universal("/x/y/c"))
+  }
+
+  @Test
+  func removeAllOnUNCDropsGapSeparator() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\server\share\"#)
+      expectTrue(path.hasTrailingSeparator)
+      path.components.removeAll()
+      expectFalse(path.hasTrailingSeparator)
+      expectEqual(path.description, #"\\server\share"#)
+    }
+  }
+
+  // MARK: - removeAll across all anchor shapes
+  //
+  // The view region for removeAll extends from anchor-end (before any gap
+  // separator) to end-of-storage. These cases exercise the four anchor
+  // shapes: anchor-includes-trailing-sep, anchor-ends-with-`:`, anchor-
+  // with-gap-sep, and verbatim variants of the same.
+
+  @Test
+  func removeAllUNCWithComponentsDropsGapSep() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\server\share\foo\bar"#)
+      expectEqual(path.components.map(\.description), ["foo", "bar"])
+      path.components.removeAll()
+      expectEqual(path.description, #"\\server\share"#)
+      expectFalse(path.hasTrailingSeparator)
+    }
+  }
+
+  @Test
+  func removeAllDriveAbsoluteKeepsAnchorSep() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"C:\foo\bar"#)
+      path.components.removeAll()
+      expectEqual(path.description, #"C:\"#)
+    }
+  }
+
+  @Test
+  func removeAllDriveRelativeKeepsColon() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"C:foo\bar"#)
+      path.components.removeAll()
+      expectEqual(path.description, "C:")
+    }
+  }
+
+  @Test
+  func removeAllVerbatimDriveKeepsAnchor() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\?\C:\foo\bar"#)
+      path.components.removeAll()
+      expectEqual(path.description, #"\\?\C:\"#)
+    }
+  }
+
+  @Test
+  func removeAllVerbatimUNCDropsGapSep() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\?\UNC\server\share\foo"#)
+      path.components.removeAll()
+      expectEqual(path.description, #"\\?\UNC\server\share"#)
+    }
+  }
+
+  @Test
+  func removeAllVerbatimDeviceDropsGapSep() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\?\name\foo"#)
+      path.components.removeAll()
+      expectEqual(path.description, #"\\?\name"#)
+    }
+  }
+
+  // MARK: - Colon-ending anchors: Windows drive-relative vs Darwin volfs
+  //
+  // The `:` IS the anchor/component boundary only on Windows
+  // (drive-relative `C:foo`). On Darwin, `:` is a regular byte that can
+  // appear in a volfs FILEID, so an anchor ending in `:` still needs a
+  // gap separator before any component bytes.
+
+  @Test
+  func windowsDriveRelativeAppendStaysDriveRelative() {
+    // Appending to `C:` must yield `C:foo`, NOT `C:\foo` (which would
+    // be drive-absolute, a different anchor shape).
+    withPlatform(.windows) {
+      var path = _StdlibFilePath("C:")
+      expectEqual(path.anchor?.description, "C:")
+      path.components.append("foo")
+      expectEqual(path.description, "C:foo")
+      expectEqual(path.anchor?.description, "C:")
+      expectEqual(path.components.map(\.description), ["foo"])
+    }
+  }
+
+  @Test
+  func windowsDriveRelativeMultiAppendStaysDriveRelative() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath("C:")
+      path.components.append("foo")
+      path.components.append("bar")
+      expectEqual(path.description, #"C:foo\bar"#)
+      expectEqual(path.anchor?.description, "C:")
+    }
+  }
+
+  @Test
+  func windowsDriveRelativeAssignKeepsAnchor() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath("C:")
+      var cv = _StdlibFilePath.ComponentView()
+      cv.append("foo")
+      path.components = cv
+      expectEqual(path.description, "C:foo")
+      expectEqual(path.anchor?.description, "C:")
+    }
+  }
+
+  @Test
+  func darwinVolfsColonInFileIdGetsGapSeparator() {
+    // Darwin volfs FILEID is "bytes up to next /". A FILEID ending in
+    // `:` is degenerate but legal. Adding a component must add a gap
+    // separator — the `:`-skips-gap-sep rule is Windows-specific.
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/.vol/12345/67890:")
+      expectEqual(path.anchor?.description, "/.vol/12345/67890:")
+      path.components.append("foo")
+      expectEqual(path.description, "/.vol/12345/67890:/foo")
+      expectEqual(path.anchor?.description, "/.vol/12345/67890:")
+      expectEqual(path.components.map(\.description), ["foo"])
+    }
+  }
+
+  @Test
+  func darwinVolfsColonAssignKeepsAnchor() {
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/.vol/12345/67890:")
+      var cv = _StdlibFilePath.ComponentView()
+      cv.append("foo")
+      path.components = cv
+      expectEqual(path.description, "/.vol/12345/67890:/foo")
+      expectEqual(path.anchor?.description, "/.vol/12345/67890:")
+    }
+  }
+
+  @Test
+  func windowsUNCWithColonShareGetsGapSeparator() {
+    // The UNC parser allows `:` in share names: `\\server\C:` parses
+    // as anchor `\\server\C:` (length 11), NOT drive-relative. The
+    // gap separator must be added on append.
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\server\C:"#)
+      expectEqual(path.anchor?.description, #"\\server\C:"#)
+      path.components.append("foo")
+      expectEqual(path.description, #"\\server\C:\foo"#)
+      expectEqual(path.anchor?.description, #"\\server\C:"#)
+    }
+  }
+
+  @Test
+  func windowsUNCWithColonShareAssignKeepsGap() {
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\server\C:"#)
+      var cv = _StdlibFilePath.ComponentView()
+      cv.append("foo")
+      path.components = cv
+      expectEqual(path.description, #"\\server\C:\foo"#)
+    }
+  }
+
+  // MARK: - Suffix interactions with splice
+
+  @Test
+  func appendAfterTrailingSepAbsorbs() {
+    var path = _StdlibFilePath("/foo/")
+    expectTrue(path.hasTrailingSeparator)
+    path.components.append("bar")
+    expectEqual(path.description, universal("/foo/bar"))
+    expectFalse(path.hasTrailingSeparator)
+  }
+
+  @Test
+  func replaceSubrangeLastWithEmptyMatchesRemoveLast() {
+    var path = _StdlibFilePath("/a/b/c")
+    let last = path.components.index(before: path.components.endIndex)
+    path.components.replaceSubrange(last..<path.components.endIndex, with: [])
+    expectEqual(path.description, universal("/a/b"))
+  }
+
+  @Test
+  func insertInteriorPreservesResourceFork() {
+    // Insert in the MIDDLE of a multi-component path that has a
+    // resource fork suffix. Middle insert is not touchesEnd, so the
+    // suffix region is untouched.
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/foo/bar/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+      expectEqual(path.components.map(\.description), ["foo", "bar"])
+      let afterFoo = path.components.index(after: path.components.startIndex)
+      path.components.insert("x", at: afterFoo)
+      expectEqual(path.description, "/foo/x/bar/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+      expectEqual(path.components.map(\.description), ["foo", "x", "bar"])
+    }
+  }
+
+  // MARK: - Cross-anchor assignment
+  //
+  // Property assignment splices newValue's contributed bytes
+  // (`[_originalStart, _suffixEnd)`) into self's post-anchor region.
+  // Self's anchor stays put; the new contribution becomes the
+  // components+suffix.
+
+  @Test
+  func assignDifferentAnchorCvKeepsSelfAnchor() {
+    // cv from a path with a different anchor. Only cv's components
+    // (the bytes after cv's original anchor) get spliced; self's
+    // anchor is preserved.
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\foo"#)
+      let cv = _StdlibFilePath(#"C:\bar"#).components
+      path.components = cv
+      expectEqual(path.description, #"\bar"#)
+    }
+  }
+
+  @Test
+  func assignAnchoredCvOntoAnchorlessKeepsAnchorless() {
+    // cv has anchor, self doesn't. Splice copies only cv's component
+    // bytes; self stays anchorless.
+    var path = _StdlibFilePath("a/b")
+    let cv = _StdlibFilePath("/foo").components
+    path.components = cv
+    expectEqual(path.description, "foo")
+  }
+
+  @Test
+  func absorptionThenAssignMatchesInPlace() {
+    // cv mutated to trigger anchor absorption, then assigned back.
+    // The splice uses cv's _originalStart (immutable since view
+    // creation), so the absorbed bytes are part of the spliced region.
+    // Result must match in-place mutation.
+    withPlatform(.darwin) {
+
+      var inPlace = _StdlibFilePath("/foo/bar")
+      inPlace.components.insert(".nofollow", at: inPlace.components.startIndex)
+      expectEqual(inPlace.description, "/.nofollow/foo/bar")
+
+      var assigned = _StdlibFilePath("/foo/bar")
+      var cv = assigned.components
+      cv.insert(".nofollow", at: cv.startIndex)
+      assigned.components = cv
+
+      expectEqual(assigned.description, inPlace.description)
+    }
+  }
+
+  // -- Darwin anchor hazards --
+
+  @Test
+  func darwinInsertNofollowAtFront() {
+    // /foo/bar -> insert ".nofollow" at 0 -> /.nofollow/foo/bar.
+    // Darwin anchor parsing absorbs "/.nofollow/" into the anchor,
+    // so the post-mutation decomposition reflects the kernel's view
+    // rather than the caller's per-component intent.
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/foo/bar")
+      expectEqual(path.anchor?.description, "/")
+
+      var cv = path.components
+      cv.insert(".nofollow", at: cv.idx(0))
+      path.components = cv
+
+      expectEqual(path.description, "/.nofollow/foo/bar")
+      expectEqual(path.anchor?.description, "/.nofollow/")
+      expectEqual(path.components.map(\.description), ["foo", "bar"])
+    }
+  }
+
+  @Test
+  func darwinInsertResolveAtFront() {
+    // /usr/bin -> insert ".resolve" at 0
+    // Then "usr" looks like the resolve flag value: /.resolve/usr/bin
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/usr/bin")
+
+      var cv = path.components
+      cv.insert(".resolve", at: cv.idx(0))
+      path.components = cv
+
+      expectEqual(path.description, "/.resolve/usr/bin")
+
+      // Reparse: /.resolve/usr/ is the anchor (flag value = "usr")
+      let newAnchor = path.anchor?.description
+      let newComps = path.components.map(\.description)
+      expectEqual(newAnchor, "/.resolve/usr/")
+      expectEqual(newComps, ["bin"])
+    }
+  }
+
+  @Test
+  func darwinInsertVolAtFront() {
+    // /1234/5678/file -> insert ".vol" at 0
+    // Becomes /.vol/1234/5678/file — anchor absorbs /.vol/1234/5678
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/1234/5678/file")
+
+      var cv = path.components
+      cv.insert(".vol", at: cv.idx(0))
+      path.components = cv
+
+      expectEqual(path.description, "/.vol/1234/5678/file")
+
+      let newAnchor = path.anchor?.description
+      let newComps = path.components.map(\.description)
+      expectEqual(newAnchor, "/.vol/1234/5678")
+      expectEqual(newComps, ["file"])
+    }
+  }
+
+  @Test
+  func darwinAppendsFormCombinedAnchor() {
+    // Starting from a `/.nofollow/` anchor, appending `.vol`, FSID, and
+    // FILEID one at a time. The first two appends leave them as plain
+    // components (vol parser fails — incomplete). The third append
+    // completes a parsable `.vol/FSID/FILEID` and triggers absorption:
+    // the combined anchor `/.nofollow/.vol/N/M` forms and components
+    // collapse to empty. (Per proposal line 111: a Darwin anchor may
+    // include resolve flags AND/OR a volume identifier.)
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/.nofollow/")
+      expectEqual(path.anchor?.description, "/.nofollow/")
+      expectEqual(path.components.map(\.description), [])
+
+      path.components.append(".vol")
+      expectEqual(path.anchor?.description, "/.nofollow/")
+      expectEqual(path.components.map(\.description), [".vol"])
+
+      path.components.append("1234")
+      expectEqual(path.anchor?.description, "/.nofollow/")
+      expectEqual(path.components.map(\.description), [".vol", "1234"])
+
+      path.components.append("5678")
+      // Absorption: components fold into the combined anchor.
+      expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
+      expectEqual(path.components.map(\.description), [])
+    }
+  }
+
+  @Test
+  func darwinRemoveLastFromCombinedAnchorStaysWithLeading() {
+    // Removing the only component of a combined-anchor path leaves the
+    // anchor + gap separator. Same shape as UNC `\\server\share\only` ->
+    // `\\server\share\`: the gap separator becomes the trailing separator,
+    // anchor stays intact, components empty.
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/.nofollow/.vol/1234/5678/foo")
+      expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
+      expectEqual(path.components.map(\.description), ["foo"])
+
+      path.components.removeLast()
+
+      expectEqual(path.description, "/.nofollow/.vol/1234/5678/")
+      expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
+      expectEqual(path.components.map(\.description), [])
+      expectTrue(path.hasTrailingSeparator)
+    }
+  }
+
+  @Test
+  func darwinRemoveComponentExposesAnchor() {
+    // Reverse direction: remove first component to reveal anchor structure.
+    // /prefix/.nofollow/foo -> remove "prefix" -> /.nofollow/foo
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/prefix/.nofollow/foo")
+      expectEqual(path.anchor?.description, "/")
+      expectEqual(path.components.map(\.description), ["prefix", ".nofollow", "foo"])
+
+      var cv = path.components
+      cv.removeFirst()
+      path.components = cv
+
+      expectEqual(path.description, "/.nofollow/foo")
+
+      let newAnchor = path.anchor?.description
+      let newComps = path.components.map(\.description)
+      expectEqual(newAnchor, "/.nofollow/")
+      expectEqual(newComps, ["foo"])
+    }
+  }
+
+  @Test
+  func darwinReplaceFirstExposesVol() {
+    // Replace first component to create .vol anchor
+    // /old/1234/5678 -> replace "old" with ".vol" -> /.vol/1234/5678
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/old/1234/5678")
+      expectEqual(path.components.count, 3)
+
+      var cv = path.components
+      cv.replaceSubrange(cv.range(0..<1), with: [".vol" as _StdlibFilePath.Component])
+      path.components = cv
+
+      expectEqual(path.description, "/.vol/1234/5678")
+
+      let newAnchor = path.anchor?.description
+      let newComps = path.components.map(\.description)
+      expectEqual(newAnchor, "/.vol/1234/5678")
+      expectEqual(newComps, [])
+    }
+  }
+
+  @Test
+  func darwinNofollowOnRelativePathIsSafe() {
+    // .nofollow only triggers anchor parsing on absolute paths
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("a/b")
+      var cv = path.components
+      cv.insert(".nofollow", at: cv.idx(0))
+      path.components = cv
+
+      // No root, so .nofollow is just a regular component
+      expectNil(path.anchor)
+      expectEqual(path.components.map(\.description), [".nofollow", "a", "b"])
+      expectEqual(path.description, ".nofollow/a/b")
+    }
+  }
+
+  @Test
+  func darwinNofollowNotFirstIsSafe() {
+    // .nofollow only triggers when it's the path-initial dot component
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/usr/bin")
+      var cv = path.components
+      cv.append(".nofollow")
+      path.components = cv
+
+      // .nofollow at end doesn't affect the anchor
+      expectEqual(path.anchor?.description, "/")
+      expectEqual(path.components.map(\.description), ["usr", "bin", ".nofollow"])
+    }
+  }
+
+  // -- Darwin resource fork hazards --
+
+  @Test
+  func darwinAppendCreatesResourceFork() {
+    // Appending "rsrc" after a component named "..namedfork" produces
+    // a path whose tail matches the /..namedfork/rsrc suffix pattern.
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/file/..namedfork")
+      expectFalse(path.isResourceFork)
+
+      var cv = path.components
+      cv.append("rsrc")
+      path.components = cv
+
+      expectEqual(path.description, "/file/..namedfork/rsrc")
+
+      // Reparse sees the resource fork suffix
+      expectTrue(path.isResourceFork)
+      // The components no longer include ..namedfork and rsrc
+      let newComps = path.components.map(\.description)
+      expectEqual(newComps, ["file"])
+    }
+  }
+
+  @Test
+  func darwinInsertBeforeRsrcBreaksSuffix() {
+    // Inserting between "..namedfork" and "rsrc" breaks the suffix pattern
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/file/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+      expectEqual(path.components.map(\.description), ["file"])
+
+      var cv = path.components
+      cv.append("oops")
+      path.components = cv
+
+      // The setter preserves isResourceFork=false (trailing sep context)
+      // but reconstruction from decomposed form doesn't auto-add the suffix.
+      // This case is tricky: the original decomposition stripped the suffix,
+      // so we only have ["file"] + the new component, no resource fork.
+      expectEqual(path.components.map(\.description), ["file", "oops"])
+      expectFalse(path.isResourceFork)
+    }
+  }
+
+  @Test
+  func darwinRemoveLastCreatesResourceFork() {
+    // /dir/file/..namedfork/rsrc/extra — the suffix doesn't match because
+    // of trailing content. Removing "extra" exposes the suffix.
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/dir/file/..namedfork/rsrc/extra")
+      expectFalse(path.isResourceFork)
+      expectEqual(path.components.map(\.description), [
+        "dir", "file", "..namedfork", "rsrc", "extra",
+      ])
+
+      var cv = path.components
+      cv.removeLast()
+      path.components = cv
+
+      expectEqual(path.description, "/dir/file/..namedfork/rsrc")
+
+      // Reparse now sees the resource fork suffix
+      expectTrue(path.isResourceFork)
+      let newComps = path.components.map(\.description)
+      expectEqual(newComps, ["dir", "file"])
+    }
+  }
+
+  @Test
+  func darwinReplaceCreatesResourceFork() {
+    // Replace last component with "rsrc" when penultimate is "..namedfork"
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("/data/..namedfork/icon")
+      expectFalse(path.isResourceFork)
+
+      var cv = path.components
+      cv.replaceSubrange(cv.index(before: cv.endIndex) ..< cv.endIndex,
+                         with: ["rsrc" as _StdlibFilePath.Component])
+      path.components = cv
+
+      expectEqual(path.description, "/data/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+      expectEqual(path.components.map(\.description), ["data"])
+    }
+  }
+
+  @Test
+  func darwinResourceForkOnRelativeIsSafe() {
+    // Resource fork suffix works on relative paths too
+    withPlatform(.darwin) {
+      var path = _StdlibFilePath("file/..namedfork")
+      var cv = path.components
+      cv.append("rsrc")
+      path.components = cv
+
+      expectEqual(path.description, "file/..namedfork/rsrc")
+      expectTrue(path.isResourceFork)
+      expectEqual(path.components.map(\.description), ["file"])
+    }
+  }
+
+  // -- Windows reparse hazards --
+
+  @Test
+  func windowsRemoveExposesRootBackslash() {
+    // \\server\share\only -> remove "only" -> \\server\share\
+    // The trailing separator now belongs to the UNC anchor.
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\server\share\only"#)
+      expectEqual(path.anchor?.description, #"\\server\share"#)
+      expectEqual(path.components.map(\.description), ["only"])
+
+      var cv = path.components
+      cv.removeLast()
+      path.components = cv
+
+      // With no components, the anchor stands alone
+      expectEqual(path.anchor?.description, #"\\server\share"#)
+      expectTrue(path.components.isEmpty)
+      expectTrue(path.hasTrailingSeparator)
+    }
+  }
+
+  @Test
+  func windowsVerbatimDotPreserved() {
+    // In verbatim paths (\\?\), dot and dotdot are regular components.
+    // Appending "." to a verbatim path should NOT be treated as currentDirectory.
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\?\C:\dir"#)
+      var cv = path.components
+      cv.append(".")
+      path.components = cv
+
+      expectEqual(path.description, #"\\?\C:\dir\."#)
+      // In verbatim context the "." is a regular component name
+      let lastComp = path.components.last!
+      expectEqual(lastComp.kind, .regular)
+    }
+  }
+
+  @Test
+  func windowsVerbatimDotDotPreserved() {
+    // Similarly, ".." in verbatim paths is just a literal name
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\?\C:\dir"#)
+      var cv = path.components
+      cv.append("..")
+      path.components = cv
+
+      expectEqual(path.description, #"\\?\C:\dir\.."#)
+      let lastComp = path.components.last!
+      expectEqual(lastComp.kind, .regular)
+    }
+  }
+
+  @Test
+  func windowsDevicePathAppend() {
+    // \\.\device paths: appending to a device-only path
+    withPlatform(.windows) {
+      var path = _StdlibFilePath(#"\\.\COM1"#)
+      var cv = path.components
+      cv.append("extra")
+      path.components = cv
+
+      expectEqual(path.description, #"\\.\COM1\extra"#)
+      expectEqual(path.components.map(\.description), ["extra"])
+    }
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/ComponentViewTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ComponentViewTests.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,12 +14,11 @@ import Testing
 @testable import System
 #endif
 
-// Migrated onto the TestSupport seam: assertions go through the `expect*`
-// helpers and platform-specific bodies are wrapped in
-// `withPlatform(.windows)` / `withPlatform(.darwin)`. Platform-INDEPENDENT
-// tests assert through `universal(...)` (TestSupport.swift), which spells an
-// expected path in the built platform's separator, so each runs unchanged on
-// whatever platform is built.
+// Assertions go through the `expect*` helpers in TestSupport.swift. A test
+// whose subject is one platform's syntax carries that platform's trait
+// (`.windowsOnly` / `.darwinOnly`); a platform-independent test asserts
+// through `universal(...)`, which spells an expected path in the built
+// platform's separator so the test runs unchanged wherever it is built.
 
 extension AllTests.ComponentViewTests {
 
@@ -40,14 +39,12 @@ extension AllTests.ComponentViewTests {
     expectNotNil(root.anchor)
   }
 
-  @Test
+  @Test(.windowsOnly)
   func rootOnlyHasNoComponentsWindows() {
-    withPlatform(.windows) {
-      let winRoot = _StdlibFilePath(#"C:\"#)
-      expectTrue(winRoot.components.isEmpty)
-      expectNotNil(winRoot.anchor)
-    }
-  }
+    let winRoot = _StdlibFilePath(#"C:\"#)
+    expectTrue(winRoot.components.isEmpty)
+    expectNotNil(winRoot.anchor)
+}
 
   @Test
   func indexTraversal() {
@@ -293,62 +290,52 @@ extension AllTests.ComponentViewTests {
 
   // MARK: - Windows platform
 
-  @Test
+  @Test(.windowsOnly)
   func windowsAppend() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"C:\Users"#)
-      path.components.append("Admin")
+    var path = _StdlibFilePath(#"C:\Users"#)
+    path.components.append("Admin")
 
-      expectEqual(path.description, #"C:\Users\Admin"#)
-      expectEqual(path.anchor?.description, #"C:\"#)
-    }
-  }
+    expectEqual(path.description, #"C:\Users\Admin"#)
+    expectEqual(path.anchor?.description, #"C:\"#)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsDriveRelativeAppend() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath("C:src")
-      var cv = path.components
-      cv.append("main.swift")
-      path.components = cv
+    var path = _StdlibFilePath("C:src")
+    var cv = path.components
+    cv.append("main.swift")
+    path.components = cv
 
-      // C: anchor (no backslash) — components follow directly
-      expectEqual(path.description, #"C:src\main.swift"#)
-      expectEqual(path.anchor?.description, "C:")
-    }
-  }
+    // C: anchor (no backslash): components follow directly
+    expectEqual(path.description, #"C:src\main.swift"#)
+    expectEqual(path.anchor?.description, "C:")
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsRemoveComponent() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"C:\Users\Admin\file.txt"#)
-      path.components.removeLast()
+    var path = _StdlibFilePath(#"C:\Users\Admin\file.txt"#)
+    path.components.removeLast()
 
-      expectEqual(path.description, #"C:\Users\Admin"#)
-    }
-  }
+    expectEqual(path.description, #"C:\Users\Admin"#)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsUNCAppend() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\server\share"#)
-      path.components.append("folder")
+    var path = _StdlibFilePath(#"\\server\share"#)
+    path.components.append("folder")
 
-      expectEqual(path.description, #"\\server\share\folder"#)
-    }
-  }
+    expectEqual(path.description, #"\\server\share\folder"#)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsReplaceComponents() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"C:\old\stuff"#)
-      path.components.replaceSubrange(
-        path.components.startIndex..<path.components.endIndex,
-        with: ["new", "things"] as [_StdlibFilePath.Component])
+    var path = _StdlibFilePath(#"C:\old\stuff"#)
+    path.components.replaceSubrange(
+      path.components.startIndex..<path.components.endIndex,
+      with: ["new", "things"] as [_StdlibFilePath.Component])
 
-      expectEqual(path.description, #"C:\new\things"#)
-    }
-  }
+    expectEqual(path.description, #"C:\new\things"#)
+}
 
   // MARK: - Anchor preservation
 
@@ -378,21 +365,19 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, universal("x/y"))
   }
 
-  @Test
+  @Test(.windowsOnly)
   func windowsAnchorSurvivesMutation() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\server\share\old\path"#)
-      let originalAnchor = path.anchor
+    var path = _StdlibFilePath(#"\\server\share\old\path"#)
+    let originalAnchor = path.anchor
 
-      var cv = path.components
-      cv.removeAll()
-      cv.append("new")
-      path.components = cv
+    var cv = path.components
+    cv.removeAll()
+    cv.append("new")
+    path.components = cv
 
-      expectEqual(path.anchor, originalAnchor)
-      expectEqual(path.description, #"\\server\share\new"#)
-    }
-  }
+    expectEqual(path.anchor, originalAnchor)
+    expectEqual(path.description, #"\\server\share\new"#)
+}
 
   // MARK: - Hashable / Equatable
 
@@ -485,19 +470,17 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, universal("src/main.swift"))
   }
 
-  @Test
+  @Test(.windowsOnly)
   func windowsBuildFromScratch() {
-    withPlatform(.windows) {
-      var cv = _StdlibFilePath.ComponentView()
-      cv.append("Users")
-      cv.append("Admin")
-      cv.append("Documents")
+    var cv = _StdlibFilePath.ComponentView()
+    cv.append("Users")
+    cv.append("Admin")
+    cv.append("Documents")
 
-      var path = _StdlibFilePath(#"C:\"#)
-      path.components = cv
-      expectEqual(path.description, #"C:\Users\Admin\Documents"#)
-    }
-  }
+    var path = _StdlibFilePath(#"C:\"#)
+    path.components = cv
+    expectEqual(path.description, #"C:\Users\Admin\Documents"#)
+}
 
   // MARK: - Edge cases
 
@@ -588,18 +571,16 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, universal("/"))
   }
 
-  @Test
+  @Test(.windowsOnly)
   func windowsTrailingSepStrippedOnRemoveLast() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"C:\Users\Admin\"#)
-      expectTrue(path.hasTrailingSeparator)
+    var path = _StdlibFilePath(#"C:\Users\Admin\"#)
+    expectTrue(path.hasTrailingSeparator)
 
-      path.components.removeLast()
+    path.components.removeLast()
 
-      expectFalse(path.hasTrailingSeparator)
-      expectEqual(path.description, #"C:\Users"#)
-    }
-  }
+    expectFalse(path.hasTrailingSeparator)
+    expectEqual(path.description, #"C:\Users"#)
+}
 
   // -- Trailing separator: preserve when last unchanged --
 
@@ -656,21 +637,19 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, universal("a/b/c/"))
   }
 
-  @Test
+  @Test(.windowsOnly)
   func trailingSepPreservedEmptyToEmpty() {
     // \\server\share\ decomposes with empty components and
     // trailing sep. Setting empty components back preserves it.
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\server\share\"#)
-      expectTrue(path.hasTrailingSeparator)
-      expectTrue(path.components.isEmpty)
+    var path = _StdlibFilePath(#"\\server\share\"#)
+    expectTrue(path.hasTrailingSeparator)
+    expectTrue(path.components.isEmpty)
 
-      let cv = path.components
-      path.components = cv
+    let cv = path.components
+    path.components = cv
 
-      expectTrue(path.hasTrailingSeparator)
-    }
-  }
+    expectTrue(path.hasTrailingSeparator)
+}
 
   // -- Trailing separator: strip on append --
 
@@ -698,99 +677,87 @@ extension AllTests.ComponentViewTests {
 
   // -- Resource fork: strip on remove/replace (Darwin) --
 
-  @Test
+  @Test(.darwinOnly)
   func resourceForkStrippedOnRemoveLast() {
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/dir/file/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
-      expectEqual(path.components.map(\.description), ["dir", "file"])
+    var path = _StdlibFilePath("/dir/file/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
+    expectEqual(path.components.map(\.description), ["dir", "file"])
 
-      path.components.removeLast()
+    path.components.removeLast()
 
-      expectFalse(path.isResourceFork)
-      expectEqual(path.description, "/dir")
-    }
-  }
+    expectFalse(path.isResourceFork)
+    expectEqual(path.description, "/dir")
+}
 
-  @Test
+  @Test(.darwinOnly)
   func resourceForkStrippedOnReplaceLast() {
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/file/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
-      expectEqual(path.components.map(\.description), ["file"])
+    var path = _StdlibFilePath("/file/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
+    expectEqual(path.components.map(\.description), ["file"])
 
-      path.components.replaceSubrange(
-        path.components.range(0..<1),
-        with: ["other" as _StdlibFilePath.Component])
+    path.components.replaceSubrange(
+      path.components.range(0..<1),
+      with: ["other" as _StdlibFilePath.Component])
 
-      expectFalse(path.isResourceFork)
-      expectEqual(path.description, "/other")
-    }
-  }
+    expectFalse(path.isResourceFork)
+    expectEqual(path.description, "/other")
+}
 
-  @Test
+  @Test(.darwinOnly)
   func resourceForkStrippedOnRemoveAll() {
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/file/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
+    var path = _StdlibFilePath("/file/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
 
-      path.components.removeAll()
+    path.components.removeAll()
 
-      expectFalse(path.isResourceFork)
-      expectEqual(path.description, "/")
-    }
-  }
+    expectFalse(path.isResourceFork)
+    expectEqual(path.description, "/")
+}
 
   // -- Resource fork: preserve when last unchanged --
 
-  @Test
+  @Test(.darwinOnly)
   func resourceForkPreservedOnInsert() {
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/file/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
-      expectEqual(path.components.map(\.description), ["file"])
+    var path = _StdlibFilePath("/file/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
+    expectEqual(path.components.map(\.description), ["file"])
 
-      path.components.insert("dir", at: path.components.idx(0))
+    path.components.insert("dir", at: path.components.idx(0))
 
-      expectTrue(path.isResourceFork)
-      expectEqual(path.components.map(\.description), ["dir", "file"])
-    }
-  }
+    expectTrue(path.isResourceFork)
+    expectEqual(path.components.map(\.description), ["dir", "file"])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func resourceForkPreservedOnNoChange() {
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/file/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
+    var path = _StdlibFilePath("/file/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
 
-      let cv = path.components
-      path.components = cv
+    let cv = path.components
+    path.components = cv
 
-      expectTrue(path.isResourceFork)
-    }
-  }
+    expectTrue(path.isResourceFork)
+}
 
   // -- Resource fork: strip on append --
 
-  @Test
+  @Test(.darwinOnly)
   func resourceForkOnAppend() {
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/file/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
+    var path = _StdlibFilePath("/file/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
 
-      path.components.append("extra")
+    path.components.append("extra")
 
-      expectFalse(path.isResourceFork)
-      expectEqual(path.description, "/file/extra")
-    }
-  }
+    expectFalse(path.isResourceFork)
+    expectEqual(path.description, "/file/extra")
+}
 
   // MARK: - Re-decomposition after component mutation
   //
   // When a component mutation produces a string that re-parses to a
   // different decomposition (e.g. inserting `.nofollow` at the front
   // of an absolute Darwin path causes anchor absorption), we honor
-  // the new decomposition rather than masking it. The string IS what
+  // the new decomposition rather than masking it. The string is what
   // the kernel sees; pretending otherwise would be a lie.
 
   // MARK: - Structural suffix rule corner cases
@@ -813,16 +780,14 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, universal("/x/y/c"))
   }
 
-  @Test
+  @Test(.windowsOnly)
   func removeAllOnUNCDropsGapSeparator() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\server\share\"#)
-      expectTrue(path.hasTrailingSeparator)
-      path.components.removeAll()
-      expectFalse(path.hasTrailingSeparator)
-      expectEqual(path.description, #"\\server\share"#)
-    }
-  }
+    var path = _StdlibFilePath(#"\\server\share\"#)
+    expectTrue(path.hasTrailingSeparator)
+    path.components.removeAll()
+    expectFalse(path.hasTrailingSeparator)
+    expectEqual(path.description, #"\\server\share"#)
+}
 
   // MARK: - removeAll across all anchor shapes
   //
@@ -831,157 +796,131 @@ extension AllTests.ComponentViewTests {
   // shapes: anchor-includes-trailing-sep, anchor-ends-with-`:`, anchor-
   // with-gap-sep, and verbatim variants of the same.
 
-  @Test
+  @Test(.windowsOnly)
   func removeAllUNCWithComponentsDropsGapSep() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\server\share\foo\bar"#)
-      expectEqual(path.components.map(\.description), ["foo", "bar"])
-      path.components.removeAll()
-      expectEqual(path.description, #"\\server\share"#)
-      expectFalse(path.hasTrailingSeparator)
-    }
-  }
+    var path = _StdlibFilePath(#"\\server\share\foo\bar"#)
+    expectEqual(path.components.map(\.description), ["foo", "bar"])
+    path.components.removeAll()
+    expectEqual(path.description, #"\\server\share"#)
+    expectFalse(path.hasTrailingSeparator)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func removeAllDriveAbsoluteKeepsAnchorSep() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"C:\foo\bar"#)
-      path.components.removeAll()
-      expectEqual(path.description, #"C:\"#)
-    }
-  }
+    var path = _StdlibFilePath(#"C:\foo\bar"#)
+    path.components.removeAll()
+    expectEqual(path.description, #"C:\"#)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func removeAllDriveRelativeKeepsColon() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"C:foo\bar"#)
-      path.components.removeAll()
-      expectEqual(path.description, "C:")
-    }
-  }
+    var path = _StdlibFilePath(#"C:foo\bar"#)
+    path.components.removeAll()
+    expectEqual(path.description, "C:")
+}
 
-  @Test
+  @Test(.windowsOnly)
   func removeAllVerbatimDriveKeepsAnchor() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\?\C:\foo\bar"#)
-      path.components.removeAll()
-      expectEqual(path.description, #"\\?\C:\"#)
-    }
-  }
+    var path = _StdlibFilePath(#"\\?\C:\foo\bar"#)
+    path.components.removeAll()
+    expectEqual(path.description, #"\\?\C:\"#)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func removeAllVerbatimUNCDropsGapSep() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\?\UNC\server\share\foo"#)
-      path.components.removeAll()
-      expectEqual(path.description, #"\\?\UNC\server\share"#)
-    }
-  }
+    var path = _StdlibFilePath(#"\\?\UNC\server\share\foo"#)
+    path.components.removeAll()
+    expectEqual(path.description, #"\\?\UNC\server\share"#)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func removeAllVerbatimDeviceDropsGapSep() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\?\name\foo"#)
-      path.components.removeAll()
-      expectEqual(path.description, #"\\?\name"#)
-    }
-  }
+    var path = _StdlibFilePath(#"\\?\name\foo"#)
+    path.components.removeAll()
+    expectEqual(path.description, #"\\?\name"#)
+}
 
   // MARK: - Colon-ending anchors: Windows drive-relative vs Darwin volfs
   //
-  // The `:` IS the anchor/component boundary only on Windows
+  // The `:` is the anchor/component boundary only on Windows
   // (drive-relative `C:foo`). On Darwin, `:` is a regular byte that can
   // appear in a volfs FILEID, so an anchor ending in `:` still needs a
   // gap separator before any component bytes.
 
-  @Test
+  @Test(.windowsOnly)
   func windowsDriveRelativeAppendStaysDriveRelative() {
-    // Appending to `C:` must yield `C:foo`, NOT `C:\foo` (which would
+    // Appending to `C:` must yield `C:foo`, not `C:\foo` (which would
     // be drive-absolute, a different anchor shape).
-    withPlatform(.windows) {
-      var path = _StdlibFilePath("C:")
-      expectEqual(path.anchor?.description, "C:")
-      path.components.append("foo")
-      expectEqual(path.description, "C:foo")
-      expectEqual(path.anchor?.description, "C:")
-      expectEqual(path.components.map(\.description), ["foo"])
-    }
-  }
+    var path = _StdlibFilePath("C:")
+    expectEqual(path.anchor?.description, "C:")
+    path.components.append("foo")
+    expectEqual(path.description, "C:foo")
+    expectEqual(path.anchor?.description, "C:")
+    expectEqual(path.components.map(\.description), ["foo"])
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsDriveRelativeMultiAppendStaysDriveRelative() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath("C:")
-      path.components.append("foo")
-      path.components.append("bar")
-      expectEqual(path.description, #"C:foo\bar"#)
-      expectEqual(path.anchor?.description, "C:")
-    }
-  }
+    var path = _StdlibFilePath("C:")
+    path.components.append("foo")
+    path.components.append("bar")
+    expectEqual(path.description, #"C:foo\bar"#)
+    expectEqual(path.anchor?.description, "C:")
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsDriveRelativeAssignKeepsAnchor() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath("C:")
-      var cv = _StdlibFilePath.ComponentView()
-      cv.append("foo")
-      path.components = cv
-      expectEqual(path.description, "C:foo")
-      expectEqual(path.anchor?.description, "C:")
-    }
-  }
+    var path = _StdlibFilePath("C:")
+    var cv = _StdlibFilePath.ComponentView()
+    cv.append("foo")
+    path.components = cv
+    expectEqual(path.description, "C:foo")
+    expectEqual(path.anchor?.description, "C:")
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinVolfsColonInFileIdGetsGapSeparator() {
     // Darwin volfs FILEID is "bytes up to next /". A FILEID ending in
     // `:` is degenerate but legal. Adding a component must add a gap
-    // separator — the `:`-skips-gap-sep rule is Windows-specific.
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/.vol/12345/67890:")
-      expectEqual(path.anchor?.description, "/.vol/12345/67890:")
-      path.components.append("foo")
-      expectEqual(path.description, "/.vol/12345/67890:/foo")
-      expectEqual(path.anchor?.description, "/.vol/12345/67890:")
-      expectEqual(path.components.map(\.description), ["foo"])
-    }
-  }
+    // separator. The `:`-skips-gap-sep rule is Windows-specific.
+    var path = _StdlibFilePath("/.vol/12345/67890:")
+    expectEqual(path.anchor?.description, "/.vol/12345/67890:")
+    path.components.append("foo")
+    expectEqual(path.description, "/.vol/12345/67890:/foo")
+    expectEqual(path.anchor?.description, "/.vol/12345/67890:")
+    expectEqual(path.components.map(\.description), ["foo"])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinVolfsColonAssignKeepsAnchor() {
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/.vol/12345/67890:")
-      var cv = _StdlibFilePath.ComponentView()
-      cv.append("foo")
-      path.components = cv
-      expectEqual(path.description, "/.vol/12345/67890:/foo")
-      expectEqual(path.anchor?.description, "/.vol/12345/67890:")
-    }
-  }
+    var path = _StdlibFilePath("/.vol/12345/67890:")
+    var cv = _StdlibFilePath.ComponentView()
+    cv.append("foo")
+    path.components = cv
+    expectEqual(path.description, "/.vol/12345/67890:/foo")
+    expectEqual(path.anchor?.description, "/.vol/12345/67890:")
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsUNCWithColonShareGetsGapSeparator() {
     // The UNC parser allows `:` in share names: `\\server\C:` parses
-    // as anchor `\\server\C:` (length 11), NOT drive-relative. The
+    // as anchor `\\server\C:` (length 11), not drive-relative. The
     // gap separator must be added on append.
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\server\C:"#)
-      expectEqual(path.anchor?.description, #"\\server\C:"#)
-      path.components.append("foo")
-      expectEqual(path.description, #"\\server\C:\foo"#)
-      expectEqual(path.anchor?.description, #"\\server\C:"#)
-    }
-  }
+    var path = _StdlibFilePath(#"\\server\C:"#)
+    expectEqual(path.anchor?.description, #"\\server\C:"#)
+    path.components.append("foo")
+    expectEqual(path.description, #"\\server\C:\foo"#)
+    expectEqual(path.anchor?.description, #"\\server\C:"#)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsUNCWithColonShareAssignKeepsGap() {
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\server\C:"#)
-      var cv = _StdlibFilePath.ComponentView()
-      cv.append("foo")
-      path.components = cv
-      expectEqual(path.description, #"\\server\C:\foo"#)
-    }
-  }
+    var path = _StdlibFilePath(#"\\server\C:"#)
+    var cv = _StdlibFilePath.ComponentView()
+    cv.append("foo")
+    path.components = cv
+    expectEqual(path.description, #"\\server\C:\foo"#)
+}
 
   // MARK: - Suffix interactions with splice
 
@@ -1002,22 +941,20 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, universal("/a/b"))
   }
 
-  @Test
+  @Test(.darwinOnly)
   func insertInteriorPreservesResourceFork() {
-    // Insert in the MIDDLE of a multi-component path that has a
+    // Insert in the middle of a multi-component path that has a
     // resource fork suffix. Middle insert is not touchesEnd, so the
     // suffix region is untouched.
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/foo/bar/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
-      expectEqual(path.components.map(\.description), ["foo", "bar"])
-      let afterFoo = path.components.index(after: path.components.startIndex)
-      path.components.insert("x", at: afterFoo)
-      expectEqual(path.description, "/foo/x/bar/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
-      expectEqual(path.components.map(\.description), ["foo", "x", "bar"])
-    }
-  }
+    var path = _StdlibFilePath("/foo/bar/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
+    expectEqual(path.components.map(\.description), ["foo", "bar"])
+    let afterFoo = path.components.index(after: path.components.startIndex)
+    path.components.insert("x", at: afterFoo)
+    expectEqual(path.description, "/foo/x/bar/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
+    expectEqual(path.components.map(\.description), ["foo", "x", "bar"])
+}
 
   // MARK: - Cross-anchor assignment
   //
@@ -1026,18 +963,16 @@ extension AllTests.ComponentViewTests {
   // Self's anchor stays put; the new contribution becomes the
   // components+suffix.
 
-  @Test
+  @Test(.windowsOnly)
   func assignDifferentAnchorCvKeepsSelfAnchor() {
     // cv from a path with a different anchor. Only cv's components
     // (the bytes after cv's original anchor) get spliced; self's
     // anchor is preserved.
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\foo"#)
-      let cv = _StdlibFilePath(#"C:\bar"#).components
-      path.components = cv
-      expectEqual(path.description, #"\bar"#)
-    }
-  }
+    var path = _StdlibFilePath(#"\foo"#)
+    let cv = _StdlibFilePath(#"C:\bar"#).components
+    path.components = cv
+    expectEqual(path.description, #"\bar"#)
+}
 
   @Test
   func assignAnchoredCvOntoAnchorlessKeepsAnchorless() {
@@ -1049,380 +984,342 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, "foo")
   }
 
-  @Test
+  @Test(.darwinOnly)
   func absorptionThenAssignMatchesInPlace() {
     // cv mutated to trigger anchor absorption, then assigned back.
     // The splice uses cv's _originalStart (immutable since view
     // creation), so the absorbed bytes are part of the spliced region.
     // Result must match in-place mutation.
-    withPlatform(.darwin) {
 
-      var inPlace = _StdlibFilePath("/foo/bar")
-      inPlace.components.insert(".nofollow", at: inPlace.components.startIndex)
-      expectEqual(inPlace.description, "/.nofollow/foo/bar")
+    var inPlace = _StdlibFilePath("/foo/bar")
+    inPlace.components.insert(".nofollow", at: inPlace.components.startIndex)
+    expectEqual(inPlace.description, "/.nofollow/foo/bar")
 
-      var assigned = _StdlibFilePath("/foo/bar")
-      var cv = assigned.components
-      cv.insert(".nofollow", at: cv.startIndex)
-      assigned.components = cv
+    var assigned = _StdlibFilePath("/foo/bar")
+    var cv = assigned.components
+    cv.insert(".nofollow", at: cv.startIndex)
+    assigned.components = cv
 
-      expectEqual(assigned.description, inPlace.description)
-    }
-  }
+    expectEqual(assigned.description, inPlace.description)
+}
 
   // -- Darwin anchor hazards --
 
-  @Test
+  @Test(.darwinOnly)
   func darwinInsertNofollowAtFront() {
     // /foo/bar -> insert ".nofollow" at 0 -> /.nofollow/foo/bar.
     // Darwin anchor parsing absorbs "/.nofollow/" into the anchor,
     // so the post-mutation decomposition reflects the kernel's view
     // rather than the caller's per-component intent.
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/foo/bar")
-      expectEqual(path.anchor?.description, "/")
+    var path = _StdlibFilePath("/foo/bar")
+    expectEqual(path.anchor?.description, "/")
 
-      var cv = path.components
-      cv.insert(".nofollow", at: cv.idx(0))
-      path.components = cv
+    var cv = path.components
+    cv.insert(".nofollow", at: cv.idx(0))
+    path.components = cv
 
-      expectEqual(path.description, "/.nofollow/foo/bar")
-      expectEqual(path.anchor?.description, "/.nofollow/")
-      expectEqual(path.components.map(\.description), ["foo", "bar"])
-    }
-  }
+    expectEqual(path.description, "/.nofollow/foo/bar")
+    expectEqual(path.anchor?.description, "/.nofollow/")
+    expectEqual(path.components.map(\.description), ["foo", "bar"])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinInsertResolveAtFront() {
     // /usr/bin -> insert ".resolve" at 0
     // Then "usr" looks like the resolve flag value: /.resolve/usr/bin
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/usr/bin")
+    var path = _StdlibFilePath("/usr/bin")
 
-      var cv = path.components
-      cv.insert(".resolve", at: cv.idx(0))
-      path.components = cv
+    var cv = path.components
+    cv.insert(".resolve", at: cv.idx(0))
+    path.components = cv
 
-      expectEqual(path.description, "/.resolve/usr/bin")
+    expectEqual(path.description, "/.resolve/usr/bin")
 
-      // Reparse: /.resolve/usr/ is the anchor (flag value = "usr")
-      let newAnchor = path.anchor?.description
-      let newComps = path.components.map(\.description)
-      expectEqual(newAnchor, "/.resolve/usr/")
-      expectEqual(newComps, ["bin"])
-    }
-  }
+    // Reparse: /.resolve/usr/ is the anchor (flag value = "usr")
+    let newAnchor = path.anchor?.description
+    let newComps = path.components.map(\.description)
+    expectEqual(newAnchor, "/.resolve/usr/")
+    expectEqual(newComps, ["bin"])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinInsertVolAtFront() {
     // /1234/5678/file -> insert ".vol" at 0
-    // Becomes /.vol/1234/5678/file — anchor absorbs /.vol/1234/5678
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/1234/5678/file")
+    // Becomes /.vol/1234/5678/file, with /.vol/1234/5678 absorbed as the anchor
+    var path = _StdlibFilePath("/1234/5678/file")
 
-      var cv = path.components
-      cv.insert(".vol", at: cv.idx(0))
-      path.components = cv
+    var cv = path.components
+    cv.insert(".vol", at: cv.idx(0))
+    path.components = cv
 
-      expectEqual(path.description, "/.vol/1234/5678/file")
+    expectEqual(path.description, "/.vol/1234/5678/file")
 
-      let newAnchor = path.anchor?.description
-      let newComps = path.components.map(\.description)
-      expectEqual(newAnchor, "/.vol/1234/5678")
-      expectEqual(newComps, ["file"])
-    }
-  }
+    let newAnchor = path.anchor?.description
+    let newComps = path.components.map(\.description)
+    expectEqual(newAnchor, "/.vol/1234/5678")
+    expectEqual(newComps, ["file"])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinAppendsFormCombinedAnchor() {
     // Starting from a `/.nofollow/` anchor, appending `.vol`, FSID, and
     // FILEID one at a time. The first two appends leave them as plain
-    // components (vol parser fails — incomplete). The third append
-    // completes a parsable `.vol/FSID/FILEID` and triggers absorption:
-    // the combined anchor `/.nofollow/.vol/N/M` forms and components
-    // collapse to empty. (Per proposal line 111: a Darwin anchor may
-    // include resolve flags AND/OR a volume identifier.)
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/.nofollow/")
-      expectEqual(path.anchor?.description, "/.nofollow/")
-      expectEqual(path.components.map(\.description), [])
+    // components (the vol parser fails on the incomplete form). The third
+    // append completes a parsable `.vol/FSID/FILEID` and triggers absorption:
+    // the combined anchor `/.nofollow/.vol/N/M` forms and the components
+    // collapse to empty, since a Darwin anchor may include resolve flags
+    // and/or a volume identifier.
+    var path = _StdlibFilePath("/.nofollow/")
+    expectEqual(path.anchor?.description, "/.nofollow/")
+    expectEqual(path.components.map(\.description), [])
 
-      path.components.append(".vol")
-      expectEqual(path.anchor?.description, "/.nofollow/")
-      expectEqual(path.components.map(\.description), [".vol"])
+    path.components.append(".vol")
+    expectEqual(path.anchor?.description, "/.nofollow/")
+    expectEqual(path.components.map(\.description), [".vol"])
 
-      path.components.append("1234")
-      expectEqual(path.anchor?.description, "/.nofollow/")
-      expectEqual(path.components.map(\.description), [".vol", "1234"])
+    path.components.append("1234")
+    expectEqual(path.anchor?.description, "/.nofollow/")
+    expectEqual(path.components.map(\.description), [".vol", "1234"])
 
-      path.components.append("5678")
-      // Absorption: components fold into the combined anchor.
-      expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
-      expectEqual(path.components.map(\.description), [])
-    }
-  }
+    path.components.append("5678")
+    // Absorption: components fold into the combined anchor.
+    expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
+    expectEqual(path.components.map(\.description), [])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinRemoveLastFromCombinedAnchorStaysWithLeading() {
     // Removing the only component of a combined-anchor path leaves the
     // anchor + gap separator. Same shape as UNC `\\server\share\only` ->
     // `\\server\share\`: the gap separator becomes the trailing separator,
     // anchor stays intact, components empty.
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/.nofollow/.vol/1234/5678/foo")
-      expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
-      expectEqual(path.components.map(\.description), ["foo"])
+    var path = _StdlibFilePath("/.nofollow/.vol/1234/5678/foo")
+    expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
+    expectEqual(path.components.map(\.description), ["foo"])
 
-      path.components.removeLast()
+    path.components.removeLast()
 
-      expectEqual(path.description, "/.nofollow/.vol/1234/5678/")
-      expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
-      expectEqual(path.components.map(\.description), [])
-      expectTrue(path.hasTrailingSeparator)
-    }
-  }
+    expectEqual(path.description, "/.nofollow/.vol/1234/5678/")
+    expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
+    expectEqual(path.components.map(\.description), [])
+    expectTrue(path.hasTrailingSeparator)
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinRemoveComponentExposesAnchor() {
     // Reverse direction: remove first component to reveal anchor structure.
     // /prefix/.nofollow/foo -> remove "prefix" -> /.nofollow/foo
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/prefix/.nofollow/foo")
-      expectEqual(path.anchor?.description, "/")
-      expectEqual(path.components.map(\.description), ["prefix", ".nofollow", "foo"])
+    var path = _StdlibFilePath("/prefix/.nofollow/foo")
+    expectEqual(path.anchor?.description, "/")
+    expectEqual(path.components.map(\.description), ["prefix", ".nofollow", "foo"])
 
-      var cv = path.components
-      cv.removeFirst()
-      path.components = cv
+    var cv = path.components
+    cv.removeFirst()
+    path.components = cv
 
-      expectEqual(path.description, "/.nofollow/foo")
+    expectEqual(path.description, "/.nofollow/foo")
 
-      let newAnchor = path.anchor?.description
-      let newComps = path.components.map(\.description)
-      expectEqual(newAnchor, "/.nofollow/")
-      expectEqual(newComps, ["foo"])
-    }
-  }
+    let newAnchor = path.anchor?.description
+    let newComps = path.components.map(\.description)
+    expectEqual(newAnchor, "/.nofollow/")
+    expectEqual(newComps, ["foo"])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinReplaceFirstExposesVol() {
     // Replace first component to create .vol anchor
     // /old/1234/5678 -> replace "old" with ".vol" -> /.vol/1234/5678
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/old/1234/5678")
-      expectEqual(path.components.count, 3)
+    var path = _StdlibFilePath("/old/1234/5678")
+    expectEqual(path.components.count, 3)
 
-      var cv = path.components
-      cv.replaceSubrange(cv.range(0..<1), with: [".vol" as _StdlibFilePath.Component])
-      path.components = cv
+    var cv = path.components
+    cv.replaceSubrange(cv.range(0..<1), with: [".vol" as _StdlibFilePath.Component])
+    path.components = cv
 
-      expectEqual(path.description, "/.vol/1234/5678")
+    expectEqual(path.description, "/.vol/1234/5678")
 
-      let newAnchor = path.anchor?.description
-      let newComps = path.components.map(\.description)
-      expectEqual(newAnchor, "/.vol/1234/5678")
-      expectEqual(newComps, [])
-    }
-  }
+    let newAnchor = path.anchor?.description
+    let newComps = path.components.map(\.description)
+    expectEqual(newAnchor, "/.vol/1234/5678")
+    expectEqual(newComps, [])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinNofollowOnRelativePathIsSafe() {
     // .nofollow only triggers anchor parsing on absolute paths
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("a/b")
-      var cv = path.components
-      cv.insert(".nofollow", at: cv.idx(0))
-      path.components = cv
+    var path = _StdlibFilePath("a/b")
+    var cv = path.components
+    cv.insert(".nofollow", at: cv.idx(0))
+    path.components = cv
 
-      // No root, so .nofollow is just a regular component
-      expectNil(path.anchor)
-      expectEqual(path.components.map(\.description), [".nofollow", "a", "b"])
-      expectEqual(path.description, ".nofollow/a/b")
-    }
-  }
+    // No root, so .nofollow is just a regular component
+    expectNil(path.anchor)
+    expectEqual(path.components.map(\.description), [".nofollow", "a", "b"])
+    expectEqual(path.description, ".nofollow/a/b")
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinNofollowNotFirstIsSafe() {
     // .nofollow only triggers when it's the path-initial dot component
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/usr/bin")
-      var cv = path.components
-      cv.append(".nofollow")
-      path.components = cv
+    var path = _StdlibFilePath("/usr/bin")
+    var cv = path.components
+    cv.append(".nofollow")
+    path.components = cv
 
-      // .nofollow at end doesn't affect the anchor
-      expectEqual(path.anchor?.description, "/")
-      expectEqual(path.components.map(\.description), ["usr", "bin", ".nofollow"])
-    }
-  }
+    // .nofollow at end doesn't affect the anchor
+    expectEqual(path.anchor?.description, "/")
+    expectEqual(path.components.map(\.description), ["usr", "bin", ".nofollow"])
+}
 
   // -- Darwin resource fork hazards --
 
-  @Test
+  @Test(.darwinOnly)
   func darwinAppendCreatesResourceFork() {
     // Appending "rsrc" after a component named "..namedfork" produces
     // a path whose tail matches the /..namedfork/rsrc suffix pattern.
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/file/..namedfork")
-      expectFalse(path.isResourceFork)
+    var path = _StdlibFilePath("/file/..namedfork")
+    expectFalse(path.isResourceFork)
 
-      var cv = path.components
-      cv.append("rsrc")
-      path.components = cv
+    var cv = path.components
+    cv.append("rsrc")
+    path.components = cv
 
-      expectEqual(path.description, "/file/..namedfork/rsrc")
+    expectEqual(path.description, "/file/..namedfork/rsrc")
 
-      // Reparse sees the resource fork suffix
-      expectTrue(path.isResourceFork)
-      // The components no longer include ..namedfork and rsrc
-      let newComps = path.components.map(\.description)
-      expectEqual(newComps, ["file"])
-    }
-  }
+    // Reparse sees the resource fork suffix
+    expectTrue(path.isResourceFork)
+    // The components no longer include ..namedfork and rsrc
+    let newComps = path.components.map(\.description)
+    expectEqual(newComps, ["file"])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinInsertBeforeRsrcBreaksSuffix() {
     // Inserting between "..namedfork" and "rsrc" breaks the suffix pattern
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/file/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
-      expectEqual(path.components.map(\.description), ["file"])
+    var path = _StdlibFilePath("/file/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
+    expectEqual(path.components.map(\.description), ["file"])
 
-      var cv = path.components
-      cv.append("oops")
-      path.components = cv
+    var cv = path.components
+    cv.append("oops")
+    path.components = cv
 
-      // The setter preserves isResourceFork=false (trailing sep context)
-      // but reconstruction from decomposed form doesn't auto-add the suffix.
-      // This case is tricky: the original decomposition stripped the suffix,
-      // so we only have ["file"] + the new component, no resource fork.
-      expectEqual(path.components.map(\.description), ["file", "oops"])
-      expectFalse(path.isResourceFork)
-    }
-  }
+    // The setter preserves isResourceFork=false (trailing sep context)
+    // but reconstruction from decomposed form doesn't auto-add the suffix.
+    // This case is tricky: the original decomposition stripped the suffix,
+    // so we only have ["file"] + the new component, no resource fork.
+    expectEqual(path.components.map(\.description), ["file", "oops"])
+    expectFalse(path.isResourceFork)
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinRemoveLastCreatesResourceFork() {
-    // /dir/file/..namedfork/rsrc/extra — the suffix doesn't match because
+    // /dir/file/..namedfork/rsrc/extra: the suffix doesn't match because
     // of trailing content. Removing "extra" exposes the suffix.
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/dir/file/..namedfork/rsrc/extra")
-      expectFalse(path.isResourceFork)
-      expectEqual(path.components.map(\.description), [
-        "dir", "file", "..namedfork", "rsrc", "extra",
-      ])
+    var path = _StdlibFilePath("/dir/file/..namedfork/rsrc/extra")
+    expectFalse(path.isResourceFork)
+    expectEqual(path.components.map(\.description), [
+      "dir", "file", "..namedfork", "rsrc", "extra",
+    ])
 
-      var cv = path.components
-      cv.removeLast()
-      path.components = cv
+    var cv = path.components
+    cv.removeLast()
+    path.components = cv
 
-      expectEqual(path.description, "/dir/file/..namedfork/rsrc")
+    expectEqual(path.description, "/dir/file/..namedfork/rsrc")
 
-      // Reparse now sees the resource fork suffix
-      expectTrue(path.isResourceFork)
-      let newComps = path.components.map(\.description)
-      expectEqual(newComps, ["dir", "file"])
-    }
-  }
+    // Reparse now sees the resource fork suffix
+    expectTrue(path.isResourceFork)
+    let newComps = path.components.map(\.description)
+    expectEqual(newComps, ["dir", "file"])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinReplaceCreatesResourceFork() {
     // Replace last component with "rsrc" when penultimate is "..namedfork"
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("/data/..namedfork/icon")
-      expectFalse(path.isResourceFork)
+    var path = _StdlibFilePath("/data/..namedfork/icon")
+    expectFalse(path.isResourceFork)
 
-      var cv = path.components
-      cv.replaceSubrange(cv.index(before: cv.endIndex) ..< cv.endIndex,
-                         with: ["rsrc" as _StdlibFilePath.Component])
-      path.components = cv
+    var cv = path.components
+    cv.replaceSubrange(cv.index(before: cv.endIndex) ..< cv.endIndex,
+                       with: ["rsrc" as _StdlibFilePath.Component])
+    path.components = cv
 
-      expectEqual(path.description, "/data/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
-      expectEqual(path.components.map(\.description), ["data"])
-    }
-  }
+    expectEqual(path.description, "/data/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
+    expectEqual(path.components.map(\.description), ["data"])
+}
 
-  @Test
+  @Test(.darwinOnly)
   func darwinResourceForkOnRelativeIsSafe() {
     // Resource fork suffix works on relative paths too
-    withPlatform(.darwin) {
-      var path = _StdlibFilePath("file/..namedfork")
-      var cv = path.components
-      cv.append("rsrc")
-      path.components = cv
+    var path = _StdlibFilePath("file/..namedfork")
+    var cv = path.components
+    cv.append("rsrc")
+    path.components = cv
 
-      expectEqual(path.description, "file/..namedfork/rsrc")
-      expectTrue(path.isResourceFork)
-      expectEqual(path.components.map(\.description), ["file"])
-    }
-  }
+    expectEqual(path.description, "file/..namedfork/rsrc")
+    expectTrue(path.isResourceFork)
+    expectEqual(path.components.map(\.description), ["file"])
+}
 
   // -- Windows reparse hazards --
 
-  @Test
+  @Test(.windowsOnly)
   func windowsRemoveExposesRootBackslash() {
     // \\server\share\only -> remove "only" -> \\server\share\
     // The trailing separator now belongs to the UNC anchor.
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\server\share\only"#)
-      expectEqual(path.anchor?.description, #"\\server\share"#)
-      expectEqual(path.components.map(\.description), ["only"])
+    var path = _StdlibFilePath(#"\\server\share\only"#)
+    expectEqual(path.anchor?.description, #"\\server\share"#)
+    expectEqual(path.components.map(\.description), ["only"])
 
-      var cv = path.components
-      cv.removeLast()
-      path.components = cv
+    var cv = path.components
+    cv.removeLast()
+    path.components = cv
 
-      // With no components, the anchor stands alone
-      expectEqual(path.anchor?.description, #"\\server\share"#)
-      expectTrue(path.components.isEmpty)
-      expectTrue(path.hasTrailingSeparator)
-    }
-  }
+    // With no components, the anchor stands alone
+    expectEqual(path.anchor?.description, #"\\server\share"#)
+    expectTrue(path.components.isEmpty)
+    expectTrue(path.hasTrailingSeparator)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsVerbatimDotPreserved() {
     // In verbatim paths (\\?\), dot and dotdot are regular components.
-    // Appending "." to a verbatim path should NOT be treated as currentDirectory.
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\?\C:\dir"#)
-      var cv = path.components
-      cv.append(".")
-      path.components = cv
+    // Appending "." to a verbatim path should not be treated as currentDirectory.
+    var path = _StdlibFilePath(#"\\?\C:\dir"#)
+    var cv = path.components
+    cv.append(".")
+    path.components = cv
 
-      expectEqual(path.description, #"\\?\C:\dir\."#)
-      // In verbatim context the "." is a regular component name
-      let lastComp = path.components.last!
-      expectEqual(lastComp.kind, .regular)
-    }
-  }
+    expectEqual(path.description, #"\\?\C:\dir\."#)
+    // In verbatim context the "." is a regular component name
+    let lastComp = path.components.last!
+    expectEqual(lastComp.kind, .regular)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsVerbatimDotDotPreserved() {
     // Similarly, ".." in verbatim paths is just a literal name
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\?\C:\dir"#)
-      var cv = path.components
-      cv.append("..")
-      path.components = cv
+    var path = _StdlibFilePath(#"\\?\C:\dir"#)
+    var cv = path.components
+    cv.append("..")
+    path.components = cv
 
-      expectEqual(path.description, #"\\?\C:\dir\.."#)
-      let lastComp = path.components.last!
-      expectEqual(lastComp.kind, .regular)
-    }
-  }
+    expectEqual(path.description, #"\\?\C:\dir\.."#)
+    let lastComp = path.components.last!
+    expectEqual(lastComp.kind, .regular)
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsDevicePathAppend() {
     // \\.\device paths: appending to a device-only path
-    withPlatform(.windows) {
-      var path = _StdlibFilePath(#"\\.\COM1"#)
-      var cv = path.components
-      cv.append("extra")
-      path.components = cv
+    var path = _StdlibFilePath(#"\\.\COM1"#)
+    var cv = path.components
+    cv.append("extra")
+    path.components = cv
 
-      expectEqual(path.description, #"\\.\COM1\extra"#)
-      expectEqual(path.components.map(\.description), ["extra"])
-    }
-  }
+    expectEqual(path.description, #"\\.\COM1\extra"#)
+    expectEqual(path.components.map(\.description), ["extra"])
+}
 }

--- a/Tests/SystemTests/StdlibFilePathTests/ComponentViewTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ComponentViewTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -44,7 +44,7 @@ extension AllTests.ComponentViewTests {
     let winRoot = _StdlibFilePath(#"C:\"#)
     expectTrue(winRoot.components.isEmpty)
     expectNotNil(winRoot.anchor)
-}
+  }
 
   @Test
   func indexTraversal() {
@@ -297,7 +297,7 @@ extension AllTests.ComponentViewTests {
 
     expectEqual(path.description, #"C:\Users\Admin"#)
     expectEqual(path.anchor?.description, #"C:\"#)
-}
+  }
 
   @Test(.windowsOnly)
   func windowsDriveRelativeAppend() {
@@ -309,7 +309,7 @@ extension AllTests.ComponentViewTests {
     // C: anchor (no backslash): components follow directly
     expectEqual(path.description, #"C:src\main.swift"#)
     expectEqual(path.anchor?.description, "C:")
-}
+  }
 
   @Test(.windowsOnly)
   func windowsRemoveComponent() {
@@ -317,7 +317,7 @@ extension AllTests.ComponentViewTests {
     path.components.removeLast()
 
     expectEqual(path.description, #"C:\Users\Admin"#)
-}
+  }
 
   @Test(.windowsOnly)
   func windowsUNCAppend() {
@@ -325,7 +325,7 @@ extension AllTests.ComponentViewTests {
     path.components.append("folder")
 
     expectEqual(path.description, #"\\server\share\folder"#)
-}
+  }
 
   @Test(.windowsOnly)
   func windowsReplaceComponents() {
@@ -335,7 +335,7 @@ extension AllTests.ComponentViewTests {
       with: ["new", "things"] as [_StdlibFilePath.Component])
 
     expectEqual(path.description, #"C:\new\things"#)
-}
+  }
 
   // MARK: - Anchor preservation
 
@@ -377,7 +377,7 @@ extension AllTests.ComponentViewTests {
 
     expectEqual(path.anchor, originalAnchor)
     expectEqual(path.description, #"\\server\share\new"#)
-}
+  }
 
   // MARK: - Hashable / Equatable
 
@@ -480,7 +480,7 @@ extension AllTests.ComponentViewTests {
     var path = _StdlibFilePath(#"C:\"#)
     path.components = cv
     expectEqual(path.description, #"C:\Users\Admin\Documents"#)
-}
+  }
 
   // MARK: - Edge cases
 
@@ -580,7 +580,7 @@ extension AllTests.ComponentViewTests {
 
     expectFalse(path.hasTrailingSeparator)
     expectEqual(path.description, #"C:\Users"#)
-}
+  }
 
   // -- Trailing separator: preserve when last unchanged --
 
@@ -649,7 +649,7 @@ extension AllTests.ComponentViewTests {
     path.components = cv
 
     expectTrue(path.hasTrailingSeparator)
-}
+  }
 
   // -- Trailing separator: strip on append --
 
@@ -687,7 +687,7 @@ extension AllTests.ComponentViewTests {
 
     expectFalse(path.isResourceFork)
     expectEqual(path.description, "/dir")
-}
+  }
 
   @Test(.darwinOnly)
   func resourceForkStrippedOnReplaceLast() {
@@ -701,7 +701,7 @@ extension AllTests.ComponentViewTests {
 
     expectFalse(path.isResourceFork)
     expectEqual(path.description, "/other")
-}
+  }
 
   @Test(.darwinOnly)
   func resourceForkStrippedOnRemoveAll() {
@@ -712,7 +712,7 @@ extension AllTests.ComponentViewTests {
 
     expectFalse(path.isResourceFork)
     expectEqual(path.description, "/")
-}
+  }
 
   // -- Resource fork: preserve when last unchanged --
 
@@ -726,7 +726,7 @@ extension AllTests.ComponentViewTests {
 
     expectTrue(path.isResourceFork)
     expectEqual(path.components.map(\.description), ["dir", "file"])
-}
+  }
 
   @Test(.darwinOnly)
   func resourceForkPreservedOnNoChange() {
@@ -737,7 +737,7 @@ extension AllTests.ComponentViewTests {
     path.components = cv
 
     expectTrue(path.isResourceFork)
-}
+  }
 
   // -- Resource fork: strip on append --
 
@@ -750,7 +750,7 @@ extension AllTests.ComponentViewTests {
 
     expectFalse(path.isResourceFork)
     expectEqual(path.description, "/file/extra")
-}
+  }
 
   // MARK: - Re-decomposition after component mutation
   //
@@ -787,7 +787,7 @@ extension AllTests.ComponentViewTests {
     path.components.removeAll()
     expectFalse(path.hasTrailingSeparator)
     expectEqual(path.description, #"\\server\share"#)
-}
+  }
 
   // MARK: - removeAll across all anchor shapes
   //
@@ -803,42 +803,42 @@ extension AllTests.ComponentViewTests {
     path.components.removeAll()
     expectEqual(path.description, #"\\server\share"#)
     expectFalse(path.hasTrailingSeparator)
-}
+  }
 
   @Test(.windowsOnly)
   func removeAllDriveAbsoluteKeepsAnchorSep() {
     var path = _StdlibFilePath(#"C:\foo\bar"#)
     path.components.removeAll()
     expectEqual(path.description, #"C:\"#)
-}
+  }
 
   @Test(.windowsOnly)
   func removeAllDriveRelativeKeepsColon() {
     var path = _StdlibFilePath(#"C:foo\bar"#)
     path.components.removeAll()
     expectEqual(path.description, "C:")
-}
+  }
 
   @Test(.windowsOnly)
   func removeAllVerbatimDriveKeepsAnchor() {
     var path = _StdlibFilePath(#"\\?\C:\foo\bar"#)
     path.components.removeAll()
     expectEqual(path.description, #"\\?\C:\"#)
-}
+  }
 
   @Test(.windowsOnly)
   func removeAllVerbatimUNCDropsGapSep() {
     var path = _StdlibFilePath(#"\\?\UNC\server\share\foo"#)
     path.components.removeAll()
     expectEqual(path.description, #"\\?\UNC\server\share"#)
-}
+  }
 
   @Test(.windowsOnly)
   func removeAllVerbatimDeviceDropsGapSep() {
     var path = _StdlibFilePath(#"\\?\name\foo"#)
     path.components.removeAll()
     expectEqual(path.description, #"\\?\name"#)
-}
+  }
 
   // MARK: - Colon-ending anchors: Windows drive-relative vs Darwin volfs
   //
@@ -857,7 +857,7 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, "C:foo")
     expectEqual(path.anchor?.description, "C:")
     expectEqual(path.components.map(\.description), ["foo"])
-}
+  }
 
   @Test(.windowsOnly)
   func windowsDriveRelativeMultiAppendStaysDriveRelative() {
@@ -866,7 +866,7 @@ extension AllTests.ComponentViewTests {
     path.components.append("bar")
     expectEqual(path.description, #"C:foo\bar"#)
     expectEqual(path.anchor?.description, "C:")
-}
+  }
 
   @Test(.windowsOnly)
   func windowsDriveRelativeAssignKeepsAnchor() {
@@ -876,7 +876,7 @@ extension AllTests.ComponentViewTests {
     path.components = cv
     expectEqual(path.description, "C:foo")
     expectEqual(path.anchor?.description, "C:")
-}
+  }
 
   @Test(.darwinOnly)
   func darwinVolfsColonInFileIdGetsGapSeparator() {
@@ -889,7 +889,7 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, "/.vol/12345/67890:/foo")
     expectEqual(path.anchor?.description, "/.vol/12345/67890:")
     expectEqual(path.components.map(\.description), ["foo"])
-}
+  }
 
   @Test(.darwinOnly)
   func darwinVolfsColonAssignKeepsAnchor() {
@@ -899,7 +899,7 @@ extension AllTests.ComponentViewTests {
     path.components = cv
     expectEqual(path.description, "/.vol/12345/67890:/foo")
     expectEqual(path.anchor?.description, "/.vol/12345/67890:")
-}
+  }
 
   @Test(.windowsOnly)
   func windowsUNCWithColonShareGetsGapSeparator() {
@@ -911,7 +911,7 @@ extension AllTests.ComponentViewTests {
     path.components.append("foo")
     expectEqual(path.description, #"\\server\C:\foo"#)
     expectEqual(path.anchor?.description, #"\\server\C:"#)
-}
+  }
 
   @Test(.windowsOnly)
   func windowsUNCWithColonShareAssignKeepsGap() {
@@ -920,7 +920,7 @@ extension AllTests.ComponentViewTests {
     cv.append("foo")
     path.components = cv
     expectEqual(path.description, #"\\server\C:\foo"#)
-}
+  }
 
   // MARK: - Suffix interactions with splice
 
@@ -954,7 +954,7 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, "/foo/x/bar/..namedfork/rsrc")
     expectTrue(path.isResourceFork)
     expectEqual(path.components.map(\.description), ["foo", "x", "bar"])
-}
+  }
 
   // MARK: - Cross-anchor assignment
   //
@@ -972,7 +972,7 @@ extension AllTests.ComponentViewTests {
     let cv = _StdlibFilePath(#"C:\bar"#).components
     path.components = cv
     expectEqual(path.description, #"\bar"#)
-}
+  }
 
   @Test
   func assignAnchoredCvOntoAnchorlessKeepsAnchorless() {
@@ -1001,7 +1001,7 @@ extension AllTests.ComponentViewTests {
     assigned.components = cv
 
     expectEqual(assigned.description, inPlace.description)
-}
+  }
 
   // -- Darwin anchor hazards --
 
@@ -1021,7 +1021,7 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, "/.nofollow/foo/bar")
     expectEqual(path.anchor?.description, "/.nofollow/")
     expectEqual(path.components.map(\.description), ["foo", "bar"])
-}
+  }
 
   @Test(.darwinOnly)
   func darwinInsertResolveAtFront() {
@@ -1040,7 +1040,7 @@ extension AllTests.ComponentViewTests {
     let newComps = path.components.map(\.description)
     expectEqual(newAnchor, "/.resolve/usr/")
     expectEqual(newComps, ["bin"])
-}
+  }
 
   @Test(.darwinOnly)
   func darwinInsertVolAtFront() {
@@ -1058,7 +1058,7 @@ extension AllTests.ComponentViewTests {
     let newComps = path.components.map(\.description)
     expectEqual(newAnchor, "/.vol/1234/5678")
     expectEqual(newComps, ["file"])
-}
+  }
 
   @Test(.darwinOnly)
   func darwinAppendsFormCombinedAnchor() {
@@ -1085,7 +1085,7 @@ extension AllTests.ComponentViewTests {
     // Absorption: components fold into the combined anchor.
     expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
     expectEqual(path.components.map(\.description), [])
-}
+  }
 
   @Test(.darwinOnly)
   func darwinRemoveLastFromCombinedAnchorStaysWithLeading() {
@@ -1103,7 +1103,7 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.anchor?.description, "/.nofollow/.vol/1234/5678")
     expectEqual(path.components.map(\.description), [])
     expectTrue(path.hasTrailingSeparator)
-}
+  }
 
   @Test(.darwinOnly)
   func darwinRemoveComponentExposesAnchor() {
@@ -1123,7 +1123,7 @@ extension AllTests.ComponentViewTests {
     let newComps = path.components.map(\.description)
     expectEqual(newAnchor, "/.nofollow/")
     expectEqual(newComps, ["foo"])
-}
+  }
 
   @Test(.darwinOnly)
   func darwinReplaceFirstExposesVol() {
@@ -1142,7 +1142,7 @@ extension AllTests.ComponentViewTests {
     let newComps = path.components.map(\.description)
     expectEqual(newAnchor, "/.vol/1234/5678")
     expectEqual(newComps, [])
-}
+  }
 
   @Test(.darwinOnly)
   func darwinNofollowOnRelativePathIsSafe() {
@@ -1156,7 +1156,7 @@ extension AllTests.ComponentViewTests {
     expectNil(path.anchor)
     expectEqual(path.components.map(\.description), [".nofollow", "a", "b"])
     expectEqual(path.description, ".nofollow/a/b")
-}
+  }
 
   @Test(.darwinOnly)
   func darwinNofollowNotFirstIsSafe() {
@@ -1169,7 +1169,7 @@ extension AllTests.ComponentViewTests {
     // .nofollow at end doesn't affect the anchor
     expectEqual(path.anchor?.description, "/")
     expectEqual(path.components.map(\.description), ["usr", "bin", ".nofollow"])
-}
+  }
 
   // -- Darwin resource fork hazards --
 
@@ -1191,7 +1191,7 @@ extension AllTests.ComponentViewTests {
     // The components no longer include ..namedfork and rsrc
     let newComps = path.components.map(\.description)
     expectEqual(newComps, ["file"])
-}
+  }
 
   @Test(.darwinOnly)
   func darwinInsertBeforeRsrcBreaksSuffix() {
@@ -1210,7 +1210,7 @@ extension AllTests.ComponentViewTests {
     // so we only have ["file"] + the new component, no resource fork.
     expectEqual(path.components.map(\.description), ["file", "oops"])
     expectFalse(path.isResourceFork)
-}
+  }
 
   @Test(.darwinOnly)
   func darwinRemoveLastCreatesResourceFork() {
@@ -1232,7 +1232,7 @@ extension AllTests.ComponentViewTests {
     expectTrue(path.isResourceFork)
     let newComps = path.components.map(\.description)
     expectEqual(newComps, ["dir", "file"])
-}
+  }
 
   @Test(.darwinOnly)
   func darwinReplaceCreatesResourceFork() {
@@ -1248,7 +1248,7 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, "/data/..namedfork/rsrc")
     expectTrue(path.isResourceFork)
     expectEqual(path.components.map(\.description), ["data"])
-}
+  }
 
   @Test(.darwinOnly)
   func darwinResourceForkOnRelativeIsSafe() {
@@ -1261,7 +1261,7 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, "file/..namedfork/rsrc")
     expectTrue(path.isResourceFork)
     expectEqual(path.components.map(\.description), ["file"])
-}
+  }
 
   // -- Windows reparse hazards --
 
@@ -1281,12 +1281,12 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.anchor?.description, #"\\server\share"#)
     expectTrue(path.components.isEmpty)
     expectTrue(path.hasTrailingSeparator)
-}
+  }
 
   @Test(.windowsOnly)
   func windowsVerbatimDotPreserved() {
     // In verbatim paths (\\?\), dot and dotdot are regular components.
-    // Appending "." to a verbatim path should not be treated as currentDirectory.
+    // Appending "." to a verbatim path is not treated as currentDirectory.
     var path = _StdlibFilePath(#"\\?\C:\dir"#)
     var cv = path.components
     cv.append(".")
@@ -1296,7 +1296,7 @@ extension AllTests.ComponentViewTests {
     // In verbatim context the "." is a regular component name
     let lastComp = path.components.last!
     expectEqual(lastComp.kind, .regular)
-}
+  }
 
   @Test(.windowsOnly)
   func windowsVerbatimDotDotPreserved() {
@@ -1309,7 +1309,7 @@ extension AllTests.ComponentViewTests {
     expectEqual(path.description, #"\\?\C:\dir\.."#)
     let lastComp = path.components.last!
     expectEqual(lastComp.kind, .regular)
-}
+  }
 
   @Test(.windowsOnly)
   func windowsDevicePathAppend() {
@@ -1321,5 +1321,5 @@ extension AllTests.ComponentViewTests {
 
     expectEqual(path.description, #"\\.\COM1\extra"#)
     expectEqual(path.components.map(\.description), ["extra"])
-}
+  }
 }

--- a/Tests/SystemTests/StdlibFilePathTests/DecompositionTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/DecompositionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SystemTests/StdlibFilePathTests/DecompositionTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/DecompositionTests.swift
@@ -1,0 +1,119 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+extension AllTests.DecompositionTests {
+
+  func runCase(_ tc: PathTestCase, platform: _Platform) {
+    withPlatform(platform) {
+      let expected: Expected
+      switch platform {
+      case .linux: expected = tc.linux
+      case .darwin: expected = tc.darwin
+      case .windows: expected = tc.windows
+      }
+
+      let path = _StdlibFilePath(tc.input)!
+
+      // anchor
+      let anchorDesc = path.anchor?.description
+      expectEqual(anchorDesc, expected.anchor,
+        "[\(platform)] input=\(tc.input.debugDescription) anchor: got \(anchorDesc.debugDescription), expected \(expected.anchor.debugDescription)")
+
+      // components
+      let compDescs = path.components.map(\.description)
+      expectEqual(compDescs, expected.components,
+        "[\(platform)] input=\(tc.input.debugDescription) components: got \(compDescs), expected \(expected.components)")
+
+      // hasTrailingSeparator
+      expectEqual(path.hasTrailingSeparator, expected.hasTrailingSeparator,
+        "[\(platform)] input=\(tc.input.debugDescription) hasTrailingSep: got \(path.hasTrailingSeparator), expected \(expected.hasTrailingSeparator)")
+
+      // isResourceFork (Darwin)
+      if platform == .darwin {
+        expectEqual(path.isResourceFork, expected.isResourceFork,
+          "[\(platform)] input=\(tc.input.debugDescription) isResourceFork: got \(path.isResourceFork), expected \(expected.isResourceFork)")
+      }
+
+      // printed
+      expectEqual(path.description, expected.printed,
+        "[\(platform)] input=\(tc.input.debugDescription) printed: got \(path.description.debugDescription), expected \(expected.printed.debugDescription)")
+
+      // isAbsolute
+      expectEqual(path.isAbsolute, expected.isAbsolute,
+        "[\(platform)] input=\(tc.input.debugDescription) isAbsolute: got \(path.isAbsolute), expected \(expected.isAbsolute)")
+
+      // isRooted
+      let expectedRooted = expected.isRooted ?? expected.isAbsolute
+      let actualRooted = path.anchor?.isRooted ?? false
+      expectEqual(actualRooted, expectedRooted,
+        "[\(platform)] input=\(tc.input.debugDescription) isRooted: got \(actualRooted), expected \(expectedRooted)")
+
+      // driveLetter
+      if let expectedDrive = expected.driveLetter {
+        expectTrue(path.anchor?._driveLetter == expectedDrive,
+          "[\(platform)] input=\(tc.input.debugDescription) driveLetter: got \(path.anchor?._driveLetter.debugDescription ?? "nil"), expected \(expectedDrive)")
+      }
+
+      // kinds
+      let actualKinds = path.components.map(\.kind)
+      if let expectedKinds = expected.kinds {
+        expectEqual(actualKinds, expectedKinds,
+          "[\(platform)] input=\(tc.input.debugDescription) kinds: got \(actualKinds), expected \(expectedKinds)")
+      } else {
+        let allRegular = actualKinds.allSatisfy { $0 == .regular }
+        expectTrue(allRegular,
+          "[\(platform)] input=\(tc.input.debugDescription) kinds: expected all .regular, got \(actualKinds)")
+      }
+
+      // Round-trip: reconstruct from decomposition
+      let roundTrip: _StdlibFilePath
+      if expected.isResourceFork {
+        roundTrip = _StdlibFilePath(
+          anchor: path.anchor,
+          path.components,
+          resourceFork: true)
+      } else {
+        roundTrip = _StdlibFilePath(
+          anchor: path.anchor,
+          path.components,
+          hasTrailingSeparator: path.hasTrailingSeparator)
+      }
+      expectEqual(roundTrip, path,
+        "[\(platform)] input=\(tc.input.debugDescription) round-trip failed: got \(roundTrip.description.debugDescription), expected \(path.description.debugDescription)")
+    }
+  }
+
+  @Test
+  func allCasesLinux() {
+    for tc in pathTestCases {
+      runCase(tc, platform: .linux)
+    }
+  }
+
+  @Test
+  func allCasesDarwin() {
+    for tc in pathTestCases {
+      runCase(tc, platform: .darwin)
+    }
+  }
+
+  @Test
+  func allCasesWindows() {
+    for tc in pathTestCases {
+      runCase(tc, platform: .windows)
+    }
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/DecompositionTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/DecompositionTests.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,100 +17,98 @@ import Testing
 extension AllTests.DecompositionTests {
 
   func runCase(_ tc: PathTestCase, platform: _Platform) {
-    withPlatform(platform) {
-      let expected: Expected
-      switch platform {
-      case .linux: expected = tc.linux
-      case .darwin: expected = tc.darwin
-      case .windows: expected = tc.windows
-      }
-
-      let path = _StdlibFilePath(tc.input)!
-
-      // anchor
-      let anchorDesc = path.anchor?.description
-      expectEqual(anchorDesc, expected.anchor,
-        "[\(platform)] input=\(tc.input.debugDescription) anchor: got \(anchorDesc.debugDescription), expected \(expected.anchor.debugDescription)")
-
-      // components
-      let compDescs = path.components.map(\.description)
-      expectEqual(compDescs, expected.components,
-        "[\(platform)] input=\(tc.input.debugDescription) components: got \(compDescs), expected \(expected.components)")
-
-      // hasTrailingSeparator
-      expectEqual(path.hasTrailingSeparator, expected.hasTrailingSeparator,
-        "[\(platform)] input=\(tc.input.debugDescription) hasTrailingSep: got \(path.hasTrailingSeparator), expected \(expected.hasTrailingSeparator)")
-
-      // isResourceFork (Darwin)
-      if platform == .darwin {
-        expectEqual(path.isResourceFork, expected.isResourceFork,
-          "[\(platform)] input=\(tc.input.debugDescription) isResourceFork: got \(path.isResourceFork), expected \(expected.isResourceFork)")
-      }
-
-      // printed
-      expectEqual(path.description, expected.printed,
-        "[\(platform)] input=\(tc.input.debugDescription) printed: got \(path.description.debugDescription), expected \(expected.printed.debugDescription)")
-
-      // isAbsolute
-      expectEqual(path.isAbsolute, expected.isAbsolute,
-        "[\(platform)] input=\(tc.input.debugDescription) isAbsolute: got \(path.isAbsolute), expected \(expected.isAbsolute)")
-
-      // isRooted
-      let expectedRooted = expected.isRooted ?? expected.isAbsolute
-      let actualRooted = path.anchor?.isRooted ?? false
-      expectEqual(actualRooted, expectedRooted,
-        "[\(platform)] input=\(tc.input.debugDescription) isRooted: got \(actualRooted), expected \(expectedRooted)")
-
-      // driveLetter
-      if let expectedDrive = expected.driveLetter {
-        expectTrue(path.anchor?._driveLetter == expectedDrive,
-          "[\(platform)] input=\(tc.input.debugDescription) driveLetter: got \(path.anchor?._driveLetter.debugDescription ?? "nil"), expected \(expectedDrive)")
-      }
-
-      // kinds
-      let actualKinds = path.components.map(\.kind)
-      if let expectedKinds = expected.kinds {
-        expectEqual(actualKinds, expectedKinds,
-          "[\(platform)] input=\(tc.input.debugDescription) kinds: got \(actualKinds), expected \(expectedKinds)")
-      } else {
-        let allRegular = actualKinds.allSatisfy { $0 == .regular }
-        expectTrue(allRegular,
-          "[\(platform)] input=\(tc.input.debugDescription) kinds: expected all .regular, got \(actualKinds)")
-      }
-
-      // Round-trip: reconstruct from decomposition
-      let roundTrip: _StdlibFilePath
-      if expected.isResourceFork {
-        roundTrip = _StdlibFilePath(
-          anchor: path.anchor,
-          path.components,
-          resourceFork: true)
-      } else {
-        roundTrip = _StdlibFilePath(
-          anchor: path.anchor,
-          path.components,
-          hasTrailingSeparator: path.hasTrailingSeparator)
-      }
-      expectEqual(roundTrip, path,
-        "[\(platform)] input=\(tc.input.debugDescription) round-trip failed: got \(roundTrip.description.debugDescription), expected \(path.description.debugDescription)")
+    let expected: Expected
+    switch platform {
+    case .linux: expected = tc.linux
+    case .darwin: expected = tc.darwin
+    case .windows: expected = tc.windows
     }
+
+    let path = _StdlibFilePath(tc.input)!
+
+    // anchor
+    let anchorDesc = path.anchor?.description
+    expectEqual(anchorDesc, expected.anchor,
+      "[\(platform)] input=\(tc.input.debugDescription) anchor: got \(anchorDesc.debugDescription), expected \(expected.anchor.debugDescription)")
+
+    // components
+    let compDescs = path.components.map(\.description)
+    expectEqual(compDescs, expected.components,
+      "[\(platform)] input=\(tc.input.debugDescription) components: got \(compDescs), expected \(expected.components)")
+
+    // hasTrailingSeparator
+    expectEqual(path.hasTrailingSeparator, expected.hasTrailingSeparator,
+      "[\(platform)] input=\(tc.input.debugDescription) hasTrailingSep: got \(path.hasTrailingSeparator), expected \(expected.hasTrailingSeparator)")
+
+    // isResourceFork (Darwin)
+    if platform == .darwin {
+      expectEqual(path.isResourceFork, expected.isResourceFork,
+        "[\(platform)] input=\(tc.input.debugDescription) isResourceFork: got \(path.isResourceFork), expected \(expected.isResourceFork)")
+    }
+
+    // printed
+    expectEqual(path.description, expected.printed,
+      "[\(platform)] input=\(tc.input.debugDescription) printed: got \(path.description.debugDescription), expected \(expected.printed.debugDescription)")
+
+    // isAbsolute
+    expectEqual(path.isAbsolute, expected.isAbsolute,
+      "[\(platform)] input=\(tc.input.debugDescription) isAbsolute: got \(path.isAbsolute), expected \(expected.isAbsolute)")
+
+    // isRooted
+    let expectedRooted = expected.isRooted ?? expected.isAbsolute
+    let actualRooted = path.anchor?.isRooted ?? false
+    expectEqual(actualRooted, expectedRooted,
+      "[\(platform)] input=\(tc.input.debugDescription) isRooted: got \(actualRooted), expected \(expectedRooted)")
+
+    // driveLetter
+    if let expectedDrive = expected.driveLetter {
+      expectTrue(path.anchor?._driveLetter == expectedDrive,
+        "[\(platform)] input=\(tc.input.debugDescription) driveLetter: got \(path.anchor?._driveLetter.debugDescription ?? "nil"), expected \(expectedDrive)")
+    }
+
+    // kinds
+    let actualKinds = path.components.map(\.kind)
+    if let expectedKinds = expected.kinds {
+      expectEqual(actualKinds, expectedKinds,
+        "[\(platform)] input=\(tc.input.debugDescription) kinds: got \(actualKinds), expected \(expectedKinds)")
+    } else {
+      let allRegular = actualKinds.allSatisfy { $0 == .regular }
+      expectTrue(allRegular,
+        "[\(platform)] input=\(tc.input.debugDescription) kinds: expected all .regular, got \(actualKinds)")
+    }
+
+    // Round-trip: reconstruct from decomposition
+    let roundTrip: _StdlibFilePath
+    if expected.isResourceFork {
+      roundTrip = _StdlibFilePath(
+        anchor: path.anchor,
+        path.components,
+        resourceFork: true)
+    } else {
+      roundTrip = _StdlibFilePath(
+        anchor: path.anchor,
+        path.components,
+        hasTrailingSeparator: path.hasTrailingSeparator)
+    }
+    expectEqual(roundTrip, path,
+      "[\(platform)] input=\(tc.input.debugDescription) round-trip failed: got \(roundTrip.description.debugDescription), expected \(path.description.debugDescription)")
   }
 
-  @Test
+  @Test(.linuxOnly)
   func allCasesLinux() {
     for tc in pathTestCases {
       runCase(tc, platform: .linux)
     }
   }
 
-  @Test
+  @Test(.darwinOnly)
   func allCasesDarwin() {
     for tc in pathTestCases {
       runCase(tc, platform: .darwin)
     }
   }
 
-  @Test
+  @Test(.windowsOnly)
   func allCasesWindows() {
     for tc in pathTestCases {
       runCase(tc, platform: .windows)

--- a/Tests/SystemTests/StdlibFilePathTests/EqualityTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/EqualityTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -63,14 +63,14 @@ extension AllTests.EqualityTests {
     // the kernel, so it is significant for ==.
     expectNotEqual(_StdlibFilePath("/.nofollow/foo/bar"), _StdlibFilePath("/foo/bar"),
       "differing Darwin anchors")
-}
+  }
 
   @Test(.windowsOnly)
   func windowsAnchorIsSignificant() {
     // Device-namespace `\\.\C:\` vs drive `C:\` are different anchors.
     expectNotEqual(_StdlibFilePath(#"\\.\C:\foo\bar"#), _StdlibFilePath(#"C:\foo\bar"#),
       "differing Windows anchors")
-}
+  }
 
   // MARK: - Darwin canonicalization equality
 
@@ -82,9 +82,9 @@ extension AllTests.EqualityTests {
     // /.vol/NNNN/2/ canonicalizes to /.vol/NNNN/@/ (inode 2 is the root @).
     expectEqual(_StdlibFilePath("/.vol/1234/2/x"), _StdlibFilePath("/.vol/1234/@/x"),
       "/.vol/1234/2/x == /.vol/1234/@/x")
-    // Combined anchor: both canonicalizations fire on
-    // the same input: `/.resolve/1/.vol/N/2/` and `/.nofollow/.vol/N/@/`
-    // are two spellings of the same anchor.
+    // Combined anchor: both canonicalizations fire on the same input, so
+    // `/.resolve/1/.vol/N/2/` and `/.nofollow/.vol/N/@/` are two spellings
+    // of the same anchor.
     expectEqual(
       _StdlibFilePath("/.resolve/1/.vol/1234/2/x"),
       _StdlibFilePath("/.nofollow/.vol/1234/@/x"),
@@ -95,7 +95,7 @@ extension AllTests.EqualityTests {
       _StdlibFilePath("/.resolve/3/.vol/1234/2/x"),
       _StdlibFilePath("/.resolve/3/.vol/1234/@/x"),
       "/.resolve/3/.vol/1234/2/x == /.resolve/3/.vol/1234/@/x")
-}
+  }
 
   // MARK: - Hash agrees with equality (equal direction only)
 
@@ -135,7 +135,7 @@ extension AllTests.EqualityTests {
       "/.nofollow/foo < /foo")
     expectFalse(_StdlibFilePath("/foo") < _StdlibFilePath("/.nofollow/foo"),
       "not /foo < /.nofollow/foo")
-}
+  }
 
   @Test
   func orderingDistinguishesOnComponents() {
@@ -218,5 +218,5 @@ extension AllTests.EqualityTests {
     expectTrue(
       _StdlibFilePath.Anchor("/.nofollow/") < _StdlibFilePath.Anchor("/.vol/1234/5678"),
       "/.nofollow/ < /.vol/1234/5678")
-}
+  }
 }

--- a/Tests/SystemTests/StdlibFilePathTests/EqualityTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/EqualityTests.swift
@@ -1,0 +1,232 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// Equality, hashing, ordering. _StdlibFilePath is pitched as a Dictionary key and as
+// sortable, so this is load-bearing. Every expected value is derived from
+// SE-0529, not from running the implementation:
+//   * Equality: two paths are equal iff they have identical anchors, identical
+//     component sequences, and the same suffix (trailing separator / resource
+//     fork). Equality is purely syntactic — equal precisely when they print
+//     the same. (Proposal "Printing, comparing, and hashing"; examples 701-718.)
+//   * Darwin anchor canonicalization: `/.resolve/1/` => `/.nofollow/`, and
+//     `/.vol/NNNN/2/` => `/.vol/NNNN/@/`. (Proposal 220-223; table 546, 549.)
+//   * Ordering: lexicographic over the normalized byte representation —
+//     anchor, then components, then suffix as final tiebreaker. (Proposal 724.)
+
+extension AllTests.EqualityTests {
+
+  // MARK: - Encoding-difference equality (proposal lines 701-711)
+
+  // Repeated separators and interior `.` are meaningless encoding differences;
+  // such spellings normalize to the same bytes and compare equal. Holds on
+  // every platform (separator coalescing + dot normalization).
+  @Test
+  func encodingDifferencesAreEqual() {
+    expectEqual(_StdlibFilePath("a///b"), _StdlibFilePath("a/b"), "a///b == a/b")
+    expectEqual(_StdlibFilePath("a/./b"), _StdlibFilePath("a/b"), "a/./b == a/b")
+    expectEqual(_StdlibFilePath("/./foo"), _StdlibFilePath("/foo"), "/./foo == /foo")
+  }
+
+  // MARK: - Suffix significance (proposal lines 713-714)
+
+  @Test
+  func trailingSeparatorIsSignificant() {
+    // "/tmp/foo" vs "/tmp/foo/": the trailing separator is meaningful.
+    expectNotEqual(_StdlibFilePath("/tmp/foo"), _StdlibFilePath("/tmp/foo/"),
+      "trailing separator differs")
+  }
+
+  @Test
+  func currentDirectoryIsNotEmpty() {
+    // "." has one component; "" is empty.
+    expectNotEqual(_StdlibFilePath("."), _StdlibFilePath(""), "\".\" != \"\"")
+  }
+
+  // MARK: - Anchor significance (proposal lines 716-717)
+
+  @Test
+  func darwinAnchorIsSignificant() {
+    withPlatform(.darwin) {
+      // The do-not-follow-symlinks flag is part of the path's directions to
+      // the kernel, so it is significant for ==.
+      expectNotEqual(_StdlibFilePath("/.nofollow/foo/bar"), _StdlibFilePath("/foo/bar"),
+        "differing Darwin anchors")
+    }
+  }
+
+  @Test
+  func windowsAnchorIsSignificant() {
+    withPlatform(.windows) {
+      // Device-namespace `\\.\C:\` vs drive `C:\` are different anchors.
+      expectNotEqual(_StdlibFilePath(#"\\.\C:\foo\bar"#), _StdlibFilePath(#"C:\foo\bar"#),
+        "differing Windows anchors")
+    }
+  }
+
+  // MARK: - Darwin canonicalization equality (proposal lines 220-223, 546, 549)
+
+  @Test
+  func darwinCanonicalizationEquality() {
+    withPlatform(.darwin) {
+      // /.resolve/1/ canonicalizes to /.nofollow/ (same XNU flag).
+      expectEqual(_StdlibFilePath("/.resolve/1/foo"), _StdlibFilePath("/.nofollow/foo"),
+        "/.resolve/1/foo == /.nofollow/foo")
+      // /.vol/NNNN/2/ canonicalizes to /.vol/NNNN/@/ (inode 2 is the root @).
+      expectEqual(_StdlibFilePath("/.vol/1234/2/x"), _StdlibFilePath("/.vol/1234/@/x"),
+        "/.vol/1234/2/x == /.vol/1234/@/x")
+      // Combined anchor (proposal line 111): both canonicalizations fire on
+      // the same input — `/.resolve/1/.vol/N/2/` and `/.nofollow/.vol/N/@/`
+      // are two spellings of the same anchor.
+      expectEqual(
+        _StdlibFilePath("/.resolve/1/.vol/1234/2/x"),
+        _StdlibFilePath("/.nofollow/.vol/1234/@/x"),
+        "/.resolve/1/.vol/1234/2/x == /.nofollow/.vol/1234/@/x")
+      // Combined anchor with only the FILEID rule firing (resolve/3 is not
+      // canonicalizing).
+      expectEqual(
+        _StdlibFilePath("/.resolve/3/.vol/1234/2/x"),
+        _StdlibFilePath("/.resolve/3/.vol/1234/@/x"),
+        "/.resolve/3/.vol/1234/2/x == /.resolve/3/.vol/1234/@/x")
+    }
+  }
+
+  // MARK: - Hash agrees with equality (equal direction only; proposal line 720)
+
+  // Hashable's contract: equal values must hash equal. Assert that for every
+  // pair we asserted equal above. (We do NOT assert unequal values hash
+  // differently — that is not required.)
+  @Test
+  func hashAgreesWithEquality() {
+    expectEqual(_StdlibFilePath("a///b").hashValue, _StdlibFilePath("a/b").hashValue,
+      "hash(a///b) == hash(a/b)")
+    expectEqual(_StdlibFilePath("a/./b").hashValue, _StdlibFilePath("a/b").hashValue,
+      "hash(a/./b) == hash(a/b)")
+    expectEqual(_StdlibFilePath("/./foo").hashValue, _StdlibFilePath("/foo").hashValue,
+      "hash(/./foo) == hash(/foo)")
+    withPlatform(.darwin) {
+      expectEqual(_StdlibFilePath("/.resolve/1/foo").hashValue,
+                  _StdlibFilePath("/.nofollow/foo").hashValue,
+        "hash canonicalization (resolve)")
+      expectEqual(_StdlibFilePath("/.vol/1234/2/x").hashValue,
+                  _StdlibFilePath("/.vol/1234/@/x").hashValue,
+        "hash canonicalization (vol)")
+    }
+  }
+
+  // MARK: - Comparable ordering (proposal lines 722-724)
+
+  // Ordering is lexicographic over the normalized byte representation: anchor
+  // bytes first, then component bytes, then the suffix as a tiebreaker. The
+  // three tests below isolate a single axis each.
+
+  @Test
+  func orderingDistinguishesOnAnchor() {
+    withPlatform(.darwin) {
+      // Same components ["foo"], same (no) suffix; differ only by anchor.
+      // Normalized bytes "/.nofollow/foo" vs "/foo" first differ at index 1
+      // ('.' 0x2E < 'f' 0x66), so the anchored path sorts first.
+      expectTrue(_StdlibFilePath("/.nofollow/foo") < _StdlibFilePath("/foo"),
+        "/.nofollow/foo < /foo")
+      expectFalse(_StdlibFilePath("/foo") < _StdlibFilePath("/.nofollow/foo"),
+        "not /foo < /.nofollow/foo")
+    }
+  }
+
+  @Test
+  func orderingDistinguishesOnComponents() {
+    // Same (no) anchor, same suffix; differ only in component bytes.
+    expectTrue(_StdlibFilePath("foo/aaa") < _StdlibFilePath("foo/bbb"),
+      "foo/aaa < foo/bbb")
+    expectFalse(_StdlibFilePath("foo/bbb") < _StdlibFilePath("foo/aaa"),
+      "not foo/bbb < foo/aaa")
+  }
+
+  @Test
+  func orderingDistinguishesOnSuffix() {
+    // Same anchor, same components; differ only by trailing separator.
+    // The unsuffixed path is a proper prefix of the suffixed one, so it
+    // sorts first — the suffix is the final tiebreaker.
+    expectTrue(_StdlibFilePath("/tmp/foo") < _StdlibFilePath("/tmp/foo/"),
+      "/tmp/foo < /tmp/foo/")
+    expectFalse(_StdlibFilePath("/tmp/foo/") < _StdlibFilePath("/tmp/foo"),
+      "not /tmp/foo/ < /tmp/foo")
+  }
+
+  @Test
+  func orderingIsStrictTotalOnThreeElements() {
+    // Sorted order is "a" < "a/b" < "b":
+    //   "a"   is a proper prefix of "a/b"          => "a"   < "a/b"
+    //   "a/b" vs "b" first differ at 'a' < 'b'     => "a/b" < "b"
+    let p1 = _StdlibFilePath("a")
+    let p2 = _StdlibFilePath("a/b")
+    let p3 = _StdlibFilePath("b")
+
+    // irreflexivity
+    expectFalse(p1 < p1, "irreflexive p1")
+    expectFalse(p2 < p2, "irreflexive p2")
+    expectFalse(p3 < p3, "irreflexive p3")
+
+    // the order itself
+    expectTrue(p1 < p2, "p1 < p2")
+    expectTrue(p2 < p3, "p2 < p3")
+
+    // antisymmetry (a < b implies not b < a)
+    expectFalse(p2 < p1, "antisymmetry p1/p2")
+    expectFalse(p3 < p2, "antisymmetry p2/p3")
+
+    // transitivity (p1 < p2 and p2 < p3 implies p1 < p3)
+    expectTrue(p1 < p3, "transitivity p1 < p3")
+  }
+
+  // MARK: - Component equality / ordering (brief)
+
+  @Test
+  func componentEqualityAndOrdering() {
+    expectEqual(_StdlibFilePath.Component("foo"), _StdlibFilePath.Component("foo"),
+      "foo == foo")
+    expectNotEqual(_StdlibFilePath.Component("foo"), _StdlibFilePath.Component("bar"),
+      "foo != bar")
+    expectEqual(_StdlibFilePath.Component("foo").hashValue,
+                _StdlibFilePath.Component("foo").hashValue,
+      "equal components hash equal")
+    expectTrue(_StdlibFilePath.Component("a") < _StdlibFilePath.Component("b"),
+      "component a < b")
+    // A proper prefix sorts first.
+    expectTrue(_StdlibFilePath.Component("a") < _StdlibFilePath.Component("ab"),
+      "component a < ab")
+  }
+
+  // MARK: - Anchor equality / ordering (brief)
+
+  @Test
+  func anchorEqualityAndOrdering() {
+    withPlatform(.darwin) {
+      // Canonicalization collapses these to the same anchor bytes.
+      expectEqual(_StdlibFilePath.Anchor("/.resolve/1/"), _StdlibFilePath.Anchor("/.nofollow/"),
+        "/.resolve/1/ anchor == /.nofollow/ anchor")
+      expectEqual(_StdlibFilePath.Anchor("/.resolve/1/").hashValue,
+                  _StdlibFilePath.Anchor("/.nofollow/").hashValue,
+        "canonical anchors hash equal")
+      expectNotEqual(_StdlibFilePath.Anchor("/"), _StdlibFilePath.Anchor("/.nofollow/"),
+        "/ anchor != /.nofollow/ anchor")
+      // "/.nofollow/" vs "/.vol/1234/5678" first differ at index 2
+      // ('n' 0x6E < 'v' 0x76).
+      expectTrue(
+        _StdlibFilePath.Anchor("/.nofollow/") < _StdlibFilePath.Anchor("/.vol/1234/5678"),
+        "/.nofollow/ < /.vol/1234/5678")
+    }
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/EqualityTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/EqualityTests.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,21 +14,21 @@ import Testing
 @testable import System
 #endif
 
-// Equality, hashing, ordering. _StdlibFilePath is pitched as a Dictionary key and as
-// sortable, so this is load-bearing. Every expected value is derived from
-// SE-0529, not from running the implementation:
+// Equality, hashing, and ordering. `_StdlibFilePath` is meant to serve as a
+// Dictionary key and to sort, so this is load-bearing. Every expected value
+// here is derived from SE-0529, not from running the implementation:
 //   * Equality: two paths are equal iff they have identical anchors, identical
-//     component sequences, and the same suffix (trailing separator / resource
-//     fork). Equality is purely syntactic — equal precisely when they print
-//     the same. (Proposal "Printing, comparing, and hashing"; examples 701-718.)
+//     component sequences, and the same suffix (trailing separator or resource
+//     fork). Equality is purely syntactic: equal precisely when they print the
+//     same. (SE-0529, "Printing, comparing, and hashing".)
 //   * Darwin anchor canonicalization: `/.resolve/1/` => `/.nofollow/`, and
-//     `/.vol/NNNN/2/` => `/.vol/NNNN/@/`. (Proposal 220-223; table 546, 549.)
-//   * Ordering: lexicographic over the normalized byte representation —
-//     anchor, then components, then suffix as final tiebreaker. (Proposal 724.)
+//     `/.vol/NNNN/2/` => `/.vol/NNNN/@/`.
+//   * Ordering: lexicographic over the normalized byte representation: anchor,
+//     then components, then the suffix as the final tiebreaker.
 
 extension AllTests.EqualityTests {
 
-  // MARK: - Encoding-difference equality (proposal lines 701-711)
+  // MARK: - Encoding-difference equality
 
   // Repeated separators and interior `.` are meaningless encoding differences;
   // such spellings normalize to the same bytes and compare equal. Holds on
@@ -40,7 +40,7 @@ extension AllTests.EqualityTests {
     expectEqual(_StdlibFilePath("/./foo"), _StdlibFilePath("/foo"), "/./foo == /foo")
   }
 
-  // MARK: - Suffix significance (proposal lines 713-714)
+  // MARK: - Suffix significance
 
   @Test
   func trailingSeparatorIsSignificant() {
@@ -55,59 +55,53 @@ extension AllTests.EqualityTests {
     expectNotEqual(_StdlibFilePath("."), _StdlibFilePath(""), "\".\" != \"\"")
   }
 
-  // MARK: - Anchor significance (proposal lines 716-717)
+  // MARK: - Anchor significance
 
-  @Test
+  @Test(.darwinOnly)
   func darwinAnchorIsSignificant() {
-    withPlatform(.darwin) {
-      // The do-not-follow-symlinks flag is part of the path's directions to
-      // the kernel, so it is significant for ==.
-      expectNotEqual(_StdlibFilePath("/.nofollow/foo/bar"), _StdlibFilePath("/foo/bar"),
-        "differing Darwin anchors")
-    }
-  }
+    // The do-not-follow-symlinks flag is part of the path's directions to
+    // the kernel, so it is significant for ==.
+    expectNotEqual(_StdlibFilePath("/.nofollow/foo/bar"), _StdlibFilePath("/foo/bar"),
+      "differing Darwin anchors")
+}
 
-  @Test
+  @Test(.windowsOnly)
   func windowsAnchorIsSignificant() {
-    withPlatform(.windows) {
-      // Device-namespace `\\.\C:\` vs drive `C:\` are different anchors.
-      expectNotEqual(_StdlibFilePath(#"\\.\C:\foo\bar"#), _StdlibFilePath(#"C:\foo\bar"#),
-        "differing Windows anchors")
-    }
-  }
+    // Device-namespace `\\.\C:\` vs drive `C:\` are different anchors.
+    expectNotEqual(_StdlibFilePath(#"\\.\C:\foo\bar"#), _StdlibFilePath(#"C:\foo\bar"#),
+      "differing Windows anchors")
+}
 
-  // MARK: - Darwin canonicalization equality (proposal lines 220-223, 546, 549)
+  // MARK: - Darwin canonicalization equality
 
-  @Test
+  @Test(.darwinOnly)
   func darwinCanonicalizationEquality() {
-    withPlatform(.darwin) {
-      // /.resolve/1/ canonicalizes to /.nofollow/ (same XNU flag).
-      expectEqual(_StdlibFilePath("/.resolve/1/foo"), _StdlibFilePath("/.nofollow/foo"),
-        "/.resolve/1/foo == /.nofollow/foo")
-      // /.vol/NNNN/2/ canonicalizes to /.vol/NNNN/@/ (inode 2 is the root @).
-      expectEqual(_StdlibFilePath("/.vol/1234/2/x"), _StdlibFilePath("/.vol/1234/@/x"),
-        "/.vol/1234/2/x == /.vol/1234/@/x")
-      // Combined anchor (proposal line 111): both canonicalizations fire on
-      // the same input — `/.resolve/1/.vol/N/2/` and `/.nofollow/.vol/N/@/`
-      // are two spellings of the same anchor.
-      expectEqual(
-        _StdlibFilePath("/.resolve/1/.vol/1234/2/x"),
-        _StdlibFilePath("/.nofollow/.vol/1234/@/x"),
-        "/.resolve/1/.vol/1234/2/x == /.nofollow/.vol/1234/@/x")
-      // Combined anchor with only the FILEID rule firing (resolve/3 is not
-      // canonicalizing).
-      expectEqual(
-        _StdlibFilePath("/.resolve/3/.vol/1234/2/x"),
-        _StdlibFilePath("/.resolve/3/.vol/1234/@/x"),
-        "/.resolve/3/.vol/1234/2/x == /.resolve/3/.vol/1234/@/x")
-    }
-  }
+    // /.resolve/1/ canonicalizes to /.nofollow/ (same XNU flag).
+    expectEqual(_StdlibFilePath("/.resolve/1/foo"), _StdlibFilePath("/.nofollow/foo"),
+      "/.resolve/1/foo == /.nofollow/foo")
+    // /.vol/NNNN/2/ canonicalizes to /.vol/NNNN/@/ (inode 2 is the root @).
+    expectEqual(_StdlibFilePath("/.vol/1234/2/x"), _StdlibFilePath("/.vol/1234/@/x"),
+      "/.vol/1234/2/x == /.vol/1234/@/x")
+    // Combined anchor: both canonicalizations fire on
+    // the same input: `/.resolve/1/.vol/N/2/` and `/.nofollow/.vol/N/@/`
+    // are two spellings of the same anchor.
+    expectEqual(
+      _StdlibFilePath("/.resolve/1/.vol/1234/2/x"),
+      _StdlibFilePath("/.nofollow/.vol/1234/@/x"),
+      "/.resolve/1/.vol/1234/2/x == /.nofollow/.vol/1234/@/x")
+    // Combined anchor with only the FILEID rule firing (resolve/3 is not
+    // canonicalizing).
+    expectEqual(
+      _StdlibFilePath("/.resolve/3/.vol/1234/2/x"),
+      _StdlibFilePath("/.resolve/3/.vol/1234/@/x"),
+      "/.resolve/3/.vol/1234/2/x == /.resolve/3/.vol/1234/@/x")
+}
 
-  // MARK: - Hash agrees with equality (equal direction only; proposal line 720)
+  // MARK: - Hash agrees with equality (equal direction only)
 
   // Hashable's contract: equal values must hash equal. Assert that for every
-  // pair we asserted equal above. (We do NOT assert unequal values hash
-  // differently — that is not required.)
+  // pair we asserted equal above. (We do not assert unequal values hash
+  // differently, which is not required.)
   @Test
   func hashAgreesWithEquality() {
     expectEqual(_StdlibFilePath("a///b").hashValue, _StdlibFilePath("a/b").hashValue,
@@ -126,24 +120,22 @@ extension AllTests.EqualityTests {
     }
   }
 
-  // MARK: - Comparable ordering (proposal lines 722-724)
+  // MARK: - Comparable ordering
 
   // Ordering is lexicographic over the normalized byte representation: anchor
   // bytes first, then component bytes, then the suffix as a tiebreaker. The
   // three tests below isolate a single axis each.
 
-  @Test
+  @Test(.darwinOnly)
   func orderingDistinguishesOnAnchor() {
-    withPlatform(.darwin) {
-      // Same components ["foo"], same (no) suffix; differ only by anchor.
-      // Normalized bytes "/.nofollow/foo" vs "/foo" first differ at index 1
-      // ('.' 0x2E < 'f' 0x66), so the anchored path sorts first.
-      expectTrue(_StdlibFilePath("/.nofollow/foo") < _StdlibFilePath("/foo"),
-        "/.nofollow/foo < /foo")
-      expectFalse(_StdlibFilePath("/foo") < _StdlibFilePath("/.nofollow/foo"),
-        "not /foo < /.nofollow/foo")
-    }
-  }
+    // Same components ["foo"], same (no) suffix; differ only by anchor.
+    // Normalized bytes "/.nofollow/foo" vs "/foo" first differ at index 1
+    // ('.' 0x2E < 'f' 0x66), so the anchored path sorts first.
+    expectTrue(_StdlibFilePath("/.nofollow/foo") < _StdlibFilePath("/foo"),
+      "/.nofollow/foo < /foo")
+    expectFalse(_StdlibFilePath("/foo") < _StdlibFilePath("/.nofollow/foo"),
+      "not /foo < /.nofollow/foo")
+}
 
   @Test
   func orderingDistinguishesOnComponents() {
@@ -158,7 +150,7 @@ extension AllTests.EqualityTests {
   func orderingDistinguishesOnSuffix() {
     // Same anchor, same components; differ only by trailing separator.
     // The unsuffixed path is a proper prefix of the suffixed one, so it
-    // sorts first — the suffix is the final tiebreaker.
+    // sorts first: the suffix is the final tiebreaker.
     expectTrue(_StdlibFilePath("/tmp/foo") < _StdlibFilePath("/tmp/foo/"),
       "/tmp/foo < /tmp/foo/")
     expectFalse(_StdlibFilePath("/tmp/foo/") < _StdlibFilePath("/tmp/foo"),
@@ -211,22 +203,20 @@ extension AllTests.EqualityTests {
 
   // MARK: - Anchor equality / ordering (brief)
 
-  @Test
+  @Test(.darwinOnly)
   func anchorEqualityAndOrdering() {
-    withPlatform(.darwin) {
-      // Canonicalization collapses these to the same anchor bytes.
-      expectEqual(_StdlibFilePath.Anchor("/.resolve/1/"), _StdlibFilePath.Anchor("/.nofollow/"),
-        "/.resolve/1/ anchor == /.nofollow/ anchor")
-      expectEqual(_StdlibFilePath.Anchor("/.resolve/1/").hashValue,
-                  _StdlibFilePath.Anchor("/.nofollow/").hashValue,
-        "canonical anchors hash equal")
-      expectNotEqual(_StdlibFilePath.Anchor("/"), _StdlibFilePath.Anchor("/.nofollow/"),
-        "/ anchor != /.nofollow/ anchor")
-      // "/.nofollow/" vs "/.vol/1234/5678" first differ at index 2
-      // ('n' 0x6E < 'v' 0x76).
-      expectTrue(
-        _StdlibFilePath.Anchor("/.nofollow/") < _StdlibFilePath.Anchor("/.vol/1234/5678"),
-        "/.nofollow/ < /.vol/1234/5678")
-    }
-  }
+    // Canonicalization collapses these to the same anchor bytes.
+    expectEqual(_StdlibFilePath.Anchor("/.resolve/1/"), _StdlibFilePath.Anchor("/.nofollow/"),
+      "/.resolve/1/ anchor == /.nofollow/ anchor")
+    expectEqual(_StdlibFilePath.Anchor("/.resolve/1/").hashValue,
+                _StdlibFilePath.Anchor("/.nofollow/").hashValue,
+      "canonical anchors hash equal")
+    expectNotEqual(_StdlibFilePath.Anchor("/"), _StdlibFilePath.Anchor("/.nofollow/"),
+      "/ anchor != /.nofollow/ anchor")
+    // "/.nofollow/" vs "/.vol/1234/5678" first differ at index 2
+    // ('n' 0x6E < 'v' 0x76).
+    expectTrue(
+      _StdlibFilePath.Anchor("/.nofollow/") < _StdlibFilePath.Anchor("/.vol/1234/5678"),
+      "/.nofollow/ < /.vol/1234/5678")
+}
 }

--- a/Tests/SystemTests/StdlibFilePathTests/PathTestCases.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/PathTestCases.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,2341 +17,2347 @@
 // (printed, isAbsolute, isRooted, driveLetter, kinds) on the next.
 
 extension Expected {
-    /// Unix parses a backslash-containing path as a single component
-    /// (backslash is not a separator on Unix).
-    static func singleComponent(
-        _ s: String, hasTrailingSeparator: Bool = false
-    ) -> Expected {
-        Expected(
-            anchor: nil, components: [s],
-            hasTrailingSeparator: hasTrailingSeparator,
-            printed: hasTrailingSeparator ? s + "/" : s,
-            isAbsolute: false)
-    }
+  /// Unix parses a backslash-containing path as a single component
+  /// (backslash is not a separator on Unix).
+  static func singleComponent(
+    _ s: String, hasTrailingSeparator: Bool = false
+  ) -> Expected {
+    Expected(
+      anchor: nil, components: [s],
+      hasTrailingSeparator: hasTrailingSeparator,
+      printed: hasTrailingSeparator ? s + "/" : s,
+      isAbsolute: false)
+  }
 }
 
 let pathTestCases: [PathTestCase] = [
 
-    // MARK: - Empty and trivial
-
-    PathTestCase(
-        input: "",
-        unix: Expected(
-            anchor: nil, components: [],
-            printed: "", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: [],
-            printed: "", isAbsolute: false)
-    ),
-
-    PathTestCase(
-        input: "/",
-        unix: Expected(
-            anchor: "/", components: [],
-            printed: "/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [],
-            printed: #"\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Multiple slashes coalesce on Unix; Windows lowers them through `/`→`\`
-    // conversion and then incomplete-UNC handling.
-
-    PathTestCase(
-        input: "//",
-        unix: Expected(
-            anchor: "/", components: [],
-            printed: "/", isAbsolute: true),
-        windows: Expected(
-            // `//` -> `\\` -> incomplete UNC, padded to `\\\` (degraded root).
-            anchor: #"\\\"#, components: [],
-            printed: #"\\\"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: "///",
-        unix: Expected(
-            anchor: "/", components: [],
-            printed: "/", isAbsolute: true),
-        windows: Expected(
-            // `///` -> `\\\`: 3+ leading backslashes are not a UNC/device
-            // path; reduce to a single current-drive root.
-            anchor: #"\"#, components: [],
-            printed: #"\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Basic absolute Unix paths
-
-    PathTestCase(
-        input: "/foo/bar",
-        unix: Expected(
-            anchor: "/", components: ["foo", "bar"],
-            printed: "/foo/bar", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "bar"],
-            printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/foo",
-        unix: Expected(
-            anchor: "/", components: ["foo"],
-            printed: "/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo"],
-            printed: #"\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Basic relative paths (no anchor)
-
-    PathTestCase(
-        input: "foo/bar",
-        unix: Expected(
-            anchor: nil, components: ["foo", "bar"],
-            printed: "foo/bar", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo", "bar"],
-            printed: #"foo\bar"#, isAbsolute: false)
-    ),
-
-    PathTestCase(
-        input: "foo",
-        unix: Expected(
-            anchor: nil, components: ["foo"],
-            printed: "foo", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo"],
-            printed: "foo", isAbsolute: false)
-    ),
-
-    // MARK: - Leading dot
-
-    PathTestCase(
-        input: ".",
-        unix: Expected(
-            anchor: nil, components: ["."],
-            printed: ".", isAbsolute: false, kinds: [.currentDirectory]),
-        windows: Expected(
-            anchor: nil, components: ["."],
-            printed: ".", isAbsolute: false, kinds: [.currentDirectory])
-    ),
-
-    PathTestCase(
-        input: "..",
-        unix: Expected(
-            anchor: nil, components: [".."],
-            printed: "..", isAbsolute: false, kinds: [.parentDirectory]),
-        windows: Expected(
-            anchor: nil, components: [".."],
-            printed: "..", isAbsolute: false, kinds: [.parentDirectory])
-    ),
-
-    PathTestCase(
-        input: "./foo",
-        unix: Expected(
-            anchor: nil, components: [".", "foo"],
-            printed: "./foo", isAbsolute: false, kinds: [.currentDirectory, .regular]),
-        windows: Expected(
-            anchor: nil, components: [".", "foo"],
-            printed: #".\foo"#, isAbsolute: false, kinds: [.currentDirectory, .regular])
-    ),
-
-    PathTestCase(
-        input: "../foo",
-        unix: Expected(
-            anchor: nil, components: ["..", "foo"],
-            printed: "../foo", isAbsolute: false, kinds: [.parentDirectory, .regular]),
-        windows: Expected(
-            anchor: nil, components: ["..", "foo"],
-            printed: #"..\foo"#, isAbsolute: false, kinds: [.parentDirectory, .regular])
-    ),
-
-    // MARK: - Interior dot normalization
-
-    // Dot is first relative component after root: dropped (rooted)
-    PathTestCase(
-        input: "/./foo",
-        unix: Expected(
-            anchor: "/", components: ["foo"],
-            printed: "/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo"],
-            printed: #"\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Absolute interior dot (not first): dropped
-    PathTestCase(
-        input: "/foo/./bar",
-        unix: Expected(
-            anchor: "/", components: ["foo", "bar"],
-            printed: "/foo/bar", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "bar"],
-            printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Relative interior dot (not first): dropped
-    PathTestCase(
-        input: "foo/./bar",
-        unix: Expected(
-            anchor: nil, components: ["foo", "bar"],
-            printed: "foo/bar", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo", "bar"],
-            printed: #"foo\bar"#, isAbsolute: false)
-    ),
-
-    // Trailing dot implies trailing separator
-    PathTestCase(
-        input: "foo/.",
-        unix: Expected(
-            anchor: nil, components: ["foo"], hasTrailingSeparator: true,
-            printed: "foo/", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo"], hasTrailingSeparator: true,
-            printed: #"foo\"#, isAbsolute: false)
-    ),
-
-    // Dot is first relative component after root: dropped (path has root)
-    PathTestCase(
-        input: "/.",
-        unix: Expected(
-            anchor: "/", components: [],
-            printed: "/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [],
-            printed: #"\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Interior dotdot (not lexically normalized, always presented)
-
-    PathTestCase(
-        input: "/foo/../bar",
-        unix: Expected(
-            anchor: "/", components: ["foo", "..", "bar"],
-            printed: "/foo/../bar", isAbsolute: true, kinds: [.regular, .parentDirectory, .regular]),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "..", "bar"],
-            printed: #"\foo\..\bar"#, isAbsolute: false, isRooted: true, kinds: [.regular, .parentDirectory, .regular])
-    ),
-
-    PathTestCase(
-        input: "a/../b",
-        unix: Expected(
-            anchor: nil, components: ["a", "..", "b"],
-            printed: "a/../b", isAbsolute: false, kinds: [.regular, .parentDirectory, .regular]),
-        windows: Expected(
-            anchor: nil, components: ["a", "..", "b"],
-            printed: #"a\..\b"#, isAbsolute: false, kinds: [.regular, .parentDirectory, .regular])
-    ),
-
-    PathTestCase(
-        input: "/a/b/../c",
-        unix: Expected(
-            anchor: "/", components: ["a", "b", "..", "c"],
-            printed: "/a/b/../c", isAbsolute: true, kinds: [.regular, .regular, .parentDirectory, .regular]),
-        windows: Expected(
-            anchor: #"\"#, components: ["a", "b", "..", "c"],
-            printed: #"\a\b\..\c"#, isAbsolute: false, isRooted: true, kinds: [.regular, .regular, .parentDirectory, .regular])
-    ),
-
-    // Trailing dotdot (not dropped, unlike trailing dot)
-    PathTestCase(
-        input: "foo/..",
-        unix: Expected(
-            anchor: nil, components: ["foo", ".."],
-            printed: "foo/..", isAbsolute: false, kinds: [.regular, .parentDirectory]),
-        windows: Expected(
-            anchor: nil, components: ["foo", ".."],
-            printed: #"foo\.."#, isAbsolute: false, kinds: [.regular, .parentDirectory])
-    ),
-
-    PathTestCase(
-        input: "foo/bar/baz/..",
-        unix: Expected(
-            anchor: nil, components: ["foo", "bar", "baz", ".."],
-            printed: "foo/bar/baz/..", isAbsolute: false,
-            kinds: [.regular, .regular, .regular, .parentDirectory]),
-        windows: Expected(
-            anchor: nil, components: ["foo", "bar", "baz", ".."],
-            printed: #"foo\bar\baz\.."#, isAbsolute: false,
-            kinds: [.regular, .regular, .regular, .parentDirectory])
-    ),
-
-    PathTestCase(
-        input: "../..",
-        unix: Expected(
-            anchor: nil, components: ["..", ".."],
-            printed: "../..", isAbsolute: false, kinds: [.parentDirectory, .parentDirectory]),
-        windows: Expected(
-            anchor: nil, components: ["..", ".."],
-            printed: #"..\.."#, isAbsolute: false, kinds: [.parentDirectory, .parentDirectory])
-    ),
-
-    // MARK: - Separator coalescing
-
-    PathTestCase(
-        input: "foo//bar",
-        unix: Expected(
-            anchor: nil, components: ["foo", "bar"],
-            printed: "foo/bar", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo", "bar"],
-            printed: #"foo\bar"#, isAbsolute: false)
-    ),
-
-    PathTestCase(
-        input: "a///b",
-        unix: Expected(
-            anchor: nil, components: ["a", "b"],
-            printed: "a/b", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["a", "b"],
-            printed: #"a\b"#, isAbsolute: false)
-    ),
-
-    // Leading double slash: Linux coalesces, Windows sees UNC
-    PathTestCase(
-        input: "//foo/bar",
-        unix: Expected(
-            anchor: "/", components: ["foo", "bar"],
-            printed: "/foo/bar", isAbsolute: true),
-        // UNC: server=foo, share=bar
-        windows: Expected(
-            anchor: #"\\foo\bar"#, components: [],
-            printed: #"\\foo\bar"#, isAbsolute: true)
-    ),
-    // TODO: verify that Windows does the backslash conversion _before_ checking for short-style UNC prefix
-
-    PathTestCase(
-        input: "///foo///bar",
-        unix: Expected(
-            anchor: "/", components: ["foo", "bar"],
-            printed: "/foo/bar", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "bar"],
-            printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-    // TODO: verify that Windows collapses _after_ checking for short-style UNC prefix
-
-    // MARK: - Trailing separator significance
-
-    PathTestCase(
-        input: "/tmp/foo",
-        unix: Expected(
-            anchor: "/", components: ["tmp", "foo"],
-            printed: "/tmp/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["tmp", "foo"],
-            printed: #"\tmp\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/tmp/foo/",
-        unix: Expected(
-            anchor: "/", components: ["tmp", "foo"], hasTrailingSeparator: true,
-            printed: "/tmp/foo/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["tmp", "foo"], hasTrailingSeparator: true,
-            printed: #"\tmp\foo\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "foo/",
-        unix: Expected(
-            anchor: nil, components: ["foo"], hasTrailingSeparator: true,
-            printed: "foo/", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo"], hasTrailingSeparator: true,
-            printed: #"foo\"#, isAbsolute: false)
-    ),
-
-    PathTestCase(
-        input: "./",
-        unix: Expected(
-            anchor: nil, components: ["."], hasTrailingSeparator: true,
-            printed: "./", isAbsolute: false, kinds: [.currentDirectory]),
-        windows: Expected(
-            anchor: nil, components: ["."], hasTrailingSeparator: true,
-            printed: #".\"#, isAbsolute: false, kinds: [.currentDirectory])
-    ),
-
-    PathTestCase(
-        input: "../",
-        unix: Expected(
-            anchor: nil, components: [".."], hasTrailingSeparator: true,
-            printed: "../", isAbsolute: false, kinds: [.parentDirectory]),
-        windows: Expected(
-            anchor: nil, components: [".."], hasTrailingSeparator: true,
-            printed: #"..\"#, isAbsolute: false, kinds: [.parentDirectory])
-    ),
-
-    // Trailing double sep coalesces to single trailing sep
-    PathTestCase(
-        input: "/foo//",
-        unix: Expected(
-            anchor: "/", components: ["foo"], hasTrailingSeparator: true,
-            printed: "/foo/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo"], hasTrailingSeparator: true,
-            printed: #"\foo\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Single component absolute with trailing sep
-    PathTestCase(
-        input: "/foo/",
-        unix: Expected(
-            anchor: "/", components: ["foo"], hasTrailingSeparator: true,
-            printed: "/foo/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo"], hasTrailingSeparator: true,
-            printed: #"\foo\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - More dot interactions
-
-    // Mixed dots and dotdots (interior dot dropped, dotdot preserved)
-    PathTestCase(
-        input: "/foo/bar/./baz/../qux",
-        unix: Expected(
-            anchor: "/", components: ["foo", "bar", "baz", "..", "qux"],
-            printed: "/foo/bar/baz/../qux", isAbsolute: true,
-            kinds: [.regular, .regular, .regular, .parentDirectory, .regular]),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "bar", "baz", "..", "qux"],
-            printed: #"\foo\bar\baz\..\qux"#, isAbsolute: false, isRooted: true,
-            kinds: [.regular, .regular, .regular, .parentDirectory, .regular])
-    ),
-
-    // Triple dot is a regular name
-    PathTestCase(
-        input: "foo/.../bar",
-        unix: Expected(
-            anchor: nil, components: ["foo", "...", "bar"],
-            printed: "foo/.../bar", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo", "...", "bar"],
-            printed: #"foo\...\bar"#, isAbsolute: false)
-    ),
-
-    // ..bar is a regular name (not parent directory)
-    PathTestCase(
-        input: "foo/..bar/baz",
-        unix: Expected(
-            anchor: nil, components: ["foo", "..bar", "baz"],
-            printed: "foo/..bar/baz", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo", "..bar", "baz"],
-            printed: #"foo\..bar\baz"#, isAbsolute: false)
-    ),
-
-    // Dotdot at root
-    PathTestCase(
-        input: "/..",
-        unix: Expected(
-            anchor: "/", components: [".."],
-            printed: "/..", isAbsolute: true, kinds: [.parentDirectory]),
-        windows: Expected(
-            anchor: #"\"#, components: [".."],
-            printed: #"\.."#, isAbsolute: false, isRooted: true, kinds: [.parentDirectory])
-    ),
-
-    // Dot then dotdot at root: dot dropped (rooted), dotdot presented
-    PathTestCase(
-        input: "/./../foo",
-        unix: Expected(
-            anchor: "/", components: ["..", "foo"],
-            printed: "/../foo", isAbsolute: true,
-            kinds: [.parentDirectory, .regular]),
-        windows: Expected(
-            anchor: #"\"#, components: ["..", "foo"],
-            printed: #"\..\foo"#, isAbsolute: false, isRooted: true,
-            kinds: [.parentDirectory, .regular])
-    ),
-
-    // MARK: - Darwin resolve flags (linux/darwin differ)
-
-    // /.resolve/1/ canonicalizes to /.nofollow/ (flag 1 = NOFOLLOW_ANY)
-    PathTestCase(
-        input: "/.resolve/1/foo/bar",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "1", "foo", "bar"],
-            printed: "/.resolve/1/foo/bar", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/", components: ["foo", "bar"],
-            printed: "/.nofollow/foo/bar", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "1", "foo", "bar"],
-            printed: #"\.resolve\1\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/.nofollow/foo/bar",
-        linux: Expected(
-            anchor: "/", components: [".nofollow", "foo", "bar"],
-            printed: "/.nofollow/foo/bar", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/", components: ["foo", "bar"],
-            printed: "/.nofollow/foo/bar", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".nofollow", "foo", "bar"],
-            printed: #"\.nofollow\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Flag zero: no shorthand
-    PathTestCase(
-        input: "/.resolve/0/foo",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "0", "foo"],
-            printed: "/.resolve/0/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.resolve/0/", components: ["foo"],
-            printed: "/.resolve/0/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "0", "foo"],
-            printed: #"\.resolve\0\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // NODOTDOT: no shorthand
-    PathTestCase(
-        input: "/.resolve/2/foo",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "2", "foo"],
-            printed: "/.resolve/2/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.resolve/2/", components: ["foo"],
-            printed: "/.resolve/2/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "2", "foo"],
-            printed: #"\.resolve\2\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // NOFOLLOW_ANY | NODOTDOT: no shorthand
-    PathTestCase(
-        input: "/.resolve/3/foo/bar",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "3", "foo", "bar"],
-            printed: "/.resolve/3/foo/bar", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.resolve/3/", components: ["foo", "bar"],
-            printed: "/.resolve/3/foo/bar", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "3", "foo", "bar"],
-            printed: #"\.resolve\3\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Large flag value, multi-digit
-    PathTestCase(
-        input: "/.resolve/127/a/b",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "127", "a", "b"],
-            printed: "/.resolve/127/a/b", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.resolve/127/", components: ["a", "b"],
-            printed: "/.resolve/127/a/b", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "127", "a", "b"],
-            printed: #"\.resolve\127\a\b"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Very large number, tests multi-digit decimal parsing
-    PathTestCase(
-        input: "/.resolve/999999/foo",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "999999", "foo"],
-            printed: "/.resolve/999999/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.resolve/999999/", components: ["foo"],
-            printed: "/.resolve/999999/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "999999", "foo"],
-            printed: #"\.resolve\999999\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Without trailing slash: not a resolve prefix, regular component
-    PathTestCase(
-        input: "/.nofollow",
-        unix: Expected(
-            anchor: "/", components: [".nofollow"],
-            printed: "/.nofollow", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".nofollow"],
-            printed: #"\.nofollow"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Without trailing slash on resolve: not a prefix, regular components
-    PathTestCase(
-        input: "/.resolve/0",
-        unix: Expected(
-            anchor: "/", components: [".resolve", "0"],
-            printed: "/.resolve/0", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "0"],
-            printed: #"\.resolve\0"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Non-numeric flags: still a resolve prefix (field is opaque)
-    PathTestCase(
-        input: "/.resolve/abc/foo",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "abc", "foo"],
-            printed: "/.resolve/abc/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.resolve/abc/", components: ["foo"],
-            printed: "/.resolve/abc/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "abc", "foo"],
-            printed: #"\.resolve\abc\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Leading zero: field is opaque, "01" != "1", no canonicalization
-    PathTestCase(
-        input: "/.resolve/01/foo",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "01", "foo"],
-            printed: "/.resolve/01/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.resolve/01/", components: ["foo"],
-            printed: "/.resolve/01/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "01", "foo"],
-            printed: #"\.resolve\01\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Negative-looking flag: field is opaque, still a prefix
-    PathTestCase(
-        input: "/.resolve/-1/foo",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "-1", "foo"],
-            printed: "/.resolve/-1/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.resolve/-1/", components: ["foo"],
-            printed: "/.resolve/-1/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "-1", "foo"],
-            printed: #"\.resolve\-1\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Wrong case on "resolve" keyword: not a prefix
-    PathTestCase(
-        input: "/.Resolve/0/foo",
-        unix: Expected(
-            anchor: "/", components: [".Resolve", "0", "foo"],
-            printed: "/.Resolve/0/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".Resolve", "0", "foo"],
-            printed: #"\.Resolve\0\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Starts with /. but matches no keyword: regular path
-    PathTestCase(
-        input: "/.hidden/foo",
-        unix: Expected(
-            anchor: "/", components: [".hidden", "foo"],
-            printed: "/.hidden/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".hidden", "foo"],
-            printed: #"\.hidden\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Darwin .vol paths (linux/darwin differ)
-
-    PathTestCase(
-        input: "/.vol/1234/5678",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "5678"],
-            printed: "/.vol/1234/5678", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/5678", components: [],
-            printed: "/.vol/1234/5678", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "5678"],
-            printed: #"\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/.vol/1234/5678/",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "5678"], hasTrailingSeparator: true,
-            printed: "/.vol/1234/5678/", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/5678", components: [], hasTrailingSeparator: true,
-            printed: "/.vol/1234/5678/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "5678"], hasTrailingSeparator: true,
-            printed: #"\.vol\1234\5678\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/.vol/1234/5678/foo/bar",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "5678", "foo", "bar"],
-            printed: "/.vol/1234/5678/foo/bar", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/5678", components: ["foo", "bar"],
-            printed: "/.vol/1234/5678/foo/bar", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "5678", "foo", "bar"],
-            printed: #"\.vol\1234\5678\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Fileid "2" canonicalizes to "@"
-    PathTestCase(
-        input: "/.vol/1234/2",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "2"],
-            printed: "/.vol/1234/2", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/@", components: [],
-            printed: "/.vol/1234/@", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "2"],
-            printed: #"\.vol\1234\2"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/.vol/1234/2/foo/bar",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "2", "foo", "bar"],
-            printed: "/.vol/1234/2/foo/bar", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/@", components: ["foo", "bar"],
-            printed: "/.vol/1234/@/foo/bar", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "2", "foo", "bar"],
-            printed: #"\.vol\1234\2\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // "@" already canonical: round-trips
-    PathTestCase(
-        input: "/.vol/1234/@",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "@"],
-            printed: "/.vol/1234/@", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/@", components: [],
-            printed: "/.vol/1234/@", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "@"],
-            printed: #"\.vol\1234\@"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/.vol/1234/@/",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "@"], hasTrailingSeparator: true,
-            printed: "/.vol/1234/@/", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/@", components: [], hasTrailingSeparator: true,
-            printed: "/.vol/1234/@/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "@"], hasTrailingSeparator: true,
-            printed: #"\.vol\1234\@\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/.vol/1234/@/foo",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "@", "foo"],
-            printed: "/.vol/1234/@/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/@", components: ["foo"],
-            printed: "/.vol/1234/@/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "@", "foo"],
-            printed: #"\.vol\1234\@\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Darwin combined anchors (resolve flag + volume identifier)
-    //
-    // An anchor may include resolve flags and/or
-    // a volume identifier; resolve always precedes vol. The combined form
-    // `[/.nofollow/ | /.resolve/N/].vol/FSID/FILEID` is a single anchor.
-    // Both canonicalizations (`/.resolve/1/` -> `/.nofollow/`, `2` -> `@`)
-    // can fire on the same input.
-
-    // Combined nofollow + vol, no canonicalization.
-    PathTestCase(
-        input: "/.nofollow/.vol/1234/5678",
-        linux: Expected(
-            anchor: "/", components: [".nofollow", ".vol", "1234", "5678"],
-            printed: "/.nofollow/.vol/1234/5678", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/.vol/1234/5678", components: [],
-            printed: "/.nofollow/.vol/1234/5678", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".nofollow", ".vol", "1234", "5678"],
-            printed: #"\.nofollow\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Combined nofollow + vol with relative content.
-    PathTestCase(
-        input: "/.nofollow/.vol/1234/5678/foo",
-        linux: Expected(
-            anchor: "/", components: [".nofollow", ".vol", "1234", "5678", "foo"],
-            printed: "/.nofollow/.vol/1234/5678/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/.vol/1234/5678", components: ["foo"],
-            printed: "/.nofollow/.vol/1234/5678/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".nofollow", ".vol", "1234", "5678", "foo"],
-            printed: #"\.nofollow\.vol\1234\5678\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Combined nofollow + vol with FILEID canonicalization (`2` -> `@`).
-    PathTestCase(
-        input: "/.nofollow/.vol/1234/2",
-        linux: Expected(
-            anchor: "/", components: [".nofollow", ".vol", "1234", "2"],
-            printed: "/.nofollow/.vol/1234/2", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/.vol/1234/@", components: [],
-            printed: "/.nofollow/.vol/1234/@", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".nofollow", ".vol", "1234", "2"],
-            printed: #"\.nofollow\.vol\1234\2"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Combined nofollow + vol, FILEID canonicalization, with relative + trailing.
-    PathTestCase(
-        input: "/.nofollow/.vol/1234/2/foo/",
-        linux: Expected(
-            anchor: "/", components: [".nofollow", ".vol", "1234", "2", "foo"],
-            hasTrailingSeparator: true,
-            printed: "/.nofollow/.vol/1234/2/foo/", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/.vol/1234/@", components: ["foo"],
-            hasTrailingSeparator: true,
-            printed: "/.nofollow/.vol/1234/@/foo/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".nofollow", ".vol", "1234", "2", "foo"],
-            hasTrailingSeparator: true,
-            printed: #"\.nofollow\.vol\1234\2\foo\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Combined resolve/N + vol (non-canonicalizing flag value).
-    PathTestCase(
-        input: "/.resolve/3/.vol/1234/5678",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "3", ".vol", "1234", "5678"],
-            printed: "/.resolve/3/.vol/1234/5678", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.resolve/3/.vol/1234/5678", components: [],
-            printed: "/.resolve/3/.vol/1234/5678", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "3", ".vol", "1234", "5678"],
-            printed: #"\.resolve\3\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Combined resolve/3 + vol with FILEID canon: only the FILEID rule
-    // fires; `.resolve/3/` is preserved as written.
-    PathTestCase(
-        input: "/.resolve/3/.vol/1234/2/",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "3", ".vol", "1234", "2"],
-            hasTrailingSeparator: true,
-            printed: "/.resolve/3/.vol/1234/2/", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.resolve/3/.vol/1234/@", components: [],
-            hasTrailingSeparator: true,
-            printed: "/.resolve/3/.vol/1234/@/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "3", ".vol", "1234", "2"],
-            hasTrailingSeparator: true,
-            printed: #"\.resolve\3\.vol\1234\2\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Combined resolve/1 + vol, where both canonicalizations fire:
-    // `/.resolve/1/` -> `/.nofollow/` and FILEID `2` -> `@`.
-    PathTestCase(
-        input: "/.resolve/1/.vol/1234/2/",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "1", ".vol", "1234", "2"],
-            hasTrailingSeparator: true,
-            printed: "/.resolve/1/.vol/1234/2/", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/.vol/1234/@", components: [],
-            hasTrailingSeparator: true,
-            printed: "/.nofollow/.vol/1234/@/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "1", ".vol", "1234", "2"],
-            hasTrailingSeparator: true,
-            printed: #"\.resolve\1\.vol\1234\2\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Combined resolve/1 + vol with relative content: both canons, plus relative.
-    PathTestCase(
-        input: "/.resolve/1/.vol/1234/2/foo/bar",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "1", ".vol", "1234", "2", "foo", "bar"],
-            printed: "/.resolve/1/.vol/1234/2/foo/bar", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/.vol/1234/@", components: ["foo", "bar"],
-            printed: "/.nofollow/.vol/1234/@/foo/bar", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "1", ".vol", "1234", "2", "foo", "bar"],
-            printed: #"\.resolve\1\.vol\1234\2\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Darwin resource forks (linux/darwin differ)
-
-    PathTestCase(
-        input: "/foo/..namedfork/rsrc",
-        linux: Expected(
-            anchor: "/", components: ["foo", "..namedfork", "rsrc"],
-            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/", components: ["foo"], isResourceFork: true,
-            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"],
-            printed: #"\foo\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Trailing slash breaks resource fork recognition
-    PathTestCase(
-        input: "/foo/..namedfork/rsrc/",
-        unix: Expected(
-            anchor: "/", components: ["foo", "..namedfork", "rsrc"], hasTrailingSeparator: true,
-            printed: "/foo/..namedfork/rsrc/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"], hasTrailingSeparator: true,
-            printed: #"\foo\..namedfork\rsrc\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Resource fork on relative path
-    PathTestCase(
-        input: "foo/..namedfork/rsrc",
-        linux: Expected(
-            anchor: nil, components: ["foo", "..namedfork", "rsrc"],
-            printed: "foo/..namedfork/rsrc", isAbsolute: false),
-        darwin: Expected(
-            anchor: nil, components: ["foo"], isResourceFork: true,
-            printed: "foo/..namedfork/rsrc", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo", "..namedfork", "rsrc"],
-            printed: #"foo\..namedfork\rsrc"#, isAbsolute: false)
-    ),
-
-    // Resource fork on root-only path (semantically invalid, syntactically recognized)
-    PathTestCase(
-        input: "/..namedfork/rsrc",
-        linux: Expected(
-            anchor: "/", components: ["..namedfork", "rsrc"],
-            printed: "/..namedfork/rsrc", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/", components: [], isResourceFork: true,
-            printed: "/..namedfork/rsrc", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["..namedfork", "rsrc"],
-            printed: #"\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Windows drive absolute
-
-    PathTestCase(
-        input: #"C:\foo\bar"#,
-        // Backslash is a legal filename char on Unix: single component
-        unix: .singleComponent(#"C:\foo\bar"#),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar"],
-            printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"C:\"#,
-        unix: .singleComponent(#"C:\"#),
-        windows: Expected(
-            anchor: #"C:\"#, components: [],
-            printed: #"C:\"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"c:\foo"#,
-        unix: .singleComponent(#"c:\foo"#),
-        windows: Expected(
-            anchor: #"c:\"#, components: ["foo"],
-            printed: #"c:\foo"#, isAbsolute: true, driveLetter: "c")
-    ),
-
-    // Interior dot dropped
-    PathTestCase(
-        input: #"C:\foo\.\bar"#,
-        unix: .singleComponent(#"C:\foo\.\bar"#),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar"],
-            printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // Interior dotdot presented, not collapsed
-    PathTestCase(
-        input: #"C:\foo\..\bar"#,
-        unix: .singleComponent(#"C:\foo\..\bar"#),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "..", "bar"],
-            printed: #"C:\foo\..\bar"#, isAbsolute: true, driveLetter: "C",
-            kinds: [.regular, .parentDirectory, .regular])
-    ),
-
-    PathTestCase(
-        input: #"C:\foo\"#,
-        unix: .singleComponent(#"C:\foo\"#),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo"], hasTrailingSeparator: true,
-            printed: #"C:\foo\"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // MARK: - Windows drive relative
-
-    PathTestCase(
-        input: "C:foo",
-        unix: Expected(
-            anchor: nil, components: ["C:foo"],
-            printed: "C:foo", isAbsolute: false),
-        windows: Expected(
-            anchor: "C:", components: ["foo"],
-            printed: "C:foo", isAbsolute: false, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: "C:",
-        unix: Expected(
-            anchor: nil, components: ["C:"],
-            printed: "C:", isAbsolute: false),
-        windows: Expected(
-            anchor: "C:", components: [],
-            printed: "C:", isAbsolute: false, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"C:foo\"#,
-        unix: .singleComponent(#"C:foo\"#),
-        windows: Expected(
-            anchor: "C:", components: ["foo"], hasTrailingSeparator: true,
-            printed: #"C:foo\"#, isAbsolute: false, driveLetter: "C")
-    ),
-
-    // MARK: - Windows rooted-not-absolute
-
-    PathTestCase(
-        input: #"\foo"#,
-        unix: .singleComponent(#"\foo"#),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo"],
-            printed: #"\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: #"\foo\bar"#,
-        unix: .singleComponent(#"\foo\bar"#),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "bar"],
-            printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: #"\"#,
-        unix: .singleComponent(#"\"#),
-        windows: Expected(
-            anchor: #"\"#, components: [],
-            printed: #"\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Windows UNC
-
-    PathTestCase(
-        input: #"\\server\share\foo"#,
-        unix: .singleComponent(#"\\server\share\foo"#),
-        windows: Expected(
-            anchor: #"\\server\share"#, components: ["foo"],
-            printed: #"\\server\share\foo"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: #"\\server\share\"#,
-        unix: .singleComponent(#"\\server\share\"#),
-        windows: Expected(
-            anchor: #"\\server\share"#, components: [], hasTrailingSeparator: true,
-            printed: #"\\server\share\"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: #"\\server\share"#,
-        unix: .singleComponent(#"\\server\share"#),
-        windows: Expected(
-            anchor: #"\\server\share"#, components: [],
-            printed: #"\\server\share"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: #"\\server\share\foo\bar\"#,
-        unix: .singleComponent(#"\\server\share\foo\bar\"#),
-        windows: Expected(
-            anchor: #"\\server\share"#, components: ["foo", "bar"], hasTrailingSeparator: true,
-            printed: #"\\server\share\foo\bar\"#, isAbsolute: true)
-    ),
-
-    // MARK: - Windows device paths (\\.\)
-
-    // Bare device prefix: anchor only
-    PathTestCase(
-        input: #"\\.\"#,
-        unix: .singleComponent(#"\\.\"#),
-        windows: Expected(
-            anchor: #"\\.\"#, components: [],
-            printed: #"\\.\"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: #"\\.\C:\foo"#,
-        unix: .singleComponent(#"\\.\C:\foo"#),
-        windows: Expected(
-            anchor: #"\\.\C:\"#, components: ["foo"],
-            printed: #"\\.\C:\foo"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"\\.\pipe\name"#,
-        unix: .singleComponent(#"\\.\pipe\name"#),
-        windows: Expected(
-            anchor: #"\\.\pipe"#, components: ["name"],
-            printed: #"\\.\pipe\name"#, isAbsolute: true)
-    ),
-
-    // Pipe device with trailing sep, no pipe name
-    PathTestCase(
-        input: #"\\.\pipe\"#,
-        unix: .singleComponent(#"\\.\pipe\"#),
-        windows: Expected(
-            anchor: #"\\.\pipe"#, components: [], hasTrailingSeparator: true,
-            printed: #"\\.\pipe\"#, isAbsolute: true)
-    ),
-
-    // Device drive without root separator
-    PathTestCase(
-        input: #"\\.\C:"#,
-        unix: .singleComponent(#"\\.\C:"#),
-        windows: Expected(
-            anchor: #"\\.\C:"#, components: [],
-            printed: #"\\.\C:"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // Dot is dropped on non-verbatim device paths
-    PathTestCase(
-        input: #"\\.\C:\foo\.\bar"#,
-        unix: .singleComponent(#"\\.\C:\foo\.\bar"#),
-        windows: Expected(
-            anchor: #"\\.\C:\"#, components: ["foo", "bar"],
-            printed: #"\\.\C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // MARK: - Windows verbatim paths (\\?\)
-
-    // Bare verbatim prefix: anchor only
-    PathTestCase(
-        input: #"\\?\"#,
-        unix: .singleComponent(#"\\?\"#),
-        windows: Expected(
-            anchor: #"\\?\"#, components: [],
-            printed: #"\\?\"#, isAbsolute: true)
-    ),
-
-    // Verbatim drive without root separator
-    PathTestCase(
-        input: #"\\?\C:"#,
-        unix: .singleComponent(#"\\?\C:"#),
-        windows: Expected(
-            anchor: #"\\?\C:"#, components: [],
-            printed: #"\\?\C:"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // Dot not dropped in verbatim: treated as regular component
-    PathTestCase(
-        input: #"\\?\C:\foo\.\bar"#,
-        unix: .singleComponent(#"\\?\C:\foo\.\bar"#),
-        windows: Expected(
-            anchor: #"\\?\C:\"#, components: ["foo", ".", "bar"],
-            printed: #"\\?\C:\foo\.\bar"#, isAbsolute: true, driveLetter: "C",
-            kinds: [.regular, .regular, .regular])
-    ),
-
-    // Dotdot not special in verbatim: treated as regular component
-    PathTestCase(
-        input: #"\\?\C:\foo\..\bar"#,
-        unix: .singleComponent(#"\\?\C:\foo\..\bar"#),
-        windows: Expected(
-            anchor: #"\\?\C:\"#, components: ["foo", "..", "bar"],
-            printed: #"\\?\C:\foo\..\bar"#, isAbsolute: true, driveLetter: "C",
-            kinds: [.regular, .regular, .regular])
-    ),
-
-    PathTestCase(
-        input: #"\\?\UNC\server\share\foo"#,
-        unix: .singleComponent(#"\\?\UNC\server\share\foo"#),
-        windows: Expected(
-            anchor: #"\\?\UNC\server\share"#, components: ["foo"],
-            printed: #"\\?\UNC\server\share\foo"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: #"\\?\C:\"#,
-        unix: .singleComponent(#"\\?\C:\"#),
-        windows: Expected(
-            anchor: #"\\?\C:\"#, components: [],
-            printed: #"\\?\C:\"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"\\?\C:\foo\"#,
-        unix: .singleComponent(#"\\?\C:\foo\"#),
-        windows: Expected(
-            anchor: #"\\?\C:\"#, components: ["foo"], hasTrailingSeparator: true,
-            printed: #"\\?\C:\foo\"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // Separator coalescing still happens in verbatim (verbatim only affects dot/dotdot)
-    PathTestCase(
-        input: #"\\?\C:\foo\\bar"#,
-        unix: .singleComponent(#"\\?\C:\foo\\bar"#),
-        windows: Expected(
-            anchor: #"\\?\C:\"#, components: ["foo", "bar"],
-            printed: #"\\?\C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // MARK: - Forward slashes inside verbatim component content
-
-    // / inside verbatim component is a legal filename character, not a separator
-    PathTestCase(
-        input: #"\\?\C:\foo/bar"#,
-        unix: Expected(
-            anchor: nil, components: [#"\\?\C:\foo"#, "bar"],
-            printed: #"\\?\C:\foo/bar"#, isAbsolute: false),
-        windows: Expected(
-            anchor: #"\\?\C:\"#, components: ["foo/bar"],
-            printed: #"\\?\C:\foo/bar"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"\\?\C:\a/b/c"#,
-        unix: Expected(
-            anchor: nil, components: [#"\\?\C:\a"#, "b", "c"],
-            printed: #"\\?\C:\a/b/c"#, isAbsolute: false),
-        windows: Expected(
-            anchor: #"\\?\C:\"#, components: ["a/b/c"],
-            printed: #"\\?\C:\a/b/c"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"\\?\UNC\s\sh\a/b"#,
-        unix: Expected(
-            anchor: nil, components: [#"\\?\UNC\s\sh\a"#, "b"],
-            printed: #"\\?\UNC\s\sh\a/b"#, isAbsolute: false),
-        windows: Expected(
-            anchor: #"\\?\UNC\s\sh"#, components: ["a/b"],
-            printed: #"\\?\UNC\s\sh\a/b"#, isAbsolute: true)
-    ),
-
-    // //?/ is not verbatim; it is device-namespace (same as //./). All / converted.
-    PathTestCase(
-        input: "//?/C:/a/b",
-        unix: Expected(
-            anchor: "/", components: ["?", "C:", "a", "b"],
-            printed: "/?/C:/a/b", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\\.\C:\"#, components: ["a", "b"],
-            printed: #"\\.\C:\a\b"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // Non-verbatim device path: all / converted (regression check)
-    PathTestCase(
-        input: "//./C:/a/b",
-        unix: Expected(
-            anchor: "/", components: ["C:", "a", "b"],
-            printed: "/C:/a/b", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\\.\C:\"#, components: ["a", "b"],
-            printed: #"\\.\C:\a\b"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // MARK: - Windows forward slash normalization
-
-    // Triple slash: coalesces on both, rooted on Windows
-    PathTestCase(
-        input: "///foo/bar",
-        unix: Expected(
-            anchor: "/", components: ["foo", "bar"],
-            printed: "/foo/bar", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "bar"],
-            printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // //./foo on Unix: dot dropped (rooted), "foo" is a regular component
-    // //./foo on Windows: device-namespace prefix, "foo" is device name
-    PathTestCase(
-        input: "//./foo",
-        unix: Expected(
-            anchor: "/", components: ["foo"],
-            printed: "/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\\.\foo"#, components: [],
-            printed: #"\\.\foo"#, isAbsolute: true)
-    ),
-
-    // //?/foo on Unix: regular components
-    // //?/foo on Windows: device-namespace (not verbatim), "foo" is device name
-    PathTestCase(
-        input: "//?/foo",
-        unix: Expected(
-            anchor: "/", components: ["?", "foo"],
-            printed: "/?/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\\.\foo"#, components: [],
-            printed: #"\\.\foo"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: "C:/foo/bar",
-        // Unix: "C:" is a component (colon is legal), "/" is separator
-        unix: Expected(
-            anchor: nil, components: ["C:", "foo", "bar"],
-            printed: "C:/foo/bar", isAbsolute: false),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar"],
-            printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: "C:/",
-        unix: Expected(
-            anchor: nil, components: ["C:"], hasTrailingSeparator: true,
-            printed: "C:/", isAbsolute: false),
-        windows: Expected(
-            anchor: #"C:\"#, components: [],
-            printed: #"C:\"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: "//server/share/foo",
-        unix: Expected(
-            anchor: "/", components: ["server", "share", "foo"],
-            printed: "/server/share/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\\server\share"#, components: ["foo"],
-            printed: #"\\server\share\foo"#, isAbsolute: true)
-    ),
-
-    // Dot dropped (rooted) on Unix, device-namespace on Windows
-    PathTestCase(
-        input: "//./C:/foo",
-        unix: Expected(
-            anchor: "/", components: ["C:", "foo"],
-            printed: "/C:/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\\.\C:\"#, components: ["foo"],
-            printed: #"\\.\C:\foo"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: "//?/C:/foo",
-        unix: Expected(
-            anchor: "/", components: ["?", "C:", "foo"],
-            printed: "/?/C:/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\\.\C:\"#, components: ["foo"],
-            printed: #"\\.\C:\foo"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // MARK: - Cross-platform mismatch
-
-    // Backslash is a legal filename char on Unix
-    PathTestCase(
-        input: #"foo\bar"#,
-        unix: .singleComponent(#"foo\bar"#),
-        windows: Expected(
-            anchor: nil, components: ["foo", "bar"],
-            printed: #"foo\bar"#, isAbsolute: false)
-    ),
-
-    // Dot-backslash: Unix sees single component, Windows sees dot + sep + component
-    PathTestCase(
-        input: #".\foo"#,
-        unix: .singleComponent(#".\foo"#),
-        windows: Expected(
-            anchor: nil, components: [".", "foo"],
-            printed: #".\foo"#, isAbsolute: false, kinds: [.currentDirectory, .regular])
-    ),
-
-    // Colon in component: legal on Unix, possible ADS marker on Windows
-    PathTestCase(
-        input: "foo:bar",
-        unix: Expected(
-            anchor: nil, components: ["foo:bar"],
-            printed: "foo:bar", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo:bar"],
-            printed: "foo:bar", isAbsolute: false)
-    ),
-
-    // Deeper relative with only backslashes
-    PathTestCase(
-        input: #"foo\bar\baz"#,
-        unix: .singleComponent(#"foo\bar\baz"#),
-        windows: Expected(
-            anchor: nil, components: ["foo", "bar", "baz"],
-            printed: #"foo\bar\baz"#, isAbsolute: false)
-    ),
-
-    // Multi-char before colon: not a drive letter
-    PathTestCase(
-        input: #"CC:\foo"#,
-        unix: .singleComponent(#"CC:\foo"#),
-        windows: Expected(
-            anchor: nil, components: ["CC:", "foo"],
-            printed: #"CC:\foo"#, isAbsolute: false)
-    ),
-
-    // MARK: - Mixed separators on Windows-style paths
-
-    // Forward slash splits on Unix (two components), both seps normalize on Windows
-    PathTestCase(
-        input: #"C:\foo/bar"#,
-        unix: Expected(
-            anchor: nil, components: [#"C:\foo"#, "bar"],
-            printed: #"C:\foo/bar"#, isAbsolute: false),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar"],
-            printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"C:\foo\bar/baz"#,
-        unix: Expected(
-            anchor: nil, components: [#"C:\foo\bar"#, "baz"],
-            printed: #"C:\foo\bar/baz"#, isAbsolute: false),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar", "baz"],
-            printed: #"C:\foo\bar\baz"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // UNC server\share then forward slash: Unix splits at /
-    PathTestCase(
-        input: #"\\server\share/foo"#,
-        unix: Expected(
-            anchor: nil, components: [#"\\server\share"#, "foo"],
-            printed: #"\\server\share/foo"#, isAbsolute: false),
-        windows: Expected(
-            anchor: #"\\server\share"#, components: ["foo"],
-            printed: #"\\server\share\foo"#, isAbsolute: true)
-    ),
-
-    // MARK: - Trailing forward slash on backslash paths
-
-    // Unix: forward slash is a separator, splits the backslash-blob from trailing sep
-    PathTestCase(
-        input: #"C:\foo/"#,
-        unix: .singleComponent(#"C:\foo"#, hasTrailingSeparator: true),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo"], hasTrailingSeparator: true,
-            printed: #"C:\foo\"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"C:\foo\bar/"#,
-        unix: .singleComponent(#"C:\foo\bar"#, hasTrailingSeparator: true),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar"], hasTrailingSeparator: true,
-            printed: #"C:\foo\bar\"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"\\server\share/"#,
-        unix: .singleComponent(#"\\server\share"#, hasTrailingSeparator: true),
-        windows: Expected(
-            anchor: #"\\server\share"#, components: [], hasTrailingSeparator: true,
-            printed: #"\\server\share\"#, isAbsolute: true)
-    ),
-
-    // MARK: - Unicode in components
-
-    PathTestCase(
-        input: "/あ/🧟‍♀️",
-        unix: Expected(
-            anchor: "/", components: ["あ", "🧟‍♀️"],
-            printed: "/あ/🧟‍♀️", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["あ", "🧟‍♀️"],
-            printed: #"\あ\🧟‍♀️"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Additional dot/dotdot patterns
-
-    PathTestCase(
-        input: "./foo/bar",
-        unix: Expected(
-            anchor: nil, components: [".", "foo", "bar"],
-            printed: "./foo/bar", isAbsolute: false, kinds: [.currentDirectory, .regular, .regular]),
-        windows: Expected(
-            anchor: nil, components: [".", "foo", "bar"],
-            printed: #".\foo\bar"#, isAbsolute: false, kinds: [.currentDirectory, .regular, .regular])
-    ),
-
-    // Dot then double slash: coalesced, dot preserved as first
-    PathTestCase(
-        input: ".//foo",
-        unix: Expected(
-            anchor: nil, components: [".", "foo"],
-            printed: "./foo", isAbsolute: false, kinds: [.currentDirectory, .regular]),
-        windows: Expected(
-            anchor: nil, components: [".", "foo"],
-            printed: #".\foo"#, isAbsolute: false, kinds: [.currentDirectory, .regular])
-    ),
-
-    PathTestCase(
-        input: "foo/../../bar",
-        unix: Expected(
-            anchor: nil, components: ["foo", "..", "..", "bar"],
-            printed: "foo/../../bar", isAbsolute: false,
-            kinds: [.regular, .parentDirectory, .parentDirectory, .regular]),
-        windows: Expected(
-            anchor: nil, components: ["foo", "..", "..", "bar"],
-            printed: #"foo\..\..\bar"#, isAbsolute: false,
-            kinds: [.regular, .parentDirectory, .parentDirectory, .regular])
-    ),
-
-    PathTestCase(
-        input: "foo/../bar/../baz",
-        unix: Expected(
-            anchor: nil, components: ["foo", "..", "bar", "..", "baz"],
-            printed: "foo/../bar/../baz", isAbsolute: false,
-            kinds: [.regular, .parentDirectory, .regular, .parentDirectory, .regular]),
-        windows: Expected(
-            anchor: nil, components: ["foo", "..", "bar", "..", "baz"],
-            printed: #"foo\..\bar\..\baz"#, isAbsolute: false,
-            kinds: [.regular, .parentDirectory, .regular, .parentDirectory, .regular])
-    ),
-
-    PathTestCase(
-        input: "/foo//bar//baz",
-        unix: Expected(
-            anchor: "/", components: ["foo", "bar", "baz"],
-            printed: "/foo/bar/baz", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "bar", "baz"],
-            printed: #"\foo\bar\baz"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - More Windows edge cases
-
-    PathTestCase(
-        input: #"C:\.."#,
-        unix: .singleComponent(#"C:\.."#),
-        windows: Expected(
-            anchor: #"C:\"#, components: [".."],
-            printed: #"C:\.."#, isAbsolute: true, driveLetter: "C",
-            kinds: [.parentDirectory])
-    ),
-
-    // Double sep after drive root: coalesced
-    PathTestCase(
-        input: #"C:\\foo"#,
-        unix: .singleComponent(#"C:\\foo"#),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo"],
-            printed: #"C:\foo"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // Trailing dot dropped, becomes trailing sep
-    PathTestCase(
-        input: #"C:\foo\bar\."#,
-        unix: .singleComponent(#"C:\foo\bar\."#),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar"], hasTrailingSeparator: true,
-            printed: #"C:\foo\bar\"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    PathTestCase(
-        input: #"C:\foo\bar\.."#,
-        unix: .singleComponent(#"C:\foo\bar\.."#),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar", ".."],
-            printed: #"C:\foo\bar\.."#, isAbsolute: true, driveLetter: "C",
-            kinds: [.regular, .regular, .parentDirectory])
-    ),
-
-    PathTestCase(
-        input: #"\\server\share\..\foo"#,
-        unix: .singleComponent(#"\\server\share\..\foo"#),
-        windows: Expected(
-            anchor: #"\\server\share"#, components: ["..", "foo"],
-            printed: #"\\server\share\..\foo"#, isAbsolute: true,
-            kinds: [.parentDirectory, .regular])
-    ),
-
-    // Mixed separators: "/" is sep on Unix, both "/" and "\" are on Windows
-    PathTestCase(
-        input: #"C:/foo\bar"#,
-        unix: Expected(
-            anchor: nil, components: ["C:", #"foo\bar"#],
-            printed: #"C:/foo\bar"#, isAbsolute: false),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar"],
-            printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // MARK: - Verbatim dot/dotdot at end
-
-    // In verbatim context, trailing dot is a regular component, not dropped
-    PathTestCase(
-        input: #"\\?\C:\foo\bar\."#,
-        unix: .singleComponent(#"\\?\C:\foo\bar\."#),
-        windows: Expected(
-            anchor: #"\\?\C:\"#, components: ["foo", "bar", "."],
-            printed: #"\\?\C:\foo\bar\."#, isAbsolute: true, driveLetter: "C",
-            kinds: [.regular, .regular, .regular])
-    ),
-
-    PathTestCase(
-        input: #"\\?\C:\foo\bar\.."#,
-        unix: .singleComponent(#"\\?\C:\foo\bar\.."#),
-        windows: Expected(
-            anchor: #"\\?\C:\"#, components: ["foo", "bar", ".."],
-            printed: #"\\?\C:\foo\bar\.."#, isAbsolute: true, driveLetter: "C",
-            kinds: [.regular, .regular, .regular])
-    ),
-
-    PathTestCase(
-        input: #"\\?\UNC\server\share\..\foo"#,
-        unix: .singleComponent(#"\\?\UNC\server\share\..\foo"#),
-        windows: Expected(
-            anchor: #"\\?\UNC\server\share"#, components: ["..", "foo"],
-            printed: #"\\?\UNC\server\share\..\foo"#, isAbsolute: true,
-            kinds: [.regular, .regular])
-    ),
-
-    // MARK: - Resolve prefix edge cases
-
-    // Prefix recognized with no components
-    PathTestCase(
-        input: "/.nofollow/",
-        linux: Expected(
-            anchor: "/", components: [".nofollow"], hasTrailingSeparator: true,
-            printed: "/.nofollow/", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/", components: [],
-            printed: "/.nofollow/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".nofollow"], hasTrailingSeparator: true,
-            printed: #"\.nofollow\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Prefix requires absolute path: not recognized on relative
-    PathTestCase(
-        input: "foo/.nofollow/bar",
-        unix: Expected(
-            anchor: nil, components: ["foo", ".nofollow", "bar"],
-            printed: "foo/.nofollow/bar", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo", ".nofollow", "bar"],
-            printed: #"foo\.nofollow\bar"#, isAbsolute: false)
-    ),
-
-    // Near-miss: wrong case
-    PathTestCase(
-        input: "/.NOFOLLOW/foo",
-        unix: Expected(
-            anchor: "/", components: [".NOFOLLOW", "foo"],
-            printed: "/.NOFOLLOW/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".NOFOLLOW", "foo"],
-            printed: #"\.NOFOLLOW\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Near-miss: extra char
-    PathTestCase(
-        input: "/.nofollowx/foo",
-        unix: Expected(
-            anchor: "/", components: [".nofollowx", "foo"],
-            printed: "/.nofollowx/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".nofollowx", "foo"],
-            printed: #"\.nofollowx\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - .vol degenerate cases
-
-    // Fewer than two components after .vol: not recognized as volfs
-    PathTestCase(
-        input: "/.vol",
-        unix: Expected(
-            anchor: "/", components: [".vol"],
-            printed: "/.vol", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol"],
-            printed: #"\.vol"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/.vol/",
-        linux: Expected(
-            anchor: "/", components: [".vol"], hasTrailingSeparator: true,
-            printed: "/.vol/", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/", components: [".vol"], hasTrailingSeparator: true,
-            printed: "/.vol/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol"], hasTrailingSeparator: true,
-            printed: #"\.vol\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Only one component after .vol: not enough
-    PathTestCase(
-        input: "/.vol/16777234",
-        linux: Expected(
-            anchor: "/", components: [".vol", "16777234"],
-            printed: "/.vol/16777234", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/", components: [".vol", "16777234"],
-            printed: "/.vol/16777234", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "16777234"],
-            printed: #"\.vol\16777234"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Wrong case: not volfs
-    PathTestCase(
-        input: "/.VOL/1234/5678",
-        unix: Expected(
-            anchor: "/", components: [".VOL", "1234", "5678"],
-            printed: "/.VOL/1234/5678", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".VOL", "1234", "5678"],
-            printed: #"\.VOL\1234\5678"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Extra char: not volfs
-    PathTestCase(
-        input: "/.volx/1234/5678",
-        unix: Expected(
-            anchor: "/", components: [".volx", "1234", "5678"],
-            printed: "/.volx/1234/5678", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".volx", "1234", "5678"],
-            printed: #"\.volx\1234\5678"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Non-numeric fsid: parser treats vol IDs opaquely
-    PathTestCase(
-        input: "/.vol/abc/12345",
-        linux: Expected(
-            anchor: "/", components: [".vol", "abc", "12345"],
-            printed: "/.vol/abc/12345", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/abc/12345", components: [],
-            printed: "/.vol/abc/12345", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "abc", "12345"],
-            printed: #"\.vol\abc\12345"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Dot after volfs anchor: dropped (volfs anchor is rooted)
-    PathTestCase(
-        input: "/.vol/1234/5678/./foo",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "5678", "foo"],
-            printed: "/.vol/1234/5678/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/5678", components: ["foo"],
-            printed: "/.vol/1234/5678/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "5678", "foo"],
-            printed: #"\.vol\1234\5678\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Dotdot after volfs anchor: presented, not collapsed
-    PathTestCase(
-        input: "/.vol/1234/5678/foo/../bar",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "5678", "foo", "..", "bar"],
-            printed: "/.vol/1234/5678/foo/../bar", isAbsolute: true,
-            kinds: [.regular, .regular, .regular, .regular, .parentDirectory, .regular]),
-        darwin: Expected(
-            anchor: "/.vol/1234/5678", components: ["foo", "..", "bar"],
-            printed: "/.vol/1234/5678/foo/../bar", isAbsolute: true,
-            kinds: [.regular, .parentDirectory, .regular]),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "5678", "foo", "..", "bar"],
-            printed: #"\.vol\1234\5678\foo\..\bar"#, isAbsolute: false, isRooted: true,
-            kinds: [.regular, .regular, .regular, .regular, .parentDirectory, .regular])
-    ),
-
-    // MARK: - Resource fork near-misses
-
-    PathTestCase(
-        input: "/foo/..namedfork/data",
-        unix: Expected(
-            anchor: "/", components: ["foo", "..namedfork", "data"],
-            printed: "/foo/..namedfork/data", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "..namedfork", "data"],
-            printed: #"\foo\..namedfork\data"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/foo/..namedfork",
-        unix: Expected(
-            anchor: "/", components: ["foo", "..namedfork"],
-            printed: "/foo/..namedfork", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "..namedfork"],
-            printed: #"\foo\..namedfork"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Extra path after rsrc: suffix too long, not matched
-    PathTestCase(
-        input: "/foo/..namedfork/rsrc/extra",
-        unix: Expected(
-            anchor: "/", components: ["foo", "..namedfork", "rsrc", "extra"],
-            printed: "/foo/..namedfork/rsrc/extra", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "..namedfork", "rsrc", "extra"],
-            printed: #"\foo\..namedfork\rsrc\extra"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Darwin double separators within anchor structures
-    //
-    // _StdlibFilePath coalesces repeated separators and decomposes the
-    // coalesced form; the only input it rejects (returns nil) is one
-    // containing NUL. For .vol, the coalesced form yields the normal volfs
-    // anchor.
-
-    // Double slash after .vol coalesces to /.vol/1234/5678 (volfs anchor)
-    PathTestCase(
-        input: "/.vol//1234/5678",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "5678"],
-            printed: "/.vol/1234/5678", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/5678", components: [],
-            printed: "/.vol/1234/5678", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "5678"],
-            printed: #"\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Double slash between vol IDs coalesces to /.vol/1234/5678 (volfs anchor)
-    PathTestCase(
-        input: "/.vol/1234//5678",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "5678"],
-            printed: "/.vol/1234/5678", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/5678", components: [],
-            printed: "/.vol/1234/5678", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "5678"],
-            printed: #"\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // The resource-fork match is an emergent property of separator
-    // coalescing, consistent with the Darwin anchor cases: the whole string is
-    // coalesced before suffix detection, so the kernel only ever receives the
-    // coalesced form (/foo/..namedfork/rsrc). There is no separate
-    // kernel-behavior question to confirm.
-    PathTestCase(
-        input: "/foo/..namedfork//rsrc",
-        linux: Expected(
-            anchor: "/", components: ["foo", "..namedfork", "rsrc"],
-            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/", components: ["foo"], isResourceFork: true,
-            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"],
-            printed: #"\foo\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Double slash before resource fork suffix: suffix is the last 17 bytes,
-    // which are "/..namedfork/rsrc" regardless of earlier double slashes.
-    PathTestCase(
-        input: "/foo//..namedfork/rsrc",
-        linux: Expected(
-            anchor: "/", components: ["foo", "..namedfork", "rsrc"],
-            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/", components: ["foo"], isResourceFork: true,
-            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"],
-            printed: #"\foo\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Double slash where the resolve flag number should be: coalesces to
-    // /.resolve/1/foo, which then canonicalizes to /.nofollow/foo on Darwin.
-    PathTestCase(
-        input: "/.resolve//1/foo",
-        linux: Expected(
-            anchor: "/", components: [".resolve", "1", "foo"],
-            printed: "/.resolve/1/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/", components: ["foo"],
-            printed: "/.nofollow/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".resolve", "1", "foo"],
-            printed: #"\.resolve\1\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // Double slash after nofollow prefix boundary: prefix matches (first 11
-    // bytes are "/.nofollow/"), extra slash is a redundant separator in the
-    // relative portion.
-    PathTestCase(
-        input: "/.nofollow//foo",
-        linux: Expected(
-            anchor: "/", components: [".nofollow", "foo"],
-            printed: "/.nofollow/foo", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/", components: ["foo"],
-            printed: "/.nofollow/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".nofollow", "foo"],
-            printed: #"\.nofollow\foo"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - .vol + resource fork
-
-    PathTestCase(
-        input: "/.vol/1234/5678/file/..namedfork/rsrc",
-        linux: Expected(
-            anchor: "/", components: [".vol", "1234", "5678", "file", "..namedfork", "rsrc"],
-            printed: "/.vol/1234/5678/file/..namedfork/rsrc", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.vol/1234/5678", components: ["file"], isResourceFork: true,
-            printed: "/.vol/1234/5678/file/..namedfork/rsrc", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".vol", "1234", "5678", "file", "..namedfork", "rsrc"],
-            printed: #"\.vol\1234\5678\file\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Resolve prefix + resource fork
-
-    PathTestCase(
-        input: "/.nofollow/path/to/file/..namedfork/rsrc",
-        linux: Expected(
-            anchor: "/", components: [".nofollow", "path", "to", "file", "..namedfork", "rsrc"],
-            printed: "/.nofollow/path/to/file/..namedfork/rsrc", isAbsolute: true),
-        darwin: Expected(
-            anchor: "/.nofollow/", components: ["path", "to", "file"], isResourceFork: true,
-            printed: "/.nofollow/path/to/file/..namedfork/rsrc", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [".nofollow", "path", "to", "file", "..namedfork", "rsrc"],
-            printed: #"\.nofollow\path\to\file\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Trailing sep on dot/dotdot after root
-
-    PathTestCase(
-        input: "/./",
-        unix: Expected(
-            anchor: "/", components: [],
-            printed: "/", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: [],
-            printed: #"\"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/../",
-        unix: Expected(
-            anchor: "/", components: [".."], hasTrailingSeparator: true,
-            printed: "/../", isAbsolute: true, kinds: [.parentDirectory]),
-        windows: Expected(
-            anchor: #"\"#, components: [".."], hasTrailingSeparator: true,
-            printed: #"\..\"#, isAbsolute: false, isRooted: true, kinds: [.parentDirectory])
-    ),
-
-    PathTestCase(
-        input: "/foo/bar/../../baz",
-        unix: Expected(
-            anchor: "/", components: ["foo", "bar", "..", "..", "baz"],
-            printed: "/foo/bar/../../baz", isAbsolute: true,
-            kinds: [.regular, .regular, .parentDirectory, .parentDirectory, .regular]),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "bar", "..", "..", "baz"],
-            printed: #"\foo\bar\..\..\baz"#, isAbsolute: false, isRooted: true,
-            kinds: [.regular, .regular, .parentDirectory, .parentDirectory, .regular])
-    ),
-
-    // MARK: - Deeper drive relative
-
-    PathTestCase(
-        input: #"C:foo\bar\baz"#,
-        unix: .singleComponent(#"C:foo\bar\baz"#),
-        windows: Expected(
-            anchor: "C:", components: ["foo", "bar", "baz"],
-            printed: #"C:foo\bar\baz"#, isAbsolute: false, driveLetter: "C")
-    ),
-
-    // MARK: - Windows device UNC
-
-    PathTestCase(
-        input: #"\\.\UNC\srv\share\foo"#,
-        unix: .singleComponent(#"\\.\UNC\srv\share\foo"#),
-        windows: Expected(
-            anchor: #"\\.\UNC"#, components: ["srv", "share", "foo"],
-            printed: #"\\.\UNC\srv\share\foo"#, isAbsolute: true)
-    ),
-
-    // \\.\UNC alone: device name only, no components
-    PathTestCase(
-        input: #"\\.\UNC"#,
-        unix: .singleComponent(#"\\.\UNC"#),
-        windows: Expected(
-            anchor: #"\\.\UNC"#, components: [],
-            printed: #"\\.\UNC"#, isAbsolute: true)
-    ),
-
-    // \\.\UNC\ trailing sep after device name
-    PathTestCase(
-        input: #"\\.\UNC\"#,
-        unix: .singleComponent(#"\\.\UNC\"#),
-        windows: Expected(
-            anchor: #"\\.\UNC"#, components: [], hasTrailingSeparator: true,
-            printed: #"\\.\UNC\"#, isAbsolute: true)
-    ),
-
-    // \\.\UNC\server: server is a component, not absorbed into anchor
-    PathTestCase(
-        input: #"\\.\UNC\server"#,
-        unix: .singleComponent(#"\\.\UNC\server"#),
-        windows: Expected(
-            anchor: #"\\.\UNC"#, components: ["server"],
-            printed: #"\\.\UNC\server"#, isAbsolute: true)
-    ),
-
-    // \\.\UNC\server\share: both are components (contrast with \\?\UNC\)
-    PathTestCase(
-        input: #"\\.\UNC\server\share"#,
-        unix: .singleComponent(#"\\.\UNC\server\share"#),
-        windows: Expected(
-            anchor: #"\\.\UNC"#, components: ["server", "share"],
-            printed: #"\\.\UNC\server\share"#, isAbsolute: true)
-    ),
-
-    // \\.\UNC\server\share\ trailing sep
-    PathTestCase(
-        input: #"\\.\UNC\server\share\"#,
-        unix: .singleComponent(#"\\.\UNC\server\share\"#),
-        windows: Expected(
-            anchor: #"\\.\UNC"#, components: ["server", "share"],
-            hasTrailingSeparator: true,
-            printed: #"\\.\UNC\server\share\"#, isAbsolute: true)
-    ),
-
-    // MARK: - Verbatim non-drive non-UNC
-
-    // Unknown device name is part of anchor
-    PathTestCase(
-        input: #"\\?\foo\bar"#,
-        unix: .singleComponent(#"\\?\foo\bar"#),
-        windows: Expected(
-            anchor: #"\\?\foo"#, components: ["bar"],
-            printed: #"\\?\foo\bar"#, isAbsolute: true)
-    ),
-
-    // GLOBALROOT (NT-namespace escape): name terminates at first backslash
-    PathTestCase(
-        input: #"\\?\GLOBALROOT\Device\HarddiskVolume1\foo"#,
-        unix: .singleComponent(#"\\?\GLOBALROOT\Device\HarddiskVolume1\foo"#),
-        windows: Expected(
-            anchor: #"\\?\GLOBALROOT"#,
-            components: ["Device", "HarddiskVolume1", "foo"],
-            printed: #"\\?\GLOBALROOT\Device\HarddiskVolume1\foo"#,
-            isAbsolute: true)
-    ),
-
-    // Volume GUID (volumes without a drive letter)
-    PathTestCase(
-        input: #"\\?\Volume{12345678-1234-1234-1234-123456789012}\foo\bar"#,
-        unix: .singleComponent(
-            #"\\?\Volume{12345678-1234-1234-1234-123456789012}\foo\bar"#),
-        windows: Expected(
-            anchor: #"\\?\Volume{12345678-1234-1234-1234-123456789012}"#,
-            components: ["foo", "bar"],
-            printed: #"\\?\Volume{12345678-1234-1234-1234-123456789012}\foo\bar"#,
-            isAbsolute: true)
-    ),
-
-    // DosDevices symlink (e.g. PIPE)
-    PathTestCase(
-        input: #"\\?\PIPE\mypipe"#,
-        unix: .singleComponent(#"\\?\PIPE\mypipe"#),
-        windows: Expected(
-            anchor: #"\\?\PIPE"#, components: ["mypipe"],
-            printed: #"\\?\PIPE\mypipe"#, isAbsolute: true)
-    ),
-
-    // .. not special in verbatim plain: regular component
-    PathTestCase(
-        input: #"\\?\GLOBALROOT\..\foo"#,
-        unix: .singleComponent(#"\\?\GLOBALROOT\..\foo"#),
-        windows: Expected(
-            anchor: #"\\?\GLOBALROOT"#, components: ["..", "foo"],
-            printed: #"\\?\GLOBALROOT\..\foo"#, isAbsolute: true,
-            kinds: [.regular, .regular])
-    ),
-
-    // . not special in verbatim plain: regular component (not dropped)
-    PathTestCase(
-        input: #"\\?\GLOBALROOT\.\foo"#,
-        unix: .singleComponent(#"\\?\GLOBALROOT\.\foo"#),
-        windows: Expected(
-            anchor: #"\\?\GLOBALROOT"#, components: [".", "foo"],
-            printed: #"\\?\GLOBALROOT\.\foo"#, isAbsolute: true,
-            kinds: [.regular, .regular])
-    ),
-
-    // / inside verbatim plain component is a regular byte, not a separator
-    PathTestCase(
-        input: #"\\?\GLOBALROOT\foo/bar"#,
-        unix: Expected(
-            anchor: nil, components: [#"\\?\GLOBALROOT\foo"#, "bar"],
-            printed: #"\\?\GLOBALROOT\foo/bar"#, isAbsolute: false),
-        windows: Expected(
-            anchor: #"\\?\GLOBALROOT"#, components: ["foo/bar"],
-            printed: #"\\?\GLOBALROOT\foo/bar"#, isAbsolute: true)
-    ),
-
-    // MARK: - Device path forward slashes for pipes
-
-    // Dot dropped (rooted) on Unix, device-namespace pipe on Windows
-    PathTestCase(
-        input: "//./pipe/foo",
-        unix: Expected(
-            anchor: "/", components: ["pipe", "foo"],
-            printed: "/pipe/foo", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\\.\pipe"#, components: ["foo"],
-            printed: #"\\.\pipe\foo"#, isAbsolute: true)
-    ),
-
-    // MARK: - Dotfile components (not special, always regular)
-
-    PathTestCase(
-        input: "/foo/.hidden",
-        unix: Expected(
-            anchor: "/", components: ["foo", ".hidden"],
-            printed: "/foo/.hidden", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", ".hidden"],
-            printed: #"\foo\.hidden"#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Double extension and trailing dot
-
-    PathTestCase(
-        input: "/foo/bar.tar.gz",
-        unix: Expected(
-            anchor: "/", components: ["foo", "bar.tar.gz"],
-            printed: "/foo/bar.tar.gz", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "bar.tar.gz"],
-            printed: #"\foo\bar.tar.gz"#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/foo/bar.",
-        unix: Expected(
-            anchor: "/", components: ["foo", "bar."],
-            printed: "/foo/bar.", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "bar."],
-            printed: #"\foo\bar."#, isAbsolute: false, isRooted: true)
-    ),
-
-    PathTestCase(
-        input: "/foo/...",
-        unix: Expected(
-            anchor: "/", components: ["foo", "..."],
-            printed: "/foo/...", isAbsolute: true),
-        windows: Expected(
-            anchor: #"\"#, components: ["foo", "..."],
-            printed: #"\foo\..."#, isAbsolute: false, isRooted: true)
-    ),
-
-    // MARK: - Windows IP address as UNC server
-
-    PathTestCase(
-        input: #"\\192.168.1.1\share\foo"#,
-        unix: .singleComponent(#"\\192.168.1.1\share\foo"#),
-        windows: Expected(
-            anchor: #"\\192.168.1.1\share"#, components: ["foo"],
-            printed: #"\\192.168.1.1\share\foo"#, isAbsolute: true)
-    ),
-
-    // MARK: - Windows drive dot and dotdot
-
-    PathTestCase(
-        input: "C:.",
-        unix: Expected(
-            anchor: nil, components: ["C:."],
-            printed: "C:.", isAbsolute: false),
-        windows: Expected(
-            anchor: "C:", components: ["."],
-            printed: "C:.", isAbsolute: false, driveLetter: "C",
-            kinds: [.currentDirectory])
-    ),
-
-    PathTestCase(
-        input: "C:..",
-        unix: Expected(
-            anchor: nil, components: ["C:.."],
-            printed: "C:..", isAbsolute: false),
-        windows: Expected(
-            anchor: "C:", components: [".."],
-            printed: "C:..", isAbsolute: false, driveLetter: "C",
-            kinds: [.parentDirectory])
-    ),
-
-    // MARK: - Windows non-letter drive
-
-    // A drive letter is any single non-separator code unit followed by a
-    // colon (matching RtlDetermineDosPathNameType_U, which keys on the
-    // second character being a colon and does not validate the first).
-    // A digit is a valid drive letter: "1:\foo" is drive-absolute.
-    PathTestCase(
-        input: #"1:\foo"#,
-        unix: .singleComponent(#"1:\foo"#),
-        windows: Expected(
-            anchor: #"1:\"#, components: ["foo"],
-            printed: #"1:\foo"#, isAbsolute: true, driveLetter: "1")
-    ),
-
-    // A colon is itself a non-separator, so "::foo" parses as drive ":"
-    // (the documented basis for the "=::" environment variable Windows
-    // creates). Like "C:foo", it is drive-relative: not rooted, not
-    // absolute.
-    PathTestCase(
-        input: "::foo",
-        unix: Expected(
-            anchor: nil, components: ["::foo"],
-            printed: "::foo", isAbsolute: false),
-        windows: Expected(
-            anchor: "::", components: ["foo"],
-            printed: "::foo", isAbsolute: false, driveLetter: ":")
-    ),
-
-    // The non-separator rule extends to device-namespace drives:
-    // "\\.\1:" exposes drive "1" just as "\\.\C:" exposes "C".
-    PathTestCase(
-        input: #"\\.\1:"#,
-        unix: .singleComponent(#"\\.\1:"#),
-        windows: Expected(
-            anchor: #"\\.\1:"#, components: [],
-            printed: #"\\.\1:"#, isAbsolute: true, driveLetter: "1")
-    ),
-
-    // ...and to verbatim drives: "\\?\1:\" exposes drive "1".
-    PathTestCase(
-        input: #"\\?\1:\"#,
-        unix: .singleComponent(#"\\?\1:\"#),
-        windows: Expected(
-            anchor: #"\\?\1:\"#, components: [],
-            printed: #"\\?\1:\"#, isAbsolute: true, driveLetter: "1")
-    ),
-
-    // Verbatim paths take bytes as written: separators are not normalized,
-    // so "/" is a legal (non-separator) drive letter and "\\?\/:" has
-    // drive "/".
-    PathTestCase(
-        input: #"\\?\/:"#,
-        unix: Expected(
-            anchor: nil, components: [#"\\?\"#, ":"],
-            printed: #"\\?\/:"#, isAbsolute: false),
-        windows: Expected(
-            anchor: #"\\?\/:"#, components: [],
-            printed: #"\\?\/:"#, isAbsolute: true, driveLetter: "/")
-    ),
-
-    // MARK: - Trailing sep on deeper paths
-
-    PathTestCase(
-        input: "foo/bar/",
-        unix: Expected(
-            anchor: nil, components: ["foo", "bar"], hasTrailingSeparator: true,
-            printed: "foo/bar/", isAbsolute: false),
-        windows: Expected(
-            anchor: nil, components: ["foo", "bar"], hasTrailingSeparator: true,
-            printed: #"foo\bar\"#, isAbsolute: false)
-    ),
-
-    // MARK: - Windows dotdot/dot + trailing sep
-
-    PathTestCase(
-        input: #"C:\foo\bar\..\"#,
-        unix: .singleComponent(#"C:\foo\bar\..\"#),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar", ".."], hasTrailingSeparator: true,
-            printed: #"C:\foo\bar\..\"#, isAbsolute: true, driveLetter: "C",
-            kinds: [.regular, .regular, .parentDirectory])
-    ),
-
-    // Trailing dot dropped + trailing sep coalesced
-    PathTestCase(
-        input: #"C:\foo\bar\.\"#,
-        unix: .singleComponent(#"C:\foo\bar\.\"#),
-        windows: Expected(
-            anchor: #"C:\"#, components: ["foo", "bar"], hasTrailingSeparator: true,
-            printed: #"C:\foo\bar\"#, isAbsolute: true, driveLetter: "C")
-    ),
-
-    // MARK: - Degenerate Windows UNC / device paths
-    //
-    // These start with `\\` but are incomplete or have doubled separators.
-    // Each is well-defined: the parser pads incomplete UNC forms with a
-    // synthesized backslash and coalesces interior doubled separators.
-
-    PathTestCase(
-        input: #"\\server"#,
-        // Incomplete UNC: server with no share. Padded to `\\server\`.
-        unix: .singleComponent(#"\\server"#),
-        windows: Expected(
-            anchor: #"\\server\"#, components: [],
-            printed: #"\\server\"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: #"\\server\"#,
-        // Server with empty share: same final form as `\\server`.
-        unix: .singleComponent(#"\\server\"#),
-        windows: Expected(
-            anchor: #"\\server\"#, components: [],
-            printed: #"\\server\"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: #"\\"#,
-        // Bare double backslash: padded to a degraded `\\\` root.
-        unix: .singleComponent(#"\\"#),
-        windows: Expected(
-            anchor: #"\\\"#, components: [],
-            printed: #"\\\"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: #"\\server\share\\foo"#,
-        // Doubled separator between share and first component coalesces.
-        unix: .singleComponent(#"\\server\share\\foo"#),
-        windows: Expected(
-            anchor: #"\\server\share"#, components: ["foo"],
-            printed: #"\\server\share\foo"#, isAbsolute: true)
-    ),
-
-    PathTestCase(
-        input: #"\\srv\\share\foo"#,
-        // Doubled separator between server and share coalesces.
-        unix: .singleComponent(#"\\srv\\share\foo"#),
-        windows: Expected(
-            anchor: #"\\srv\share"#, components: ["foo"],
-            printed: #"\\srv\share\foo"#, isAbsolute: true)
-    ),
+  // MARK: - Empty and trivial
+
+  PathTestCase(
+    input: "",
+    unix: Expected(
+      anchor: nil, components: [],
+      printed: "", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: [],
+      printed: "", isAbsolute: false)
+  ),
+
+  PathTestCase(
+    input: "/",
+    unix: Expected(
+      anchor: "/", components: [],
+      printed: "/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [],
+      printed: #"\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Multiple slashes coalesce on Unix; Windows lowers them through `/`→`\`
+  // conversion and then incomplete-UNC handling.
+
+  PathTestCase(
+    input: "//",
+    unix: Expected(
+      anchor: "/", components: [],
+      printed: "/", isAbsolute: true),
+    windows: Expected(
+      // `//` -> `\\` -> incomplete UNC, padded to `\\\` (degraded root).
+      anchor: #"\\\"#, components: [],
+      printed: #"\\\"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: "///",
+    unix: Expected(
+      anchor: "/", components: [],
+      printed: "/", isAbsolute: true),
+    windows: Expected(
+      // `///` -> `\\\`: 3+ leading backslashes are not a UNC/device
+      // path; reduce to a single current-drive root.
+      anchor: #"\"#, components: [],
+      printed: #"\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Basic absolute Unix paths
+
+  PathTestCase(
+    input: "/foo/bar",
+    unix: Expected(
+      anchor: "/", components: ["foo", "bar"],
+      printed: "/foo/bar", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "bar"],
+      printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/foo",
+    unix: Expected(
+      anchor: "/", components: ["foo"],
+      printed: "/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo"],
+      printed: #"\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Basic relative paths (no anchor)
+
+  PathTestCase(
+    input: "foo/bar",
+    unix: Expected(
+      anchor: nil, components: ["foo", "bar"],
+      printed: "foo/bar", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo", "bar"],
+      printed: #"foo\bar"#, isAbsolute: false)
+  ),
+
+  PathTestCase(
+    input: "foo",
+    unix: Expected(
+      anchor: nil, components: ["foo"],
+      printed: "foo", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo"],
+      printed: "foo", isAbsolute: false)
+  ),
+
+  // MARK: - Leading dot
+
+  PathTestCase(
+    input: ".",
+    unix: Expected(
+      anchor: nil, components: ["."],
+      printed: ".", isAbsolute: false, kinds: [.currentDirectory]),
+    windows: Expected(
+      anchor: nil, components: ["."],
+      printed: ".", isAbsolute: false, kinds: [.currentDirectory])
+  ),
+
+  PathTestCase(
+    input: "..",
+    unix: Expected(
+      anchor: nil, components: [".."],
+      printed: "..", isAbsolute: false, kinds: [.parentDirectory]),
+    windows: Expected(
+      anchor: nil, components: [".."],
+      printed: "..", isAbsolute: false, kinds: [.parentDirectory])
+  ),
+
+  PathTestCase(
+    input: "./foo",
+    unix: Expected(
+      anchor: nil, components: [".", "foo"],
+      printed: "./foo", isAbsolute: false, kinds: [.currentDirectory, .regular]),
+    windows: Expected(
+      anchor: nil, components: [".", "foo"],
+      printed: #".\foo"#, isAbsolute: false, kinds: [.currentDirectory, .regular])
+  ),
+
+  PathTestCase(
+    input: "../foo",
+    unix: Expected(
+      anchor: nil, components: ["..", "foo"],
+      printed: "../foo", isAbsolute: false, kinds: [.parentDirectory, .regular]),
+    windows: Expected(
+      anchor: nil, components: ["..", "foo"],
+      printed: #"..\foo"#, isAbsolute: false, kinds: [.parentDirectory, .regular])
+  ),
+
+  // MARK: - Interior dot normalization
+
+  // Dot is first relative component after root: dropped (rooted)
+  PathTestCase(
+    input: "/./foo",
+    unix: Expected(
+      anchor: "/", components: ["foo"],
+      printed: "/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo"],
+      printed: #"\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Absolute interior dot (not first): dropped
+  PathTestCase(
+    input: "/foo/./bar",
+    unix: Expected(
+      anchor: "/", components: ["foo", "bar"],
+      printed: "/foo/bar", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "bar"],
+      printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Relative interior dot (not first): dropped
+  PathTestCase(
+    input: "foo/./bar",
+    unix: Expected(
+      anchor: nil, components: ["foo", "bar"],
+      printed: "foo/bar", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo", "bar"],
+      printed: #"foo\bar"#, isAbsolute: false)
+  ),
+
+  // Trailing dot implies trailing separator
+  PathTestCase(
+    input: "foo/.",
+    unix: Expected(
+      anchor: nil, components: ["foo"], hasTrailingSeparator: true,
+      printed: "foo/", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo"], hasTrailingSeparator: true,
+      printed: #"foo\"#, isAbsolute: false)
+  ),
+
+  // Dot is first relative component after root: dropped (path has root)
+  PathTestCase(
+    input: "/.",
+    unix: Expected(
+      anchor: "/", components: [],
+      printed: "/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [],
+      printed: #"\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Interior dotdot (not lexically normalized, always presented)
+
+  PathTestCase(
+    input: "/foo/../bar",
+    unix: Expected(
+      anchor: "/", components: ["foo", "..", "bar"],
+      printed: "/foo/../bar", isAbsolute: true, kinds: [.regular, .parentDirectory, .regular]),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "..", "bar"],
+      printed: #"\foo\..\bar"#, isAbsolute: false, isRooted: true, kinds: [.regular, .parentDirectory, .regular])
+  ),
+
+  PathTestCase(
+    input: "a/../b",
+    unix: Expected(
+      anchor: nil, components: ["a", "..", "b"],
+      printed: "a/../b", isAbsolute: false, kinds: [.regular, .parentDirectory, .regular]),
+    windows: Expected(
+      anchor: nil, components: ["a", "..", "b"],
+      printed: #"a\..\b"#, isAbsolute: false, kinds: [.regular, .parentDirectory, .regular])
+  ),
+
+  PathTestCase(
+    input: "/a/b/../c",
+    unix: Expected(
+      anchor: "/", components: ["a", "b", "..", "c"],
+      printed: "/a/b/../c", isAbsolute: true, kinds: [.regular, .regular, .parentDirectory, .regular]),
+    windows: Expected(
+      anchor: #"\"#, components: ["a", "b", "..", "c"],
+      printed: #"\a\b\..\c"#, isAbsolute: false, isRooted: true, kinds: [.regular, .regular, .parentDirectory, .regular])
+  ),
+
+  // Trailing dotdot (not dropped, unlike trailing dot)
+  PathTestCase(
+    input: "foo/..",
+    unix: Expected(
+      anchor: nil, components: ["foo", ".."],
+      printed: "foo/..", isAbsolute: false, kinds: [.regular, .parentDirectory]),
+    windows: Expected(
+      anchor: nil, components: ["foo", ".."],
+      printed: #"foo\.."#, isAbsolute: false, kinds: [.regular, .parentDirectory])
+  ),
+
+  PathTestCase(
+    input: "foo/bar/baz/..",
+    unix: Expected(
+      anchor: nil, components: ["foo", "bar", "baz", ".."],
+      printed: "foo/bar/baz/..", isAbsolute: false,
+      kinds: [.regular, .regular, .regular, .parentDirectory]),
+    windows: Expected(
+      anchor: nil, components: ["foo", "bar", "baz", ".."],
+      printed: #"foo\bar\baz\.."#, isAbsolute: false,
+      kinds: [.regular, .regular, .regular, .parentDirectory])
+  ),
+
+  PathTestCase(
+    input: "../..",
+    unix: Expected(
+      anchor: nil, components: ["..", ".."],
+      printed: "../..", isAbsolute: false, kinds: [.parentDirectory, .parentDirectory]),
+    windows: Expected(
+      anchor: nil, components: ["..", ".."],
+      printed: #"..\.."#, isAbsolute: false, kinds: [.parentDirectory, .parentDirectory])
+  ),
+
+  // MARK: - Separator coalescing
+
+  PathTestCase(
+    input: "foo//bar",
+    unix: Expected(
+      anchor: nil, components: ["foo", "bar"],
+      printed: "foo/bar", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo", "bar"],
+      printed: #"foo\bar"#, isAbsolute: false)
+  ),
+
+  PathTestCase(
+    input: "a///b",
+    unix: Expected(
+      anchor: nil, components: ["a", "b"],
+      printed: "a/b", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["a", "b"],
+      printed: #"a\b"#, isAbsolute: false)
+  ),
+
+  // Leading double slash: Linux coalesces, Windows sees UNC
+  PathTestCase(
+    input: "//foo/bar",
+    unix: Expected(
+      anchor: "/", components: ["foo", "bar"],
+      printed: "/foo/bar", isAbsolute: true),
+    // UNC: server=foo, share=bar
+    windows: Expected(
+      anchor: #"\\foo\bar"#, components: [],
+      printed: #"\\foo\bar"#, isAbsolute: true)
+  ),
+  // TODO: verify that Windows does the backslash conversion _before_ checking for short-style UNC prefix
+
+  PathTestCase(
+    input: "///foo///bar",
+    unix: Expected(
+      anchor: "/", components: ["foo", "bar"],
+      printed: "/foo/bar", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "bar"],
+      printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+  // TODO: verify that Windows collapses _after_ checking for short-style UNC prefix
+
+  // MARK: - Trailing separator significance
+
+  PathTestCase(
+    input: "/tmp/foo",
+    unix: Expected(
+      anchor: "/", components: ["tmp", "foo"],
+      printed: "/tmp/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["tmp", "foo"],
+      printed: #"\tmp\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/tmp/foo/",
+    unix: Expected(
+      anchor: "/", components: ["tmp", "foo"], hasTrailingSeparator: true,
+      printed: "/tmp/foo/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["tmp", "foo"], hasTrailingSeparator: true,
+      printed: #"\tmp\foo\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "foo/",
+    unix: Expected(
+      anchor: nil, components: ["foo"], hasTrailingSeparator: true,
+      printed: "foo/", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo"], hasTrailingSeparator: true,
+      printed: #"foo\"#, isAbsolute: false)
+  ),
+
+  PathTestCase(
+    input: "./",
+    unix: Expected(
+      anchor: nil, components: ["."], hasTrailingSeparator: true,
+      printed: "./", isAbsolute: false, kinds: [.currentDirectory]),
+    windows: Expected(
+      anchor: nil, components: ["."], hasTrailingSeparator: true,
+      printed: #".\"#, isAbsolute: false, kinds: [.currentDirectory])
+  ),
+
+  PathTestCase(
+    input: "../",
+    unix: Expected(
+      anchor: nil, components: [".."], hasTrailingSeparator: true,
+      printed: "../", isAbsolute: false, kinds: [.parentDirectory]),
+    windows: Expected(
+      anchor: nil, components: [".."], hasTrailingSeparator: true,
+      printed: #"..\"#, isAbsolute: false, kinds: [.parentDirectory])
+  ),
+
+  // Trailing double sep coalesces to single trailing sep
+  PathTestCase(
+    input: "/foo//",
+    unix: Expected(
+      anchor: "/", components: ["foo"], hasTrailingSeparator: true,
+      printed: "/foo/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo"], hasTrailingSeparator: true,
+      printed: #"\foo\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Single component absolute with trailing sep
+  PathTestCase(
+    input: "/foo/",
+    unix: Expected(
+      anchor: "/", components: ["foo"], hasTrailingSeparator: true,
+      printed: "/foo/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo"], hasTrailingSeparator: true,
+      printed: #"\foo\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - More dot interactions
+
+  // Mixed dots and dotdots (interior dot dropped, dotdot preserved)
+  PathTestCase(
+    input: "/foo/bar/./baz/../qux",
+    unix: Expected(
+      anchor: "/", components: ["foo", "bar", "baz", "..", "qux"],
+      printed: "/foo/bar/baz/../qux", isAbsolute: true,
+      kinds: [.regular, .regular, .regular, .parentDirectory, .regular]),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "bar", "baz", "..", "qux"],
+      printed: #"\foo\bar\baz\..\qux"#, isAbsolute: false, isRooted: true,
+      kinds: [.regular, .regular, .regular, .parentDirectory, .regular])
+  ),
+
+  // Triple dot is a regular name
+  PathTestCase(
+    input: "foo/.../bar",
+    unix: Expected(
+      anchor: nil, components: ["foo", "...", "bar"],
+      printed: "foo/.../bar", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo", "...", "bar"],
+      printed: #"foo\...\bar"#, isAbsolute: false)
+  ),
+
+  // ..bar is a regular name (not parent directory)
+  PathTestCase(
+    input: "foo/..bar/baz",
+    unix: Expected(
+      anchor: nil, components: ["foo", "..bar", "baz"],
+      printed: "foo/..bar/baz", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo", "..bar", "baz"],
+      printed: #"foo\..bar\baz"#, isAbsolute: false)
+  ),
+
+  // Dotdot at root
+  PathTestCase(
+    input: "/..",
+    unix: Expected(
+      anchor: "/", components: [".."],
+      printed: "/..", isAbsolute: true, kinds: [.parentDirectory]),
+    windows: Expected(
+      anchor: #"\"#, components: [".."],
+      printed: #"\.."#, isAbsolute: false, isRooted: true, kinds: [.parentDirectory])
+  ),
+
+  // Dot then dotdot at root: dot dropped (rooted), dotdot presented
+  PathTestCase(
+    input: "/./../foo",
+    unix: Expected(
+      anchor: "/", components: ["..", "foo"],
+      printed: "/../foo", isAbsolute: true,
+      kinds: [.parentDirectory, .regular]),
+    windows: Expected(
+      anchor: #"\"#, components: ["..", "foo"],
+      printed: #"\..\foo"#, isAbsolute: false, isRooted: true,
+      kinds: [.parentDirectory, .regular])
+  ),
+
+  // MARK: - Darwin resolve flags (linux/darwin differ)
+
+  // /.resolve/1/ canonicalizes to /.nofollow/ (flag 1 = NOFOLLOW_ANY)
+  PathTestCase(
+    input: "/.resolve/1/foo/bar",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "1", "foo", "bar"],
+      printed: "/.resolve/1/foo/bar", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/", components: ["foo", "bar"],
+      printed: "/.nofollow/foo/bar", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "1", "foo", "bar"],
+      printed: #"\.resolve\1\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/.nofollow/foo/bar",
+    linux: Expected(
+      anchor: "/", components: [".nofollow", "foo", "bar"],
+      printed: "/.nofollow/foo/bar", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/", components: ["foo", "bar"],
+      printed: "/.nofollow/foo/bar", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".nofollow", "foo", "bar"],
+      printed: #"\.nofollow\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Flag zero: no shorthand
+  PathTestCase(
+    input: "/.resolve/0/foo",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "0", "foo"],
+      printed: "/.resolve/0/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.resolve/0/", components: ["foo"],
+      printed: "/.resolve/0/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "0", "foo"],
+      printed: #"\.resolve\0\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // NODOTDOT: no shorthand
+  PathTestCase(
+    input: "/.resolve/2/foo",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "2", "foo"],
+      printed: "/.resolve/2/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.resolve/2/", components: ["foo"],
+      printed: "/.resolve/2/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "2", "foo"],
+      printed: #"\.resolve\2\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // NOFOLLOW_ANY | NODOTDOT: no shorthand
+  PathTestCase(
+    input: "/.resolve/3/foo/bar",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "3", "foo", "bar"],
+      printed: "/.resolve/3/foo/bar", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.resolve/3/", components: ["foo", "bar"],
+      printed: "/.resolve/3/foo/bar", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "3", "foo", "bar"],
+      printed: #"\.resolve\3\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Large flag value, multi-digit
+  PathTestCase(
+    input: "/.resolve/127/a/b",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "127", "a", "b"],
+      printed: "/.resolve/127/a/b", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.resolve/127/", components: ["a", "b"],
+      printed: "/.resolve/127/a/b", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "127", "a", "b"],
+      printed: #"\.resolve\127\a\b"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Very large number, tests multi-digit decimal parsing
+  PathTestCase(
+    input: "/.resolve/999999/foo",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "999999", "foo"],
+      printed: "/.resolve/999999/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.resolve/999999/", components: ["foo"],
+      printed: "/.resolve/999999/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "999999", "foo"],
+      printed: #"\.resolve\999999\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Without trailing slash: not a resolve prefix, regular component
+  PathTestCase(
+    input: "/.nofollow",
+    unix: Expected(
+      anchor: "/", components: [".nofollow"],
+      printed: "/.nofollow", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".nofollow"],
+      printed: #"\.nofollow"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Without trailing slash on resolve: not a prefix, regular components
+  PathTestCase(
+    input: "/.resolve/0",
+    unix: Expected(
+      anchor: "/", components: [".resolve", "0"],
+      printed: "/.resolve/0", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "0"],
+      printed: #"\.resolve\0"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Non-numeric flags: still a resolve prefix (field is opaque)
+  PathTestCase(
+    input: "/.resolve/abc/foo",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "abc", "foo"],
+      printed: "/.resolve/abc/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.resolve/abc/", components: ["foo"],
+      printed: "/.resolve/abc/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "abc", "foo"],
+      printed: #"\.resolve\abc\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Leading zero: field is opaque, "01" != "1", no canonicalization
+  PathTestCase(
+    input: "/.resolve/01/foo",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "01", "foo"],
+      printed: "/.resolve/01/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.resolve/01/", components: ["foo"],
+      printed: "/.resolve/01/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "01", "foo"],
+      printed: #"\.resolve\01\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Negative-looking flag: field is opaque, still a prefix
+  PathTestCase(
+    input: "/.resolve/-1/foo",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "-1", "foo"],
+      printed: "/.resolve/-1/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.resolve/-1/", components: ["foo"],
+      printed: "/.resolve/-1/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "-1", "foo"],
+      printed: #"\.resolve\-1\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Wrong case on "resolve" keyword: not a prefix
+  PathTestCase(
+    input: "/.Resolve/0/foo",
+    unix: Expected(
+      anchor: "/", components: [".Resolve", "0", "foo"],
+      printed: "/.Resolve/0/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".Resolve", "0", "foo"],
+      printed: #"\.Resolve\0\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Starts with /. but matches no keyword: regular path
+  PathTestCase(
+    input: "/.hidden/foo",
+    unix: Expected(
+      anchor: "/", components: [".hidden", "foo"],
+      printed: "/.hidden/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".hidden", "foo"],
+      printed: #"\.hidden\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Darwin .vol paths (linux/darwin differ)
+
+  PathTestCase(
+    input: "/.vol/1234/5678",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "5678"],
+      printed: "/.vol/1234/5678", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/5678", components: [],
+      printed: "/.vol/1234/5678", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "5678"],
+      printed: #"\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/.vol/1234/5678/",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "5678"], hasTrailingSeparator: true,
+      printed: "/.vol/1234/5678/", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/5678", components: [], hasTrailingSeparator: true,
+      printed: "/.vol/1234/5678/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "5678"], hasTrailingSeparator: true,
+      printed: #"\.vol\1234\5678\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/.vol/1234/5678/foo/bar",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "5678", "foo", "bar"],
+      printed: "/.vol/1234/5678/foo/bar", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/5678", components: ["foo", "bar"],
+      printed: "/.vol/1234/5678/foo/bar", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "5678", "foo", "bar"],
+      printed: #"\.vol\1234\5678\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Fileid "2" canonicalizes to "@"
+  PathTestCase(
+    input: "/.vol/1234/2",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "2"],
+      printed: "/.vol/1234/2", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/@", components: [],
+      printed: "/.vol/1234/@", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "2"],
+      printed: #"\.vol\1234\2"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/.vol/1234/2/foo/bar",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "2", "foo", "bar"],
+      printed: "/.vol/1234/2/foo/bar", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/@", components: ["foo", "bar"],
+      printed: "/.vol/1234/@/foo/bar", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "2", "foo", "bar"],
+      printed: #"\.vol\1234\2\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // "@" already canonical: round-trips
+  PathTestCase(
+    input: "/.vol/1234/@",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "@"],
+      printed: "/.vol/1234/@", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/@", components: [],
+      printed: "/.vol/1234/@", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "@"],
+      printed: #"\.vol\1234\@"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/.vol/1234/@/",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "@"], hasTrailingSeparator: true,
+      printed: "/.vol/1234/@/", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/@", components: [], hasTrailingSeparator: true,
+      printed: "/.vol/1234/@/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "@"], hasTrailingSeparator: true,
+      printed: #"\.vol\1234\@\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/.vol/1234/@/foo",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "@", "foo"],
+      printed: "/.vol/1234/@/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/@", components: ["foo"],
+      printed: "/.vol/1234/@/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "@", "foo"],
+      printed: #"\.vol\1234\@\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Darwin combined anchors (resolve flag + volume identifier)
+  //
+  // An anchor may include resolve flags and/or a volume identifier, and
+  // resolve always precedes vol. The combined form
+  // `[/.nofollow/ | /.resolve/N/].vol/FSID/FILEID` is a single anchor.
+  // Both canonicalizations (`/.resolve/1/` -> `/.nofollow/`, `2` -> `@`)
+  // can fire on the same input.
+
+  // Combined nofollow + vol, no canonicalization.
+  PathTestCase(
+    input: "/.nofollow/.vol/1234/5678",
+    linux: Expected(
+      anchor: "/", components: [".nofollow", ".vol", "1234", "5678"],
+      printed: "/.nofollow/.vol/1234/5678", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/.vol/1234/5678", components: [],
+      printed: "/.nofollow/.vol/1234/5678", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".nofollow", ".vol", "1234", "5678"],
+      printed: #"\.nofollow\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Combined nofollow + vol with relative content.
+  PathTestCase(
+    input: "/.nofollow/.vol/1234/5678/foo",
+    linux: Expected(
+      anchor: "/", components: [".nofollow", ".vol", "1234", "5678", "foo"],
+      printed: "/.nofollow/.vol/1234/5678/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/.vol/1234/5678", components: ["foo"],
+      printed: "/.nofollow/.vol/1234/5678/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".nofollow", ".vol", "1234", "5678", "foo"],
+      printed: #"\.nofollow\.vol\1234\5678\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Combined nofollow + vol with FILEID canonicalization (`2` -> `@`).
+  PathTestCase(
+    input: "/.nofollow/.vol/1234/2",
+    linux: Expected(
+      anchor: "/", components: [".nofollow", ".vol", "1234", "2"],
+      printed: "/.nofollow/.vol/1234/2", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/.vol/1234/@", components: [],
+      printed: "/.nofollow/.vol/1234/@", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".nofollow", ".vol", "1234", "2"],
+      printed: #"\.nofollow\.vol\1234\2"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Combined nofollow + vol, FILEID canonicalization, with relative + trailing.
+  PathTestCase(
+    input: "/.nofollow/.vol/1234/2/foo/",
+    linux: Expected(
+      anchor: "/", components: [".nofollow", ".vol", "1234", "2", "foo"],
+      hasTrailingSeparator: true,
+      printed: "/.nofollow/.vol/1234/2/foo/", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/.vol/1234/@", components: ["foo"],
+      hasTrailingSeparator: true,
+      printed: "/.nofollow/.vol/1234/@/foo/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".nofollow", ".vol", "1234", "2", "foo"],
+      hasTrailingSeparator: true,
+      printed: #"\.nofollow\.vol\1234\2\foo\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Combined resolve/N + vol (non-canonicalizing flag value).
+  PathTestCase(
+    input: "/.resolve/3/.vol/1234/5678",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "3", ".vol", "1234", "5678"],
+      printed: "/.resolve/3/.vol/1234/5678", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.resolve/3/.vol/1234/5678", components: [],
+      printed: "/.resolve/3/.vol/1234/5678", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "3", ".vol", "1234", "5678"],
+      printed: #"\.resolve\3\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Combined resolve/3 + vol with FILEID canon: only the FILEID rule
+  // fires; `.resolve/3/` is preserved as written.
+  PathTestCase(
+    input: "/.resolve/3/.vol/1234/2/",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "3", ".vol", "1234", "2"],
+      hasTrailingSeparator: true,
+      printed: "/.resolve/3/.vol/1234/2/", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.resolve/3/.vol/1234/@", components: [],
+      hasTrailingSeparator: true,
+      printed: "/.resolve/3/.vol/1234/@/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "3", ".vol", "1234", "2"],
+      hasTrailingSeparator: true,
+      printed: #"\.resolve\3\.vol\1234\2\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Combined resolve/1 + vol, where both canonicalizations fire:
+  // `/.resolve/1/` -> `/.nofollow/` and FILEID `2` -> `@`.
+  PathTestCase(
+    input: "/.resolve/1/.vol/1234/2/",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "1", ".vol", "1234", "2"],
+      hasTrailingSeparator: true,
+      printed: "/.resolve/1/.vol/1234/2/", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/.vol/1234/@", components: [],
+      hasTrailingSeparator: true,
+      printed: "/.nofollow/.vol/1234/@/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "1", ".vol", "1234", "2"],
+      hasTrailingSeparator: true,
+      printed: #"\.resolve\1\.vol\1234\2\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Combined resolve/1 + vol with relative content: both canons, plus relative.
+  PathTestCase(
+    input: "/.resolve/1/.vol/1234/2/foo/bar",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "1", ".vol", "1234", "2", "foo", "bar"],
+      printed: "/.resolve/1/.vol/1234/2/foo/bar", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/.vol/1234/@", components: ["foo", "bar"],
+      printed: "/.nofollow/.vol/1234/@/foo/bar", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "1", ".vol", "1234", "2", "foo", "bar"],
+      printed: #"\.resolve\1\.vol\1234\2\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Darwin resource forks (linux/darwin differ)
+
+  PathTestCase(
+    input: "/foo/..namedfork/rsrc",
+    linux: Expected(
+      anchor: "/", components: ["foo", "..namedfork", "rsrc"],
+      printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/", components: ["foo"], isResourceFork: true,
+      printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"],
+      printed: #"\foo\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Trailing slash breaks resource fork recognition
+  PathTestCase(
+    input: "/foo/..namedfork/rsrc/",
+    unix: Expected(
+      anchor: "/", components: ["foo", "..namedfork", "rsrc"], hasTrailingSeparator: true,
+      printed: "/foo/..namedfork/rsrc/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"], hasTrailingSeparator: true,
+      printed: #"\foo\..namedfork\rsrc\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Resource fork on relative path
+  PathTestCase(
+    input: "foo/..namedfork/rsrc",
+    linux: Expected(
+      anchor: nil, components: ["foo", "..namedfork", "rsrc"],
+      printed: "foo/..namedfork/rsrc", isAbsolute: false),
+    darwin: Expected(
+      anchor: nil, components: ["foo"], isResourceFork: true,
+      printed: "foo/..namedfork/rsrc", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo", "..namedfork", "rsrc"],
+      printed: #"foo\..namedfork\rsrc"#, isAbsolute: false)
+  ),
+
+  // Resource fork on a root-only path (semantically invalid, but
+  // syntactically recognized)
+  PathTestCase(
+    input: "/..namedfork/rsrc",
+    linux: Expected(
+      anchor: "/", components: ["..namedfork", "rsrc"],
+      printed: "/..namedfork/rsrc", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/", components: [], isResourceFork: true,
+      printed: "/..namedfork/rsrc", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["..namedfork", "rsrc"],
+      printed: #"\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Windows drive absolute
+
+  PathTestCase(
+    input: #"C:\foo\bar"#,
+    // Backslash is a legal filename char on Unix: single component
+    unix: .singleComponent(#"C:\foo\bar"#),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar"],
+      printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"C:\"#,
+    unix: .singleComponent(#"C:\"#),
+    windows: Expected(
+      anchor: #"C:\"#, components: [],
+      printed: #"C:\"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"c:\foo"#,
+    unix: .singleComponent(#"c:\foo"#),
+    windows: Expected(
+      anchor: #"c:\"#, components: ["foo"],
+      printed: #"c:\foo"#, isAbsolute: true, driveLetter: "c")
+  ),
+
+  // Interior dot dropped
+  PathTestCase(
+    input: #"C:\foo\.\bar"#,
+    unix: .singleComponent(#"C:\foo\.\bar"#),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar"],
+      printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // Interior dotdot presented, not collapsed
+  PathTestCase(
+    input: #"C:\foo\..\bar"#,
+    unix: .singleComponent(#"C:\foo\..\bar"#),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "..", "bar"],
+      printed: #"C:\foo\..\bar"#, isAbsolute: true, driveLetter: "C",
+      kinds: [.regular, .parentDirectory, .regular])
+  ),
+
+  PathTestCase(
+    input: #"C:\foo\"#,
+    unix: .singleComponent(#"C:\foo\"#),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo"], hasTrailingSeparator: true,
+      printed: #"C:\foo\"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // MARK: - Windows drive relative
+
+  PathTestCase(
+    input: "C:foo",
+    unix: Expected(
+      anchor: nil, components: ["C:foo"],
+      printed: "C:foo", isAbsolute: false),
+    windows: Expected(
+      anchor: "C:", components: ["foo"],
+      printed: "C:foo", isAbsolute: false, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: "C:",
+    unix: Expected(
+      anchor: nil, components: ["C:"],
+      printed: "C:", isAbsolute: false),
+    windows: Expected(
+      anchor: "C:", components: [],
+      printed: "C:", isAbsolute: false, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"C:foo\"#,
+    unix: .singleComponent(#"C:foo\"#),
+    windows: Expected(
+      anchor: "C:", components: ["foo"], hasTrailingSeparator: true,
+      printed: #"C:foo\"#, isAbsolute: false, driveLetter: "C")
+  ),
+
+  // MARK: - Windows rooted-not-absolute
+
+  PathTestCase(
+    input: #"\foo"#,
+    unix: .singleComponent(#"\foo"#),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo"],
+      printed: #"\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: #"\foo\bar"#,
+    unix: .singleComponent(#"\foo\bar"#),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "bar"],
+      printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: #"\"#,
+    unix: .singleComponent(#"\"#),
+    windows: Expected(
+      anchor: #"\"#, components: [],
+      printed: #"\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Windows UNC
+
+  PathTestCase(
+    input: #"\\server\share\foo"#,
+    unix: .singleComponent(#"\\server\share\foo"#),
+    windows: Expected(
+      anchor: #"\\server\share"#, components: ["foo"],
+      printed: #"\\server\share\foo"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: #"\\server\share\"#,
+    unix: .singleComponent(#"\\server\share\"#),
+    windows: Expected(
+      anchor: #"\\server\share"#, components: [], hasTrailingSeparator: true,
+      printed: #"\\server\share\"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: #"\\server\share"#,
+    unix: .singleComponent(#"\\server\share"#),
+    windows: Expected(
+      anchor: #"\\server\share"#, components: [],
+      printed: #"\\server\share"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: #"\\server\share\foo\bar\"#,
+    unix: .singleComponent(#"\\server\share\foo\bar\"#),
+    windows: Expected(
+      anchor: #"\\server\share"#, components: ["foo", "bar"], hasTrailingSeparator: true,
+      printed: #"\\server\share\foo\bar\"#, isAbsolute: true)
+  ),
+
+  // MARK: - Windows device paths (\\.\)
+
+  // Bare device prefix: anchor only
+  PathTestCase(
+    input: #"\\.\"#,
+    unix: .singleComponent(#"\\.\"#),
+    windows: Expected(
+      anchor: #"\\.\"#, components: [],
+      printed: #"\\.\"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: #"\\.\C:\foo"#,
+    unix: .singleComponent(#"\\.\C:\foo"#),
+    windows: Expected(
+      anchor: #"\\.\C:\"#, components: ["foo"],
+      printed: #"\\.\C:\foo"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"\\.\pipe\name"#,
+    unix: .singleComponent(#"\\.\pipe\name"#),
+    windows: Expected(
+      anchor: #"\\.\pipe"#, components: ["name"],
+      printed: #"\\.\pipe\name"#, isAbsolute: true)
+  ),
+
+  // Pipe device with trailing sep, no pipe name
+  PathTestCase(
+    input: #"\\.\pipe\"#,
+    unix: .singleComponent(#"\\.\pipe\"#),
+    windows: Expected(
+      anchor: #"\\.\pipe"#, components: [], hasTrailingSeparator: true,
+      printed: #"\\.\pipe\"#, isAbsolute: true)
+  ),
+
+  // Device drive without root separator
+  PathTestCase(
+    input: #"\\.\C:"#,
+    unix: .singleComponent(#"\\.\C:"#),
+    windows: Expected(
+      anchor: #"\\.\C:"#, components: [],
+      printed: #"\\.\C:"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // Dot is dropped on non-verbatim device paths
+  PathTestCase(
+    input: #"\\.\C:\foo\.\bar"#,
+    unix: .singleComponent(#"\\.\C:\foo\.\bar"#),
+    windows: Expected(
+      anchor: #"\\.\C:\"#, components: ["foo", "bar"],
+      printed: #"\\.\C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // MARK: - Windows verbatim paths (\\?\)
+
+  // Bare verbatim prefix: anchor only
+  PathTestCase(
+    input: #"\\?\"#,
+    unix: .singleComponent(#"\\?\"#),
+    windows: Expected(
+      anchor: #"\\?\"#, components: [],
+      printed: #"\\?\"#, isAbsolute: true)
+  ),
+
+  // Verbatim drive without root separator
+  PathTestCase(
+    input: #"\\?\C:"#,
+    unix: .singleComponent(#"\\?\C:"#),
+    windows: Expected(
+      anchor: #"\\?\C:"#, components: [],
+      printed: #"\\?\C:"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // Dot not dropped in verbatim: treated as regular component
+  PathTestCase(
+    input: #"\\?\C:\foo\.\bar"#,
+    unix: .singleComponent(#"\\?\C:\foo\.\bar"#),
+    windows: Expected(
+      anchor: #"\\?\C:\"#, components: ["foo", ".", "bar"],
+      printed: #"\\?\C:\foo\.\bar"#, isAbsolute: true, driveLetter: "C",
+      kinds: [.regular, .regular, .regular])
+  ),
+
+  // Dotdot not special in verbatim: treated as regular component
+  PathTestCase(
+    input: #"\\?\C:\foo\..\bar"#,
+    unix: .singleComponent(#"\\?\C:\foo\..\bar"#),
+    windows: Expected(
+      anchor: #"\\?\C:\"#, components: ["foo", "..", "bar"],
+      printed: #"\\?\C:\foo\..\bar"#, isAbsolute: true, driveLetter: "C",
+      kinds: [.regular, .regular, .regular])
+  ),
+
+  PathTestCase(
+    input: #"\\?\UNC\server\share\foo"#,
+    unix: .singleComponent(#"\\?\UNC\server\share\foo"#),
+    windows: Expected(
+      anchor: #"\\?\UNC\server\share"#, components: ["foo"],
+      printed: #"\\?\UNC\server\share\foo"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: #"\\?\C:\"#,
+    unix: .singleComponent(#"\\?\C:\"#),
+    windows: Expected(
+      anchor: #"\\?\C:\"#, components: [],
+      printed: #"\\?\C:\"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"\\?\C:\foo\"#,
+    unix: .singleComponent(#"\\?\C:\foo\"#),
+    windows: Expected(
+      anchor: #"\\?\C:\"#, components: ["foo"], hasTrailingSeparator: true,
+      printed: #"\\?\C:\foo\"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // Separator coalescing still happens in verbatim (which only affects
+  // dot/dotdot)
+  PathTestCase(
+    input: #"\\?\C:\foo\\bar"#,
+    unix: .singleComponent(#"\\?\C:\foo\\bar"#),
+    windows: Expected(
+      anchor: #"\\?\C:\"#, components: ["foo", "bar"],
+      printed: #"\\?\C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // MARK: - Forward slashes inside verbatim component content
+
+  // / inside verbatim component is a legal filename character, not a separator
+  PathTestCase(
+    input: #"\\?\C:\foo/bar"#,
+    unix: Expected(
+      anchor: nil, components: [#"\\?\C:\foo"#, "bar"],
+      printed: #"\\?\C:\foo/bar"#, isAbsolute: false),
+    windows: Expected(
+      anchor: #"\\?\C:\"#, components: ["foo/bar"],
+      printed: #"\\?\C:\foo/bar"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"\\?\C:\a/b/c"#,
+    unix: Expected(
+      anchor: nil, components: [#"\\?\C:\a"#, "b", "c"],
+      printed: #"\\?\C:\a/b/c"#, isAbsolute: false),
+    windows: Expected(
+      anchor: #"\\?\C:\"#, components: ["a/b/c"],
+      printed: #"\\?\C:\a/b/c"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"\\?\UNC\s\sh\a/b"#,
+    unix: Expected(
+      anchor: nil, components: [#"\\?\UNC\s\sh\a"#, "b"],
+      printed: #"\\?\UNC\s\sh\a/b"#, isAbsolute: false),
+    windows: Expected(
+      anchor: #"\\?\UNC\s\sh"#, components: ["a/b"],
+      printed: #"\\?\UNC\s\sh\a/b"#, isAbsolute: true)
+  ),
+
+  // //?/ is not verbatim; it is device-namespace (same as //./).
+  // All / converted.
+  PathTestCase(
+    input: "//?/C:/a/b",
+    unix: Expected(
+      anchor: "/", components: ["?", "C:", "a", "b"],
+      printed: "/?/C:/a/b", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\\.\C:\"#, components: ["a", "b"],
+      printed: #"\\.\C:\a\b"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // Non-verbatim device path: all / converted (regression check)
+  PathTestCase(
+    input: "//./C:/a/b",
+    unix: Expected(
+      anchor: "/", components: ["C:", "a", "b"],
+      printed: "/C:/a/b", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\\.\C:\"#, components: ["a", "b"],
+      printed: #"\\.\C:\a\b"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // MARK: - Windows forward slash normalization
+
+  // Triple slash: coalesces on both, rooted on Windows
+  PathTestCase(
+    input: "///foo/bar",
+    unix: Expected(
+      anchor: "/", components: ["foo", "bar"],
+      printed: "/foo/bar", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "bar"],
+      printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // //./foo on Unix: dot dropped (rooted), "foo" is a regular component
+  // //./foo on Windows: device-namespace prefix, "foo" is device name
+  PathTestCase(
+    input: "//./foo",
+    unix: Expected(
+      anchor: "/", components: ["foo"],
+      printed: "/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\\.\foo"#, components: [],
+      printed: #"\\.\foo"#, isAbsolute: true)
+  ),
+
+  // //?/foo on Unix: regular components
+  // //?/foo on Windows: device-namespace (not verbatim), "foo" is device name
+  PathTestCase(
+    input: "//?/foo",
+    unix: Expected(
+      anchor: "/", components: ["?", "foo"],
+      printed: "/?/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\\.\foo"#, components: [],
+      printed: #"\\.\foo"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: "C:/foo/bar",
+    // Unix: "C:" is a component (colon is legal), "/" is separator
+    unix: Expected(
+      anchor: nil, components: ["C:", "foo", "bar"],
+      printed: "C:/foo/bar", isAbsolute: false),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar"],
+      printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: "C:/",
+    unix: Expected(
+      anchor: nil, components: ["C:"], hasTrailingSeparator: true,
+      printed: "C:/", isAbsolute: false),
+    windows: Expected(
+      anchor: #"C:\"#, components: [],
+      printed: #"C:\"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: "//server/share/foo",
+    unix: Expected(
+      anchor: "/", components: ["server", "share", "foo"],
+      printed: "/server/share/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\\server\share"#, components: ["foo"],
+      printed: #"\\server\share\foo"#, isAbsolute: true)
+  ),
+
+  // Dot dropped (rooted) on Unix, device-namespace on Windows
+  PathTestCase(
+    input: "//./C:/foo",
+    unix: Expected(
+      anchor: "/", components: ["C:", "foo"],
+      printed: "/C:/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\\.\C:\"#, components: ["foo"],
+      printed: #"\\.\C:\foo"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: "//?/C:/foo",
+    unix: Expected(
+      anchor: "/", components: ["?", "C:", "foo"],
+      printed: "/?/C:/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\\.\C:\"#, components: ["foo"],
+      printed: #"\\.\C:\foo"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // MARK: - Cross-platform mismatch
+
+  // Backslash is a legal filename char on Unix
+  PathTestCase(
+    input: #"foo\bar"#,
+    unix: .singleComponent(#"foo\bar"#),
+    windows: Expected(
+      anchor: nil, components: ["foo", "bar"],
+      printed: #"foo\bar"#, isAbsolute: false)
+  ),
+
+  // Dot-backslash: Unix sees a single component, Windows sees
+  // dot + separator + component
+  PathTestCase(
+    input: #".\foo"#,
+    unix: .singleComponent(#".\foo"#),
+    windows: Expected(
+      anchor: nil, components: [".", "foo"],
+      printed: #".\foo"#, isAbsolute: false, kinds: [.currentDirectory, .regular])
+  ),
+
+  // Colon in component: legal on Unix, possible ADS marker on Windows
+  PathTestCase(
+    input: "foo:bar",
+    unix: Expected(
+      anchor: nil, components: ["foo:bar"],
+      printed: "foo:bar", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo:bar"],
+      printed: "foo:bar", isAbsolute: false)
+  ),
+
+  // Deeper relative with only backslashes
+  PathTestCase(
+    input: #"foo\bar\baz"#,
+    unix: .singleComponent(#"foo\bar\baz"#),
+    windows: Expected(
+      anchor: nil, components: ["foo", "bar", "baz"],
+      printed: #"foo\bar\baz"#, isAbsolute: false)
+  ),
+
+  // Multi-char before colon: not a drive letter
+  PathTestCase(
+    input: #"CC:\foo"#,
+    unix: .singleComponent(#"CC:\foo"#),
+    windows: Expected(
+      anchor: nil, components: ["CC:", "foo"],
+      printed: #"CC:\foo"#, isAbsolute: false)
+  ),
+
+  // MARK: - Mixed separators on Windows-style paths
+
+  // Forward slash splits on Unix (two components); on Windows both
+  // separators normalize
+  PathTestCase(
+    input: #"C:\foo/bar"#,
+    unix: Expected(
+      anchor: nil, components: [#"C:\foo"#, "bar"],
+      printed: #"C:\foo/bar"#, isAbsolute: false),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar"],
+      printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"C:\foo\bar/baz"#,
+    unix: Expected(
+      anchor: nil, components: [#"C:\foo\bar"#, "baz"],
+      printed: #"C:\foo\bar/baz"#, isAbsolute: false),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar", "baz"],
+      printed: #"C:\foo\bar\baz"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // UNC server\share then forward slash: Unix splits at /
+  PathTestCase(
+    input: #"\\server\share/foo"#,
+    unix: Expected(
+      anchor: nil, components: [#"\\server\share"#, "foo"],
+      printed: #"\\server\share/foo"#, isAbsolute: false),
+    windows: Expected(
+      anchor: #"\\server\share"#, components: ["foo"],
+      printed: #"\\server\share\foo"#, isAbsolute: true)
+  ),
+
+  // MARK: - Trailing forward slash on backslash paths
+
+  // Unix: forward slash is a separator, splitting the backslash-blob from
+  // the trailing separator
+  PathTestCase(
+    input: #"C:\foo/"#,
+    unix: .singleComponent(#"C:\foo"#, hasTrailingSeparator: true),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo"], hasTrailingSeparator: true,
+      printed: #"C:\foo\"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"C:\foo\bar/"#,
+    unix: .singleComponent(#"C:\foo\bar"#, hasTrailingSeparator: true),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar"], hasTrailingSeparator: true,
+      printed: #"C:\foo\bar\"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"\\server\share/"#,
+    unix: .singleComponent(#"\\server\share"#, hasTrailingSeparator: true),
+    windows: Expected(
+      anchor: #"\\server\share"#, components: [], hasTrailingSeparator: true,
+      printed: #"\\server\share\"#, isAbsolute: true)
+  ),
+
+  // MARK: - Unicode in components
+
+  PathTestCase(
+    input: "/あ/🧟‍♀️",
+    unix: Expected(
+      anchor: "/", components: ["あ", "🧟‍♀️"],
+      printed: "/あ/🧟‍♀️", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["あ", "🧟‍♀️"],
+      printed: #"\あ\🧟‍♀️"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Additional dot/dotdot patterns
+
+  PathTestCase(
+    input: "./foo/bar",
+    unix: Expected(
+      anchor: nil, components: [".", "foo", "bar"],
+      printed: "./foo/bar", isAbsolute: false, kinds: [.currentDirectory, .regular, .regular]),
+    windows: Expected(
+      anchor: nil, components: [".", "foo", "bar"],
+      printed: #".\foo\bar"#, isAbsolute: false, kinds: [.currentDirectory, .regular, .regular])
+  ),
+
+  // Dot then double slash: coalesced, dot preserved as first
+  PathTestCase(
+    input: ".//foo",
+    unix: Expected(
+      anchor: nil, components: [".", "foo"],
+      printed: "./foo", isAbsolute: false, kinds: [.currentDirectory, .regular]),
+    windows: Expected(
+      anchor: nil, components: [".", "foo"],
+      printed: #".\foo"#, isAbsolute: false, kinds: [.currentDirectory, .regular])
+  ),
+
+  PathTestCase(
+    input: "foo/../../bar",
+    unix: Expected(
+      anchor: nil, components: ["foo", "..", "..", "bar"],
+      printed: "foo/../../bar", isAbsolute: false,
+      kinds: [.regular, .parentDirectory, .parentDirectory, .regular]),
+    windows: Expected(
+      anchor: nil, components: ["foo", "..", "..", "bar"],
+      printed: #"foo\..\..\bar"#, isAbsolute: false,
+      kinds: [.regular, .parentDirectory, .parentDirectory, .regular])
+  ),
+
+  PathTestCase(
+    input: "foo/../bar/../baz",
+    unix: Expected(
+      anchor: nil, components: ["foo", "..", "bar", "..", "baz"],
+      printed: "foo/../bar/../baz", isAbsolute: false,
+      kinds: [.regular, .parentDirectory, .regular, .parentDirectory, .regular]),
+    windows: Expected(
+      anchor: nil, components: ["foo", "..", "bar", "..", "baz"],
+      printed: #"foo\..\bar\..\baz"#, isAbsolute: false,
+      kinds: [.regular, .parentDirectory, .regular, .parentDirectory, .regular])
+  ),
+
+  PathTestCase(
+    input: "/foo//bar//baz",
+    unix: Expected(
+      anchor: "/", components: ["foo", "bar", "baz"],
+      printed: "/foo/bar/baz", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "bar", "baz"],
+      printed: #"\foo\bar\baz"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - More Windows edge cases
+
+  PathTestCase(
+    input: #"C:\.."#,
+    unix: .singleComponent(#"C:\.."#),
+    windows: Expected(
+      anchor: #"C:\"#, components: [".."],
+      printed: #"C:\.."#, isAbsolute: true, driveLetter: "C",
+      kinds: [.parentDirectory])
+  ),
+
+  // Double sep after drive root: coalesced
+  PathTestCase(
+    input: #"C:\\foo"#,
+    unix: .singleComponent(#"C:\\foo"#),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo"],
+      printed: #"C:\foo"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // Trailing dot dropped, becomes trailing sep
+  PathTestCase(
+    input: #"C:\foo\bar\."#,
+    unix: .singleComponent(#"C:\foo\bar\."#),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar"], hasTrailingSeparator: true,
+      printed: #"C:\foo\bar\"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  PathTestCase(
+    input: #"C:\foo\bar\.."#,
+    unix: .singleComponent(#"C:\foo\bar\.."#),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar", ".."],
+      printed: #"C:\foo\bar\.."#, isAbsolute: true, driveLetter: "C",
+      kinds: [.regular, .regular, .parentDirectory])
+  ),
+
+  PathTestCase(
+    input: #"\\server\share\..\foo"#,
+    unix: .singleComponent(#"\\server\share\..\foo"#),
+    windows: Expected(
+      anchor: #"\\server\share"#, components: ["..", "foo"],
+      printed: #"\\server\share\..\foo"#, isAbsolute: true,
+      kinds: [.parentDirectory, .regular])
+  ),
+
+  // Mixed separators: "/" is sep on Unix, both "/" and "\" are on Windows
+  PathTestCase(
+    input: #"C:/foo\bar"#,
+    unix: Expected(
+      anchor: nil, components: ["C:", #"foo\bar"#],
+      printed: #"C:/foo\bar"#, isAbsolute: false),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar"],
+      printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // MARK: - Verbatim dot/dotdot at end
+
+  // In verbatim context, trailing dot is a regular component, not dropped
+  PathTestCase(
+    input: #"\\?\C:\foo\bar\."#,
+    unix: .singleComponent(#"\\?\C:\foo\bar\."#),
+    windows: Expected(
+      anchor: #"\\?\C:\"#, components: ["foo", "bar", "."],
+      printed: #"\\?\C:\foo\bar\."#, isAbsolute: true, driveLetter: "C",
+      kinds: [.regular, .regular, .regular])
+  ),
+
+  PathTestCase(
+    input: #"\\?\C:\foo\bar\.."#,
+    unix: .singleComponent(#"\\?\C:\foo\bar\.."#),
+    windows: Expected(
+      anchor: #"\\?\C:\"#, components: ["foo", "bar", ".."],
+      printed: #"\\?\C:\foo\bar\.."#, isAbsolute: true, driveLetter: "C",
+      kinds: [.regular, .regular, .regular])
+  ),
+
+  PathTestCase(
+    input: #"\\?\UNC\server\share\..\foo"#,
+    unix: .singleComponent(#"\\?\UNC\server\share\..\foo"#),
+    windows: Expected(
+      anchor: #"\\?\UNC\server\share"#, components: ["..", "foo"],
+      printed: #"\\?\UNC\server\share\..\foo"#, isAbsolute: true,
+      kinds: [.regular, .regular])
+  ),
+
+  // MARK: - Resolve prefix edge cases
+
+  // Prefix recognized with no components
+  PathTestCase(
+    input: "/.nofollow/",
+    linux: Expected(
+      anchor: "/", components: [".nofollow"], hasTrailingSeparator: true,
+      printed: "/.nofollow/", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/", components: [],
+      printed: "/.nofollow/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".nofollow"], hasTrailingSeparator: true,
+      printed: #"\.nofollow\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Prefix requires absolute path: not recognized on relative
+  PathTestCase(
+    input: "foo/.nofollow/bar",
+    unix: Expected(
+      anchor: nil, components: ["foo", ".nofollow", "bar"],
+      printed: "foo/.nofollow/bar", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo", ".nofollow", "bar"],
+      printed: #"foo\.nofollow\bar"#, isAbsolute: false)
+  ),
+
+  // Near-miss: wrong case
+  PathTestCase(
+    input: "/.NOFOLLOW/foo",
+    unix: Expected(
+      anchor: "/", components: [".NOFOLLOW", "foo"],
+      printed: "/.NOFOLLOW/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".NOFOLLOW", "foo"],
+      printed: #"\.NOFOLLOW\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Near-miss: extra char
+  PathTestCase(
+    input: "/.nofollowx/foo",
+    unix: Expected(
+      anchor: "/", components: [".nofollowx", "foo"],
+      printed: "/.nofollowx/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".nofollowx", "foo"],
+      printed: #"\.nofollowx\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - .vol degenerate cases
+
+  // Fewer than two components after .vol: not recognized as volfs
+  PathTestCase(
+    input: "/.vol",
+    unix: Expected(
+      anchor: "/", components: [".vol"],
+      printed: "/.vol", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol"],
+      printed: #"\.vol"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/.vol/",
+    linux: Expected(
+      anchor: "/", components: [".vol"], hasTrailingSeparator: true,
+      printed: "/.vol/", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/", components: [".vol"], hasTrailingSeparator: true,
+      printed: "/.vol/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol"], hasTrailingSeparator: true,
+      printed: #"\.vol\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Only one component after .vol: not enough
+  PathTestCase(
+    input: "/.vol/16777234",
+    linux: Expected(
+      anchor: "/", components: [".vol", "16777234"],
+      printed: "/.vol/16777234", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/", components: [".vol", "16777234"],
+      printed: "/.vol/16777234", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "16777234"],
+      printed: #"\.vol\16777234"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Wrong case: not volfs
+  PathTestCase(
+    input: "/.VOL/1234/5678",
+    unix: Expected(
+      anchor: "/", components: [".VOL", "1234", "5678"],
+      printed: "/.VOL/1234/5678", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".VOL", "1234", "5678"],
+      printed: #"\.VOL\1234\5678"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Extra char: not volfs
+  PathTestCase(
+    input: "/.volx/1234/5678",
+    unix: Expected(
+      anchor: "/", components: [".volx", "1234", "5678"],
+      printed: "/.volx/1234/5678", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".volx", "1234", "5678"],
+      printed: #"\.volx\1234\5678"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Non-numeric fsid: parser treats vol IDs opaquely
+  PathTestCase(
+    input: "/.vol/abc/12345",
+    linux: Expected(
+      anchor: "/", components: [".vol", "abc", "12345"],
+      printed: "/.vol/abc/12345", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/abc/12345", components: [],
+      printed: "/.vol/abc/12345", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "abc", "12345"],
+      printed: #"\.vol\abc\12345"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Dot after volfs anchor: dropped (volfs anchor is rooted)
+  PathTestCase(
+    input: "/.vol/1234/5678/./foo",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "5678", "foo"],
+      printed: "/.vol/1234/5678/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/5678", components: ["foo"],
+      printed: "/.vol/1234/5678/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "5678", "foo"],
+      printed: #"\.vol\1234\5678\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Dotdot after volfs anchor: presented, not collapsed
+  PathTestCase(
+    input: "/.vol/1234/5678/foo/../bar",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "5678", "foo", "..", "bar"],
+      printed: "/.vol/1234/5678/foo/../bar", isAbsolute: true,
+      kinds: [.regular, .regular, .regular, .regular, .parentDirectory, .regular]),
+    darwin: Expected(
+      anchor: "/.vol/1234/5678", components: ["foo", "..", "bar"],
+      printed: "/.vol/1234/5678/foo/../bar", isAbsolute: true,
+      kinds: [.regular, .parentDirectory, .regular]),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "5678", "foo", "..", "bar"],
+      printed: #"\.vol\1234\5678\foo\..\bar"#, isAbsolute: false, isRooted: true,
+      kinds: [.regular, .regular, .regular, .regular, .parentDirectory, .regular])
+  ),
+
+  // MARK: - Resource fork near-misses
+
+  PathTestCase(
+    input: "/foo/..namedfork/data",
+    unix: Expected(
+      anchor: "/", components: ["foo", "..namedfork", "data"],
+      printed: "/foo/..namedfork/data", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "..namedfork", "data"],
+      printed: #"\foo\..namedfork\data"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/foo/..namedfork",
+    unix: Expected(
+      anchor: "/", components: ["foo", "..namedfork"],
+      printed: "/foo/..namedfork", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "..namedfork"],
+      printed: #"\foo\..namedfork"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Extra path after rsrc: suffix too long, not matched
+  PathTestCase(
+    input: "/foo/..namedfork/rsrc/extra",
+    unix: Expected(
+      anchor: "/", components: ["foo", "..namedfork", "rsrc", "extra"],
+      printed: "/foo/..namedfork/rsrc/extra", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "..namedfork", "rsrc", "extra"],
+      printed: #"\foo\..namedfork\rsrc\extra"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Darwin double separators within anchor structures
+  //
+  // _StdlibFilePath coalesces repeated separators and decomposes the
+  // coalesced form; the only input it rejects (returns nil) is one
+  // containing NUL. For .vol, the coalesced form yields the normal volfs
+  // anchor.
+
+  // Double slash after .vol coalesces to /.vol/1234/5678 (volfs anchor)
+  PathTestCase(
+    input: "/.vol//1234/5678",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "5678"],
+      printed: "/.vol/1234/5678", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/5678", components: [],
+      printed: "/.vol/1234/5678", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "5678"],
+      printed: #"\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Double slash between vol IDs coalesces to /.vol/1234/5678 (volfs anchor)
+  PathTestCase(
+    input: "/.vol/1234//5678",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "5678"],
+      printed: "/.vol/1234/5678", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/5678", components: [],
+      printed: "/.vol/1234/5678", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "5678"],
+      printed: #"\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // The resource-fork match is an emergent property of separator
+  // coalescing, consistent with the Darwin anchor cases: the whole string is
+  // coalesced before suffix detection, so the kernel only ever receives the
+  // coalesced form (/foo/..namedfork/rsrc). There is no separate
+  // kernel-behavior question to confirm.
+  PathTestCase(
+    input: "/foo/..namedfork//rsrc",
+    linux: Expected(
+      anchor: "/", components: ["foo", "..namedfork", "rsrc"],
+      printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/", components: ["foo"], isResourceFork: true,
+      printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"],
+      printed: #"\foo\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Double slash before resource fork suffix: suffix is the last 17 bytes,
+  // which are "/..namedfork/rsrc" regardless of earlier double slashes.
+  PathTestCase(
+    input: "/foo//..namedfork/rsrc",
+    linux: Expected(
+      anchor: "/", components: ["foo", "..namedfork", "rsrc"],
+      printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/", components: ["foo"], isResourceFork: true,
+      printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"],
+      printed: #"\foo\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Double slash where the resolve flag number should be: coalesces to
+  // /.resolve/1/foo, which then canonicalizes to /.nofollow/foo on Darwin.
+  PathTestCase(
+    input: "/.resolve//1/foo",
+    linux: Expected(
+      anchor: "/", components: [".resolve", "1", "foo"],
+      printed: "/.resolve/1/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/", components: ["foo"],
+      printed: "/.nofollow/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".resolve", "1", "foo"],
+      printed: #"\.resolve\1\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // Double slash after nofollow prefix boundary: prefix matches (first 11
+  // bytes are "/.nofollow/"), extra slash is a redundant separator in the
+  // relative portion.
+  PathTestCase(
+    input: "/.nofollow//foo",
+    linux: Expected(
+      anchor: "/", components: [".nofollow", "foo"],
+      printed: "/.nofollow/foo", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/", components: ["foo"],
+      printed: "/.nofollow/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".nofollow", "foo"],
+      printed: #"\.nofollow\foo"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - .vol + resource fork
+
+  PathTestCase(
+    input: "/.vol/1234/5678/file/..namedfork/rsrc",
+    linux: Expected(
+      anchor: "/", components: [".vol", "1234", "5678", "file", "..namedfork", "rsrc"],
+      printed: "/.vol/1234/5678/file/..namedfork/rsrc", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.vol/1234/5678", components: ["file"], isResourceFork: true,
+      printed: "/.vol/1234/5678/file/..namedfork/rsrc", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".vol", "1234", "5678", "file", "..namedfork", "rsrc"],
+      printed: #"\.vol\1234\5678\file\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Resolve prefix + resource fork
+
+  PathTestCase(
+    input: "/.nofollow/path/to/file/..namedfork/rsrc",
+    linux: Expected(
+      anchor: "/", components: [".nofollow", "path", "to", "file", "..namedfork", "rsrc"],
+      printed: "/.nofollow/path/to/file/..namedfork/rsrc", isAbsolute: true),
+    darwin: Expected(
+      anchor: "/.nofollow/", components: ["path", "to", "file"], isResourceFork: true,
+      printed: "/.nofollow/path/to/file/..namedfork/rsrc", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [".nofollow", "path", "to", "file", "..namedfork", "rsrc"],
+      printed: #"\.nofollow\path\to\file\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Trailing sep on dot/dotdot after root
+
+  PathTestCase(
+    input: "/./",
+    unix: Expected(
+      anchor: "/", components: [],
+      printed: "/", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: [],
+      printed: #"\"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/../",
+    unix: Expected(
+      anchor: "/", components: [".."], hasTrailingSeparator: true,
+      printed: "/../", isAbsolute: true, kinds: [.parentDirectory]),
+    windows: Expected(
+      anchor: #"\"#, components: [".."], hasTrailingSeparator: true,
+      printed: #"\..\"#, isAbsolute: false, isRooted: true, kinds: [.parentDirectory])
+  ),
+
+  PathTestCase(
+    input: "/foo/bar/../../baz",
+    unix: Expected(
+      anchor: "/", components: ["foo", "bar", "..", "..", "baz"],
+      printed: "/foo/bar/../../baz", isAbsolute: true,
+      kinds: [.regular, .regular, .parentDirectory, .parentDirectory, .regular]),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "bar", "..", "..", "baz"],
+      printed: #"\foo\bar\..\..\baz"#, isAbsolute: false, isRooted: true,
+      kinds: [.regular, .regular, .parentDirectory, .parentDirectory, .regular])
+  ),
+
+  // MARK: - Deeper drive relative
+
+  PathTestCase(
+    input: #"C:foo\bar\baz"#,
+    unix: .singleComponent(#"C:foo\bar\baz"#),
+    windows: Expected(
+      anchor: "C:", components: ["foo", "bar", "baz"],
+      printed: #"C:foo\bar\baz"#, isAbsolute: false, driveLetter: "C")
+  ),
+
+  // MARK: - Windows device UNC
+
+  PathTestCase(
+    input: #"\\.\UNC\srv\share\foo"#,
+    unix: .singleComponent(#"\\.\UNC\srv\share\foo"#),
+    windows: Expected(
+      anchor: #"\\.\UNC"#, components: ["srv", "share", "foo"],
+      printed: #"\\.\UNC\srv\share\foo"#, isAbsolute: true)
+  ),
+
+  // \\.\UNC alone: device name only, no components
+  PathTestCase(
+    input: #"\\.\UNC"#,
+    unix: .singleComponent(#"\\.\UNC"#),
+    windows: Expected(
+      anchor: #"\\.\UNC"#, components: [],
+      printed: #"\\.\UNC"#, isAbsolute: true)
+  ),
+
+  // \\.\UNC\ trailing sep after device name
+  PathTestCase(
+    input: #"\\.\UNC\"#,
+    unix: .singleComponent(#"\\.\UNC\"#),
+    windows: Expected(
+      anchor: #"\\.\UNC"#, components: [], hasTrailingSeparator: true,
+      printed: #"\\.\UNC\"#, isAbsolute: true)
+  ),
+
+  // \\.\UNC\server: server is a component, not absorbed into anchor
+  PathTestCase(
+    input: #"\\.\UNC\server"#,
+    unix: .singleComponent(#"\\.\UNC\server"#),
+    windows: Expected(
+      anchor: #"\\.\UNC"#, components: ["server"],
+      printed: #"\\.\UNC\server"#, isAbsolute: true)
+  ),
+
+  // \\.\UNC\server\share: both are components (contrast with \\?\UNC\)
+  PathTestCase(
+    input: #"\\.\UNC\server\share"#,
+    unix: .singleComponent(#"\\.\UNC\server\share"#),
+    windows: Expected(
+      anchor: #"\\.\UNC"#, components: ["server", "share"],
+      printed: #"\\.\UNC\server\share"#, isAbsolute: true)
+  ),
+
+  // \\.\UNC\server\share\ trailing sep
+  PathTestCase(
+    input: #"\\.\UNC\server\share\"#,
+    unix: .singleComponent(#"\\.\UNC\server\share\"#),
+    windows: Expected(
+      anchor: #"\\.\UNC"#, components: ["server", "share"],
+      hasTrailingSeparator: true,
+      printed: #"\\.\UNC\server\share\"#, isAbsolute: true)
+  ),
+
+  // MARK: - Verbatim non-drive non-UNC
+
+  // Unknown device name is part of anchor
+  PathTestCase(
+    input: #"\\?\foo\bar"#,
+    unix: .singleComponent(#"\\?\foo\bar"#),
+    windows: Expected(
+      anchor: #"\\?\foo"#, components: ["bar"],
+      printed: #"\\?\foo\bar"#, isAbsolute: true)
+  ),
+
+  // GLOBALROOT (NT-namespace escape): name terminates at first backslash
+  PathTestCase(
+    input: #"\\?\GLOBALROOT\Device\HarddiskVolume1\foo"#,
+    unix: .singleComponent(#"\\?\GLOBALROOT\Device\HarddiskVolume1\foo"#),
+    windows: Expected(
+      anchor: #"\\?\GLOBALROOT"#,
+      components: ["Device", "HarddiskVolume1", "foo"],
+      printed: #"\\?\GLOBALROOT\Device\HarddiskVolume1\foo"#,
+      isAbsolute: true)
+  ),
+
+  // Volume GUID (volumes without a drive letter)
+  PathTestCase(
+    input: #"\\?\Volume{12345678-1234-1234-1234-123456789012}\foo\bar"#,
+    unix: .singleComponent(
+      #"\\?\Volume{12345678-1234-1234-1234-123456789012}\foo\bar"#),
+    windows: Expected(
+      anchor: #"\\?\Volume{12345678-1234-1234-1234-123456789012}"#,
+      components: ["foo", "bar"],
+      printed: #"\\?\Volume{12345678-1234-1234-1234-123456789012}\foo\bar"#,
+      isAbsolute: true)
+  ),
+
+  // DosDevices symlink (e.g. PIPE)
+  PathTestCase(
+    input: #"\\?\PIPE\mypipe"#,
+    unix: .singleComponent(#"\\?\PIPE\mypipe"#),
+    windows: Expected(
+      anchor: #"\\?\PIPE"#, components: ["mypipe"],
+      printed: #"\\?\PIPE\mypipe"#, isAbsolute: true)
+  ),
+
+  // .. not special in verbatim plain: regular component
+  PathTestCase(
+    input: #"\\?\GLOBALROOT\..\foo"#,
+    unix: .singleComponent(#"\\?\GLOBALROOT\..\foo"#),
+    windows: Expected(
+      anchor: #"\\?\GLOBALROOT"#, components: ["..", "foo"],
+      printed: #"\\?\GLOBALROOT\..\foo"#, isAbsolute: true,
+      kinds: [.regular, .regular])
+  ),
+
+  // . not special in verbatim plain: regular component (not dropped)
+  PathTestCase(
+    input: #"\\?\GLOBALROOT\.\foo"#,
+    unix: .singleComponent(#"\\?\GLOBALROOT\.\foo"#),
+    windows: Expected(
+      anchor: #"\\?\GLOBALROOT"#, components: [".", "foo"],
+      printed: #"\\?\GLOBALROOT\.\foo"#, isAbsolute: true,
+      kinds: [.regular, .regular])
+  ),
+
+  // / inside verbatim plain component is a regular byte, not a separator
+  PathTestCase(
+    input: #"\\?\GLOBALROOT\foo/bar"#,
+    unix: Expected(
+      anchor: nil, components: [#"\\?\GLOBALROOT\foo"#, "bar"],
+      printed: #"\\?\GLOBALROOT\foo/bar"#, isAbsolute: false),
+    windows: Expected(
+      anchor: #"\\?\GLOBALROOT"#, components: ["foo/bar"],
+      printed: #"\\?\GLOBALROOT\foo/bar"#, isAbsolute: true)
+  ),
+
+  // MARK: - Device path forward slashes for pipes
+
+  // Dot dropped (rooted) on Unix, device-namespace pipe on Windows
+  PathTestCase(
+    input: "//./pipe/foo",
+    unix: Expected(
+      anchor: "/", components: ["pipe", "foo"],
+      printed: "/pipe/foo", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\\.\pipe"#, components: ["foo"],
+      printed: #"\\.\pipe\foo"#, isAbsolute: true)
+  ),
+
+  // MARK: - Dotfile components (not special, always regular)
+
+  PathTestCase(
+    input: "/foo/.hidden",
+    unix: Expected(
+      anchor: "/", components: ["foo", ".hidden"],
+      printed: "/foo/.hidden", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", ".hidden"],
+      printed: #"\foo\.hidden"#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Double extension and trailing dot
+
+  PathTestCase(
+    input: "/foo/bar.tar.gz",
+    unix: Expected(
+      anchor: "/", components: ["foo", "bar.tar.gz"],
+      printed: "/foo/bar.tar.gz", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "bar.tar.gz"],
+      printed: #"\foo\bar.tar.gz"#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/foo/bar.",
+    unix: Expected(
+      anchor: "/", components: ["foo", "bar."],
+      printed: "/foo/bar.", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "bar."],
+      printed: #"\foo\bar."#, isAbsolute: false, isRooted: true)
+  ),
+
+  PathTestCase(
+    input: "/foo/...",
+    unix: Expected(
+      anchor: "/", components: ["foo", "..."],
+      printed: "/foo/...", isAbsolute: true),
+    windows: Expected(
+      anchor: #"\"#, components: ["foo", "..."],
+      printed: #"\foo\..."#, isAbsolute: false, isRooted: true)
+  ),
+
+  // MARK: - Windows IP address as UNC server
+
+  PathTestCase(
+    input: #"\\192.168.1.1\share\foo"#,
+    unix: .singleComponent(#"\\192.168.1.1\share\foo"#),
+    windows: Expected(
+      anchor: #"\\192.168.1.1\share"#, components: ["foo"],
+      printed: #"\\192.168.1.1\share\foo"#, isAbsolute: true)
+  ),
+
+  // MARK: - Windows drive dot and dotdot
+
+  PathTestCase(
+    input: "C:.",
+    unix: Expected(
+      anchor: nil, components: ["C:."],
+      printed: "C:.", isAbsolute: false),
+    windows: Expected(
+      anchor: "C:", components: ["."],
+      printed: "C:.", isAbsolute: false, driveLetter: "C",
+      kinds: [.currentDirectory])
+  ),
+
+  PathTestCase(
+    input: "C:..",
+    unix: Expected(
+      anchor: nil, components: ["C:.."],
+      printed: "C:..", isAbsolute: false),
+    windows: Expected(
+      anchor: "C:", components: [".."],
+      printed: "C:..", isAbsolute: false, driveLetter: "C",
+      kinds: [.parentDirectory])
+  ),
+
+  // MARK: - Windows non-letter drive
+
+  // A drive letter is any single non-separator code unit followed by a
+  // colon (matching RtlDetermineDosPathNameType_U, which keys on the
+  // second character being a colon and does not validate the first).
+  // A digit is a valid drive letter: "1:\foo" is drive-absolute.
+  PathTestCase(
+    input: #"1:\foo"#,
+    unix: .singleComponent(#"1:\foo"#),
+    windows: Expected(
+      anchor: #"1:\"#, components: ["foo"],
+      printed: #"1:\foo"#, isAbsolute: true, driveLetter: "1")
+  ),
+
+  // A colon is itself a non-separator, so "::foo" parses as drive ":"
+  // (the documented basis for the "=::" environment variable Windows
+  // creates). Like "C:foo", it is drive-relative: not rooted, not
+  // absolute.
+  PathTestCase(
+    input: "::foo",
+    unix: Expected(
+      anchor: nil, components: ["::foo"],
+      printed: "::foo", isAbsolute: false),
+    windows: Expected(
+      anchor: "::", components: ["foo"],
+      printed: "::foo", isAbsolute: false, driveLetter: ":")
+  ),
+
+  // The non-separator rule extends to device-namespace drives:
+  // "\\.\1:" exposes drive "1" just as "\\.\C:" exposes "C".
+  PathTestCase(
+    input: #"\\.\1:"#,
+    unix: .singleComponent(#"\\.\1:"#),
+    windows: Expected(
+      anchor: #"\\.\1:"#, components: [],
+      printed: #"\\.\1:"#, isAbsolute: true, driveLetter: "1")
+  ),
+
+  // ...and to verbatim drives: "\\?\1:\" exposes drive "1".
+  PathTestCase(
+    input: #"\\?\1:\"#,
+    unix: .singleComponent(#"\\?\1:\"#),
+    windows: Expected(
+      anchor: #"\\?\1:\"#, components: [],
+      printed: #"\\?\1:\"#, isAbsolute: true, driveLetter: "1")
+  ),
+
+  // Verbatim paths take bytes as written: separators are not normalized,
+  // so "/" is a legal (non-separator) drive letter and "\\?\/:" has
+  // drive "/".
+  PathTestCase(
+    input: #"\\?\/:"#,
+    unix: Expected(
+      anchor: nil, components: [#"\\?\"#, ":"],
+      printed: #"\\?\/:"#, isAbsolute: false),
+    windows: Expected(
+      anchor: #"\\?\/:"#, components: [],
+      printed: #"\\?\/:"#, isAbsolute: true, driveLetter: "/")
+  ),
+
+  // MARK: - Trailing sep on deeper paths
+
+  PathTestCase(
+    input: "foo/bar/",
+    unix: Expected(
+      anchor: nil, components: ["foo", "bar"], hasTrailingSeparator: true,
+      printed: "foo/bar/", isAbsolute: false),
+    windows: Expected(
+      anchor: nil, components: ["foo", "bar"], hasTrailingSeparator: true,
+      printed: #"foo\bar\"#, isAbsolute: false)
+  ),
+
+  // MARK: - Windows dotdot/dot + trailing sep
+
+  PathTestCase(
+    input: #"C:\foo\bar\..\"#,
+    unix: .singleComponent(#"C:\foo\bar\..\"#),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar", ".."], hasTrailingSeparator: true,
+      printed: #"C:\foo\bar\..\"#, isAbsolute: true, driveLetter: "C",
+      kinds: [.regular, .regular, .parentDirectory])
+  ),
+
+  // Trailing dot dropped + trailing sep coalesced
+  PathTestCase(
+    input: #"C:\foo\bar\.\"#,
+    unix: .singleComponent(#"C:\foo\bar\.\"#),
+    windows: Expected(
+      anchor: #"C:\"#, components: ["foo", "bar"], hasTrailingSeparator: true,
+      printed: #"C:\foo\bar\"#, isAbsolute: true, driveLetter: "C")
+  ),
+
+  // MARK: - Degenerate Windows UNC / device paths
+  //
+  // These start with `\\` but are incomplete or have doubled separators.
+  // Each is well-defined: the parser pads incomplete UNC forms with a
+  // synthesized backslash and coalesces interior doubled separators.
+
+  PathTestCase(
+    input: #"\\server"#,
+    // Incomplete UNC: server with no share. Padded to `\\server\`.
+    unix: .singleComponent(#"\\server"#),
+    windows: Expected(
+      anchor: #"\\server\"#, components: [],
+      printed: #"\\server\"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: #"\\server\"#,
+    // Server with empty share: same final form as `\\server`.
+    unix: .singleComponent(#"\\server\"#),
+    windows: Expected(
+      anchor: #"\\server\"#, components: [],
+      printed: #"\\server\"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: #"\\"#,
+    // Bare double backslash: padded to a degraded `\\\` root.
+    unix: .singleComponent(#"\\"#),
+    windows: Expected(
+      anchor: #"\\\"#, components: [],
+      printed: #"\\\"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: #"\\server\share\\foo"#,
+    // Doubled separator between share and first component coalesces.
+    unix: .singleComponent(#"\\server\share\\foo"#),
+    windows: Expected(
+      anchor: #"\\server\share"#, components: ["foo"],
+      printed: #"\\server\share\foo"#, isAbsolute: true)
+  ),
+
+  PathTestCase(
+    input: #"\\srv\\share\foo"#,
+    // Doubled separator between server and share coalesces.
+    unix: .singleComponent(#"\\srv\\share\foo"#),
+    windows: Expected(
+      anchor: #"\\srv\share"#, components: ["foo"],
+      printed: #"\\srv\share\foo"#, isAbsolute: true)
+  ),
 ]

--- a/Tests/SystemTests/StdlibFilePathTests/PathTestCases.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/PathTestCases.swift
@@ -1,0 +1,2351 @@
+// PathTestCases.swift
+// Comprehensive test data for _StdlibFilePath parsing across Linux, Darwin, and Windows.
+//
+// Each test case specifies the expected decomposition on all three platforms.
+// Round-trip assertion: construct from input, decompose, reconstruct, check equality.
+//
+// Formatting: decomposition fields (anchor, components, hasTrailingSeparator,
+// isResourceFork) on one line. Derived fields (printed, isAbsolute, isRooted,
+// driveLetter, kinds) on the next.
+
+extension Expected {
+    /// Unix parses a backslash-containing path as a single component
+    /// (backslash is not a separator on Unix).
+    static func singleComponent(
+        _ s: String, hasTrailingSeparator: Bool = false
+    ) -> Expected {
+        Expected(
+            anchor: nil, components: [s],
+            hasTrailingSeparator: hasTrailingSeparator,
+            printed: hasTrailingSeparator ? s + "/" : s,
+            isAbsolute: false)
+    }
+}
+
+let pathTestCases: [PathTestCase] = [
+
+    // MARK: - Empty and trivial
+
+    PathTestCase(
+        input: "",
+        unix: Expected(
+            anchor: nil, components: [],
+            printed: "", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: [],
+            printed: "", isAbsolute: false)
+    ),
+
+    PathTestCase(
+        input: "/",
+        unix: Expected(
+            anchor: "/", components: [],
+            printed: "/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [],
+            printed: #"\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Multiple slashes coalesce on Unix; Windows lowers them through `/`→`\`
+    // conversion and then incomplete-UNC handling.
+
+    PathTestCase(
+        input: "//",
+        unix: Expected(
+            anchor: "/", components: [],
+            printed: "/", isAbsolute: true),
+        windows: Expected(
+            // `//` -> `\\` -> incomplete UNC, padded to `\\\` (degraded root).
+            anchor: #"\\\"#, components: [],
+            printed: #"\\\"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: "///",
+        unix: Expected(
+            anchor: "/", components: [],
+            printed: "/", isAbsolute: true),
+        windows: Expected(
+            // `///` -> `\\\`: 3+ leading backslashes are NOT a UNC/device
+            // path; reduce to a single current-drive root.
+            anchor: #"\"#, components: [],
+            printed: #"\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Basic absolute Unix paths
+
+    PathTestCase(
+        input: "/foo/bar",
+        unix: Expected(
+            anchor: "/", components: ["foo", "bar"],
+            printed: "/foo/bar", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "bar"],
+            printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/foo",
+        unix: Expected(
+            anchor: "/", components: ["foo"],
+            printed: "/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo"],
+            printed: #"\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Basic relative paths (no anchor)
+
+    PathTestCase(
+        input: "foo/bar",
+        unix: Expected(
+            anchor: nil, components: ["foo", "bar"],
+            printed: "foo/bar", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo", "bar"],
+            printed: #"foo\bar"#, isAbsolute: false)
+    ),
+
+    PathTestCase(
+        input: "foo",
+        unix: Expected(
+            anchor: nil, components: ["foo"],
+            printed: "foo", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo"],
+            printed: "foo", isAbsolute: false)
+    ),
+
+    // MARK: - Leading dot
+
+    PathTestCase(
+        input: ".",
+        unix: Expected(
+            anchor: nil, components: ["."],
+            printed: ".", isAbsolute: false, kinds: [.currentDirectory]),
+        windows: Expected(
+            anchor: nil, components: ["."],
+            printed: ".", isAbsolute: false, kinds: [.currentDirectory])
+    ),
+
+    PathTestCase(
+        input: "..",
+        unix: Expected(
+            anchor: nil, components: [".."],
+            printed: "..", isAbsolute: false, kinds: [.parentDirectory]),
+        windows: Expected(
+            anchor: nil, components: [".."],
+            printed: "..", isAbsolute: false, kinds: [.parentDirectory])
+    ),
+
+    PathTestCase(
+        input: "./foo",
+        unix: Expected(
+            anchor: nil, components: [".", "foo"],
+            printed: "./foo", isAbsolute: false, kinds: [.currentDirectory, .regular]),
+        windows: Expected(
+            anchor: nil, components: [".", "foo"],
+            printed: #".\foo"#, isAbsolute: false, kinds: [.currentDirectory, .regular])
+    ),
+
+    PathTestCase(
+        input: "../foo",
+        unix: Expected(
+            anchor: nil, components: ["..", "foo"],
+            printed: "../foo", isAbsolute: false, kinds: [.parentDirectory, .regular]),
+        windows: Expected(
+            anchor: nil, components: ["..", "foo"],
+            printed: #"..\foo"#, isAbsolute: false, kinds: [.parentDirectory, .regular])
+    ),
+
+    // MARK: - Interior dot normalization
+
+    // Dot is first relative component after root: dropped (rooted)
+    PathTestCase(
+        input: "/./foo",
+        unix: Expected(
+            anchor: "/", components: ["foo"],
+            printed: "/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo"],
+            printed: #"\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Absolute interior dot (not first): dropped
+    PathTestCase(
+        input: "/foo/./bar",
+        unix: Expected(
+            anchor: "/", components: ["foo", "bar"],
+            printed: "/foo/bar", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "bar"],
+            printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Relative interior dot (not first): dropped
+    PathTestCase(
+        input: "foo/./bar",
+        unix: Expected(
+            anchor: nil, components: ["foo", "bar"],
+            printed: "foo/bar", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo", "bar"],
+            printed: #"foo\bar"#, isAbsolute: false)
+    ),
+
+    // Trailing dot implies trailing separator
+    PathTestCase(
+        input: "foo/.",
+        unix: Expected(
+            anchor: nil, components: ["foo"], hasTrailingSeparator: true,
+            printed: "foo/", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo"], hasTrailingSeparator: true,
+            printed: #"foo\"#, isAbsolute: false)
+    ),
+
+    // Dot is first relative component after root: dropped (path has root)
+    PathTestCase(
+        input: "/.",
+        unix: Expected(
+            anchor: "/", components: [],
+            printed: "/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [],
+            printed: #"\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Interior dotdot (not lexically normalized, always presented)
+
+    PathTestCase(
+        input: "/foo/../bar",
+        unix: Expected(
+            anchor: "/", components: ["foo", "..", "bar"],
+            printed: "/foo/../bar", isAbsolute: true, kinds: [.regular, .parentDirectory, .regular]),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "..", "bar"],
+            printed: #"\foo\..\bar"#, isAbsolute: false, isRooted: true, kinds: [.regular, .parentDirectory, .regular])
+    ),
+
+    PathTestCase(
+        input: "a/../b",
+        unix: Expected(
+            anchor: nil, components: ["a", "..", "b"],
+            printed: "a/../b", isAbsolute: false, kinds: [.regular, .parentDirectory, .regular]),
+        windows: Expected(
+            anchor: nil, components: ["a", "..", "b"],
+            printed: #"a\..\b"#, isAbsolute: false, kinds: [.regular, .parentDirectory, .regular])
+    ),
+
+    PathTestCase(
+        input: "/a/b/../c",
+        unix: Expected(
+            anchor: "/", components: ["a", "b", "..", "c"],
+            printed: "/a/b/../c", isAbsolute: true, kinds: [.regular, .regular, .parentDirectory, .regular]),
+        windows: Expected(
+            anchor: #"\"#, components: ["a", "b", "..", "c"],
+            printed: #"\a\b\..\c"#, isAbsolute: false, isRooted: true, kinds: [.regular, .regular, .parentDirectory, .regular])
+    ),
+
+    // Trailing dotdot (not dropped, unlike trailing dot)
+    PathTestCase(
+        input: "foo/..",
+        unix: Expected(
+            anchor: nil, components: ["foo", ".."],
+            printed: "foo/..", isAbsolute: false, kinds: [.regular, .parentDirectory]),
+        windows: Expected(
+            anchor: nil, components: ["foo", ".."],
+            printed: #"foo\.."#, isAbsolute: false, kinds: [.regular, .parentDirectory])
+    ),
+
+    PathTestCase(
+        input: "foo/bar/baz/..",
+        unix: Expected(
+            anchor: nil, components: ["foo", "bar", "baz", ".."],
+            printed: "foo/bar/baz/..", isAbsolute: false,
+            kinds: [.regular, .regular, .regular, .parentDirectory]),
+        windows: Expected(
+            anchor: nil, components: ["foo", "bar", "baz", ".."],
+            printed: #"foo\bar\baz\.."#, isAbsolute: false,
+            kinds: [.regular, .regular, .regular, .parentDirectory])
+    ),
+
+    PathTestCase(
+        input: "../..",
+        unix: Expected(
+            anchor: nil, components: ["..", ".."],
+            printed: "../..", isAbsolute: false, kinds: [.parentDirectory, .parentDirectory]),
+        windows: Expected(
+            anchor: nil, components: ["..", ".."],
+            printed: #"..\.."#, isAbsolute: false, kinds: [.parentDirectory, .parentDirectory])
+    ),
+
+    // MARK: - Separator coalescing
+
+    PathTestCase(
+        input: "foo//bar",
+        unix: Expected(
+            anchor: nil, components: ["foo", "bar"],
+            printed: "foo/bar", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo", "bar"],
+            printed: #"foo\bar"#, isAbsolute: false)
+    ),
+
+    PathTestCase(
+        input: "a///b",
+        unix: Expected(
+            anchor: nil, components: ["a", "b"],
+            printed: "a/b", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["a", "b"],
+            printed: #"a\b"#, isAbsolute: false)
+    ),
+
+    // Leading double slash: Linux coalesces, Windows sees UNC
+    PathTestCase(
+        input: "//foo/bar",
+        unix: Expected(
+            anchor: "/", components: ["foo", "bar"],
+            printed: "/foo/bar", isAbsolute: true),
+        // UNC: server=foo, share=bar
+        windows: Expected(
+            anchor: #"\\foo\bar"#, components: [],
+            printed: #"\\foo\bar"#, isAbsolute: true)
+    ),
+    // TODO: verify that Windows does the backslash conversion _before_ checking for short-style UNC prefix
+
+    PathTestCase(
+        input: "///foo///bar",
+        unix: Expected(
+            anchor: "/", components: ["foo", "bar"],
+            printed: "/foo/bar", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "bar"],
+            printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+    // TODO: verify that Windows collapses _after_ checking for short-style UNC prefix
+
+    // MARK: - Trailing separator significance
+
+    PathTestCase(
+        input: "/tmp/foo",
+        unix: Expected(
+            anchor: "/", components: ["tmp", "foo"],
+            printed: "/tmp/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["tmp", "foo"],
+            printed: #"\tmp\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/tmp/foo/",
+        unix: Expected(
+            anchor: "/", components: ["tmp", "foo"], hasTrailingSeparator: true,
+            printed: "/tmp/foo/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["tmp", "foo"], hasTrailingSeparator: true,
+            printed: #"\tmp\foo\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "foo/",
+        unix: Expected(
+            anchor: nil, components: ["foo"], hasTrailingSeparator: true,
+            printed: "foo/", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo"], hasTrailingSeparator: true,
+            printed: #"foo\"#, isAbsolute: false)
+    ),
+
+    PathTestCase(
+        input: "./",
+        unix: Expected(
+            anchor: nil, components: ["."], hasTrailingSeparator: true,
+            printed: "./", isAbsolute: false, kinds: [.currentDirectory]),
+        windows: Expected(
+            anchor: nil, components: ["."], hasTrailingSeparator: true,
+            printed: #".\"#, isAbsolute: false, kinds: [.currentDirectory])
+    ),
+
+    PathTestCase(
+        input: "../",
+        unix: Expected(
+            anchor: nil, components: [".."], hasTrailingSeparator: true,
+            printed: "../", isAbsolute: false, kinds: [.parentDirectory]),
+        windows: Expected(
+            anchor: nil, components: [".."], hasTrailingSeparator: true,
+            printed: #"..\"#, isAbsolute: false, kinds: [.parentDirectory])
+    ),
+
+    // Trailing double sep coalesces to single trailing sep
+    PathTestCase(
+        input: "/foo//",
+        unix: Expected(
+            anchor: "/", components: ["foo"], hasTrailingSeparator: true,
+            printed: "/foo/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo"], hasTrailingSeparator: true,
+            printed: #"\foo\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Single component absolute with trailing sep
+    PathTestCase(
+        input: "/foo/",
+        unix: Expected(
+            anchor: "/", components: ["foo"], hasTrailingSeparator: true,
+            printed: "/foo/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo"], hasTrailingSeparator: true,
+            printed: #"\foo\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - More dot interactions
+
+    // Mixed dots and dotdots (interior dot dropped, dotdot preserved)
+    PathTestCase(
+        input: "/foo/bar/./baz/../qux",
+        unix: Expected(
+            anchor: "/", components: ["foo", "bar", "baz", "..", "qux"],
+            printed: "/foo/bar/baz/../qux", isAbsolute: true,
+            kinds: [.regular, .regular, .regular, .parentDirectory, .regular]),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "bar", "baz", "..", "qux"],
+            printed: #"\foo\bar\baz\..\qux"#, isAbsolute: false, isRooted: true,
+            kinds: [.regular, .regular, .regular, .parentDirectory, .regular])
+    ),
+
+    // Triple dot is a regular name
+    PathTestCase(
+        input: "foo/.../bar",
+        unix: Expected(
+            anchor: nil, components: ["foo", "...", "bar"],
+            printed: "foo/.../bar", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo", "...", "bar"],
+            printed: #"foo\...\bar"#, isAbsolute: false)
+    ),
+
+    // ..bar is a regular name (not parent directory)
+    PathTestCase(
+        input: "foo/..bar/baz",
+        unix: Expected(
+            anchor: nil, components: ["foo", "..bar", "baz"],
+            printed: "foo/..bar/baz", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo", "..bar", "baz"],
+            printed: #"foo\..bar\baz"#, isAbsolute: false)
+    ),
+
+    // Dotdot at root
+    PathTestCase(
+        input: "/..",
+        unix: Expected(
+            anchor: "/", components: [".."],
+            printed: "/..", isAbsolute: true, kinds: [.parentDirectory]),
+        windows: Expected(
+            anchor: #"\"#, components: [".."],
+            printed: #"\.."#, isAbsolute: false, isRooted: true, kinds: [.parentDirectory])
+    ),
+
+    // Dot then dotdot at root: dot dropped (rooted), dotdot presented
+    PathTestCase(
+        input: "/./../foo",
+        unix: Expected(
+            anchor: "/", components: ["..", "foo"],
+            printed: "/../foo", isAbsolute: true,
+            kinds: [.parentDirectory, .regular]),
+        windows: Expected(
+            anchor: #"\"#, components: ["..", "foo"],
+            printed: #"\..\foo"#, isAbsolute: false, isRooted: true,
+            kinds: [.parentDirectory, .regular])
+    ),
+
+    // MARK: - Darwin resolve flags (linux/darwin differ)
+
+    // /.resolve/1/ canonicalizes to /.nofollow/ (flag 1 = NOFOLLOW_ANY)
+    PathTestCase(
+        input: "/.resolve/1/foo/bar",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "1", "foo", "bar"],
+            printed: "/.resolve/1/foo/bar", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/", components: ["foo", "bar"],
+            printed: "/.nofollow/foo/bar", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "1", "foo", "bar"],
+            printed: #"\.resolve\1\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/.nofollow/foo/bar",
+        linux: Expected(
+            anchor: "/", components: [".nofollow", "foo", "bar"],
+            printed: "/.nofollow/foo/bar", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/", components: ["foo", "bar"],
+            printed: "/.nofollow/foo/bar", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".nofollow", "foo", "bar"],
+            printed: #"\.nofollow\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Flag zero: no shorthand
+    PathTestCase(
+        input: "/.resolve/0/foo",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "0", "foo"],
+            printed: "/.resolve/0/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.resolve/0/", components: ["foo"],
+            printed: "/.resolve/0/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "0", "foo"],
+            printed: #"\.resolve\0\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // NODOTDOT: no shorthand
+    PathTestCase(
+        input: "/.resolve/2/foo",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "2", "foo"],
+            printed: "/.resolve/2/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.resolve/2/", components: ["foo"],
+            printed: "/.resolve/2/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "2", "foo"],
+            printed: #"\.resolve\2\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // NOFOLLOW_ANY | NODOTDOT: no shorthand
+    PathTestCase(
+        input: "/.resolve/3/foo/bar",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "3", "foo", "bar"],
+            printed: "/.resolve/3/foo/bar", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.resolve/3/", components: ["foo", "bar"],
+            printed: "/.resolve/3/foo/bar", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "3", "foo", "bar"],
+            printed: #"\.resolve\3\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Large flag value, multi-digit
+    PathTestCase(
+        input: "/.resolve/127/a/b",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "127", "a", "b"],
+            printed: "/.resolve/127/a/b", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.resolve/127/", components: ["a", "b"],
+            printed: "/.resolve/127/a/b", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "127", "a", "b"],
+            printed: #"\.resolve\127\a\b"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Very large number, tests multi-digit decimal parsing
+    PathTestCase(
+        input: "/.resolve/999999/foo",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "999999", "foo"],
+            printed: "/.resolve/999999/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.resolve/999999/", components: ["foo"],
+            printed: "/.resolve/999999/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "999999", "foo"],
+            printed: #"\.resolve\999999\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Without trailing slash: NOT a resolve prefix, regular component
+    PathTestCase(
+        input: "/.nofollow",
+        unix: Expected(
+            anchor: "/", components: [".nofollow"],
+            printed: "/.nofollow", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".nofollow"],
+            printed: #"\.nofollow"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Without trailing slash on resolve: NOT a prefix, regular components
+    PathTestCase(
+        input: "/.resolve/0",
+        unix: Expected(
+            anchor: "/", components: [".resolve", "0"],
+            printed: "/.resolve/0", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "0"],
+            printed: #"\.resolve\0"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Non-numeric flags: still a resolve prefix (field is opaque)
+    PathTestCase(
+        input: "/.resolve/abc/foo",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "abc", "foo"],
+            printed: "/.resolve/abc/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.resolve/abc/", components: ["foo"],
+            printed: "/.resolve/abc/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "abc", "foo"],
+            printed: #"\.resolve\abc\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Leading zero: field is opaque, "01" != "1", no canonicalization
+    PathTestCase(
+        input: "/.resolve/01/foo",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "01", "foo"],
+            printed: "/.resolve/01/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.resolve/01/", components: ["foo"],
+            printed: "/.resolve/01/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "01", "foo"],
+            printed: #"\.resolve\01\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Negative-looking flag: field is opaque, still a prefix
+    PathTestCase(
+        input: "/.resolve/-1/foo",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "-1", "foo"],
+            printed: "/.resolve/-1/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.resolve/-1/", components: ["foo"],
+            printed: "/.resolve/-1/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "-1", "foo"],
+            printed: #"\.resolve\-1\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Wrong case on "resolve" keyword: not a prefix
+    PathTestCase(
+        input: "/.Resolve/0/foo",
+        unix: Expected(
+            anchor: "/", components: [".Resolve", "0", "foo"],
+            printed: "/.Resolve/0/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".Resolve", "0", "foo"],
+            printed: #"\.Resolve\0\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Starts with /. but matches no keyword: regular path
+    PathTestCase(
+        input: "/.hidden/foo",
+        unix: Expected(
+            anchor: "/", components: [".hidden", "foo"],
+            printed: "/.hidden/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".hidden", "foo"],
+            printed: #"\.hidden\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Darwin .vol paths (linux/darwin differ)
+
+    PathTestCase(
+        input: "/.vol/1234/5678",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "5678"],
+            printed: "/.vol/1234/5678", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/5678", components: [],
+            printed: "/.vol/1234/5678", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "5678"],
+            printed: #"\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/.vol/1234/5678/",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "5678"], hasTrailingSeparator: true,
+            printed: "/.vol/1234/5678/", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/5678", components: [], hasTrailingSeparator: true,
+            printed: "/.vol/1234/5678/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "5678"], hasTrailingSeparator: true,
+            printed: #"\.vol\1234\5678\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/.vol/1234/5678/foo/bar",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "5678", "foo", "bar"],
+            printed: "/.vol/1234/5678/foo/bar", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/5678", components: ["foo", "bar"],
+            printed: "/.vol/1234/5678/foo/bar", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "5678", "foo", "bar"],
+            printed: #"\.vol\1234\5678\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Fileid "2" canonicalizes to "@"
+    PathTestCase(
+        input: "/.vol/1234/2",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "2"],
+            printed: "/.vol/1234/2", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/@", components: [],
+            printed: "/.vol/1234/@", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "2"],
+            printed: #"\.vol\1234\2"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/.vol/1234/2/foo/bar",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "2", "foo", "bar"],
+            printed: "/.vol/1234/2/foo/bar", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/@", components: ["foo", "bar"],
+            printed: "/.vol/1234/@/foo/bar", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "2", "foo", "bar"],
+            printed: #"\.vol\1234\2\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // "@" already canonical: round-trips
+    PathTestCase(
+        input: "/.vol/1234/@",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "@"],
+            printed: "/.vol/1234/@", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/@", components: [],
+            printed: "/.vol/1234/@", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "@"],
+            printed: #"\.vol\1234\@"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/.vol/1234/@/",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "@"], hasTrailingSeparator: true,
+            printed: "/.vol/1234/@/", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/@", components: [], hasTrailingSeparator: true,
+            printed: "/.vol/1234/@/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "@"], hasTrailingSeparator: true,
+            printed: #"\.vol\1234\@\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/.vol/1234/@/foo",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "@", "foo"],
+            printed: "/.vol/1234/@/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/@", components: ["foo"],
+            printed: "/.vol/1234/@/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "@", "foo"],
+            printed: #"\.vol\1234\@\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Darwin combined anchors (resolve flag + volume identifier)
+    //
+    // Per proposal line 111: an anchor may include resolve flags AND/OR
+    // a volume identifier; resolve always precedes vol. The combined form
+    // `[/.nofollow/ | /.resolve/N/].vol/FSID/FILEID` is a single anchor.
+    // Both canonicalizations (`/.resolve/1/` -> `/.nofollow/`, `2` -> `@`)
+    // can fire on the same input.
+
+    // Combined nofollow + vol, no canonicalization.
+    PathTestCase(
+        input: "/.nofollow/.vol/1234/5678",
+        linux: Expected(
+            anchor: "/", components: [".nofollow", ".vol", "1234", "5678"],
+            printed: "/.nofollow/.vol/1234/5678", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/.vol/1234/5678", components: [],
+            printed: "/.nofollow/.vol/1234/5678", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".nofollow", ".vol", "1234", "5678"],
+            printed: #"\.nofollow\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Combined nofollow + vol with relative content.
+    PathTestCase(
+        input: "/.nofollow/.vol/1234/5678/foo",
+        linux: Expected(
+            anchor: "/", components: [".nofollow", ".vol", "1234", "5678", "foo"],
+            printed: "/.nofollow/.vol/1234/5678/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/.vol/1234/5678", components: ["foo"],
+            printed: "/.nofollow/.vol/1234/5678/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".nofollow", ".vol", "1234", "5678", "foo"],
+            printed: #"\.nofollow\.vol\1234\5678\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Combined nofollow + vol with FILEID canonicalization (`2` -> `@`).
+    PathTestCase(
+        input: "/.nofollow/.vol/1234/2",
+        linux: Expected(
+            anchor: "/", components: [".nofollow", ".vol", "1234", "2"],
+            printed: "/.nofollow/.vol/1234/2", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/.vol/1234/@", components: [],
+            printed: "/.nofollow/.vol/1234/@", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".nofollow", ".vol", "1234", "2"],
+            printed: #"\.nofollow\.vol\1234\2"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Combined nofollow + vol, FILEID canonicalization, with relative + trailing.
+    PathTestCase(
+        input: "/.nofollow/.vol/1234/2/foo/",
+        linux: Expected(
+            anchor: "/", components: [".nofollow", ".vol", "1234", "2", "foo"],
+            hasTrailingSeparator: true,
+            printed: "/.nofollow/.vol/1234/2/foo/", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/.vol/1234/@", components: ["foo"],
+            hasTrailingSeparator: true,
+            printed: "/.nofollow/.vol/1234/@/foo/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".nofollow", ".vol", "1234", "2", "foo"],
+            hasTrailingSeparator: true,
+            printed: #"\.nofollow\.vol\1234\2\foo\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Combined resolve/N + vol (non-canonicalizing flag value).
+    PathTestCase(
+        input: "/.resolve/3/.vol/1234/5678",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "3", ".vol", "1234", "5678"],
+            printed: "/.resolve/3/.vol/1234/5678", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.resolve/3/.vol/1234/5678", components: [],
+            printed: "/.resolve/3/.vol/1234/5678", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "3", ".vol", "1234", "5678"],
+            printed: #"\.resolve\3\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Combined resolve/3 + vol with FILEID canon — only the FILEID rule
+    // fires; `.resolve/3/` is preserved as written.
+    PathTestCase(
+        input: "/.resolve/3/.vol/1234/2/",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "3", ".vol", "1234", "2"],
+            hasTrailingSeparator: true,
+            printed: "/.resolve/3/.vol/1234/2/", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.resolve/3/.vol/1234/@", components: [],
+            hasTrailingSeparator: true,
+            printed: "/.resolve/3/.vol/1234/@/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "3", ".vol", "1234", "2"],
+            hasTrailingSeparator: true,
+            printed: #"\.resolve\3\.vol\1234\2\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Combined resolve/1 + vol — BOTH canonicalizations fire:
+    // `/.resolve/1/` -> `/.nofollow/` AND FILEID `2` -> `@`.
+    PathTestCase(
+        input: "/.resolve/1/.vol/1234/2/",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "1", ".vol", "1234", "2"],
+            hasTrailingSeparator: true,
+            printed: "/.resolve/1/.vol/1234/2/", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/.vol/1234/@", components: [],
+            hasTrailingSeparator: true,
+            printed: "/.nofollow/.vol/1234/@/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "1", ".vol", "1234", "2"],
+            hasTrailingSeparator: true,
+            printed: #"\.resolve\1\.vol\1234\2\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Combined resolve/1 + vol with relative content — both canons + relative.
+    PathTestCase(
+        input: "/.resolve/1/.vol/1234/2/foo/bar",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "1", ".vol", "1234", "2", "foo", "bar"],
+            printed: "/.resolve/1/.vol/1234/2/foo/bar", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/.vol/1234/@", components: ["foo", "bar"],
+            printed: "/.nofollow/.vol/1234/@/foo/bar", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "1", ".vol", "1234", "2", "foo", "bar"],
+            printed: #"\.resolve\1\.vol\1234\2\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Darwin resource forks (linux/darwin differ)
+
+    PathTestCase(
+        input: "/foo/..namedfork/rsrc",
+        linux: Expected(
+            anchor: "/", components: ["foo", "..namedfork", "rsrc"],
+            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/", components: ["foo"], isResourceFork: true,
+            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"],
+            printed: #"\foo\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Trailing slash breaks resource fork recognition
+    PathTestCase(
+        input: "/foo/..namedfork/rsrc/",
+        unix: Expected(
+            anchor: "/", components: ["foo", "..namedfork", "rsrc"], hasTrailingSeparator: true,
+            printed: "/foo/..namedfork/rsrc/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"], hasTrailingSeparator: true,
+            printed: #"\foo\..namedfork\rsrc\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Resource fork on relative path
+    PathTestCase(
+        input: "foo/..namedfork/rsrc",
+        linux: Expected(
+            anchor: nil, components: ["foo", "..namedfork", "rsrc"],
+            printed: "foo/..namedfork/rsrc", isAbsolute: false),
+        darwin: Expected(
+            anchor: nil, components: ["foo"], isResourceFork: true,
+            printed: "foo/..namedfork/rsrc", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo", "..namedfork", "rsrc"],
+            printed: #"foo\..namedfork\rsrc"#, isAbsolute: false)
+    ),
+
+    // Resource fork on root-only path (semantically invalid, syntactically recognized)
+    PathTestCase(
+        input: "/..namedfork/rsrc",
+        linux: Expected(
+            anchor: "/", components: ["..namedfork", "rsrc"],
+            printed: "/..namedfork/rsrc", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/", components: [], isResourceFork: true,
+            printed: "/..namedfork/rsrc", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["..namedfork", "rsrc"],
+            printed: #"\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Windows drive absolute
+
+    PathTestCase(
+        input: #"C:\foo\bar"#,
+        // Backslash is a legal filename char on Unix: single component
+        unix: .singleComponent(#"C:\foo\bar"#),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar"],
+            printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"C:\"#,
+        unix: .singleComponent(#"C:\"#),
+        windows: Expected(
+            anchor: #"C:\"#, components: [],
+            printed: #"C:\"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"c:\foo"#,
+        unix: .singleComponent(#"c:\foo"#),
+        windows: Expected(
+            anchor: #"c:\"#, components: ["foo"],
+            printed: #"c:\foo"#, isAbsolute: true, driveLetter: "c")
+    ),
+
+    // Interior dot dropped
+    PathTestCase(
+        input: #"C:\foo\.\bar"#,
+        unix: .singleComponent(#"C:\foo\.\bar"#),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar"],
+            printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // Interior dotdot presented, not collapsed
+    PathTestCase(
+        input: #"C:\foo\..\bar"#,
+        unix: .singleComponent(#"C:\foo\..\bar"#),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "..", "bar"],
+            printed: #"C:\foo\..\bar"#, isAbsolute: true, driveLetter: "C",
+            kinds: [.regular, .parentDirectory, .regular])
+    ),
+
+    PathTestCase(
+        input: #"C:\foo\"#,
+        unix: .singleComponent(#"C:\foo\"#),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo"], hasTrailingSeparator: true,
+            printed: #"C:\foo\"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // MARK: - Windows drive relative
+
+    PathTestCase(
+        input: "C:foo",
+        unix: Expected(
+            anchor: nil, components: ["C:foo"],
+            printed: "C:foo", isAbsolute: false),
+        windows: Expected(
+            anchor: "C:", components: ["foo"],
+            printed: "C:foo", isAbsolute: false, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: "C:",
+        unix: Expected(
+            anchor: nil, components: ["C:"],
+            printed: "C:", isAbsolute: false),
+        windows: Expected(
+            anchor: "C:", components: [],
+            printed: "C:", isAbsolute: false, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"C:foo\"#,
+        unix: .singleComponent(#"C:foo\"#),
+        windows: Expected(
+            anchor: "C:", components: ["foo"], hasTrailingSeparator: true,
+            printed: #"C:foo\"#, isAbsolute: false, driveLetter: "C")
+    ),
+
+    // MARK: - Windows rooted-not-absolute
+
+    PathTestCase(
+        input: #"\foo"#,
+        unix: .singleComponent(#"\foo"#),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo"],
+            printed: #"\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: #"\foo\bar"#,
+        unix: .singleComponent(#"\foo\bar"#),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "bar"],
+            printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: #"\"#,
+        unix: .singleComponent(#"\"#),
+        windows: Expected(
+            anchor: #"\"#, components: [],
+            printed: #"\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Windows UNC
+
+    PathTestCase(
+        input: #"\\server\share\foo"#,
+        unix: .singleComponent(#"\\server\share\foo"#),
+        windows: Expected(
+            anchor: #"\\server\share"#, components: ["foo"],
+            printed: #"\\server\share\foo"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: #"\\server\share\"#,
+        unix: .singleComponent(#"\\server\share\"#),
+        windows: Expected(
+            anchor: #"\\server\share"#, components: [], hasTrailingSeparator: true,
+            printed: #"\\server\share\"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: #"\\server\share"#,
+        unix: .singleComponent(#"\\server\share"#),
+        windows: Expected(
+            anchor: #"\\server\share"#, components: [],
+            printed: #"\\server\share"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: #"\\server\share\foo\bar\"#,
+        unix: .singleComponent(#"\\server\share\foo\bar\"#),
+        windows: Expected(
+            anchor: #"\\server\share"#, components: ["foo", "bar"], hasTrailingSeparator: true,
+            printed: #"\\server\share\foo\bar\"#, isAbsolute: true)
+    ),
+
+    // MARK: - Windows device paths (\\.\)
+
+    // Bare device prefix: anchor only
+    PathTestCase(
+        input: #"\\.\"#,
+        unix: .singleComponent(#"\\.\"#),
+        windows: Expected(
+            anchor: #"\\.\"#, components: [],
+            printed: #"\\.\"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: #"\\.\C:\foo"#,
+        unix: .singleComponent(#"\\.\C:\foo"#),
+        windows: Expected(
+            anchor: #"\\.\C:\"#, components: ["foo"],
+            printed: #"\\.\C:\foo"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"\\.\pipe\name"#,
+        unix: .singleComponent(#"\\.\pipe\name"#),
+        windows: Expected(
+            anchor: #"\\.\pipe"#, components: ["name"],
+            printed: #"\\.\pipe\name"#, isAbsolute: true)
+    ),
+
+    // Pipe device with trailing sep, no pipe name
+    PathTestCase(
+        input: #"\\.\pipe\"#,
+        unix: .singleComponent(#"\\.\pipe\"#),
+        windows: Expected(
+            anchor: #"\\.\pipe"#, components: [], hasTrailingSeparator: true,
+            printed: #"\\.\pipe\"#, isAbsolute: true)
+    ),
+
+    // Device drive without root separator
+    PathTestCase(
+        input: #"\\.\C:"#,
+        unix: .singleComponent(#"\\.\C:"#),
+        windows: Expected(
+            anchor: #"\\.\C:"#, components: [],
+            printed: #"\\.\C:"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // Dot IS dropped on non-verbatim device paths
+    PathTestCase(
+        input: #"\\.\C:\foo\.\bar"#,
+        unix: .singleComponent(#"\\.\C:\foo\.\bar"#),
+        windows: Expected(
+            anchor: #"\\.\C:\"#, components: ["foo", "bar"],
+            printed: #"\\.\C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // MARK: - Windows verbatim paths (\\?\)
+
+    // Bare verbatim prefix: anchor only
+    PathTestCase(
+        input: #"\\?\"#,
+        unix: .singleComponent(#"\\?\"#),
+        windows: Expected(
+            anchor: #"\\?\"#, components: [],
+            printed: #"\\?\"#, isAbsolute: true)
+    ),
+
+    // Verbatim drive without root separator
+    PathTestCase(
+        input: #"\\?\C:"#,
+        unix: .singleComponent(#"\\?\C:"#),
+        windows: Expected(
+            anchor: #"\\?\C:"#, components: [],
+            printed: #"\\?\C:"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // Dot NOT dropped in verbatim: treated as regular component
+    PathTestCase(
+        input: #"\\?\C:\foo\.\bar"#,
+        unix: .singleComponent(#"\\?\C:\foo\.\bar"#),
+        windows: Expected(
+            anchor: #"\\?\C:\"#, components: ["foo", ".", "bar"],
+            printed: #"\\?\C:\foo\.\bar"#, isAbsolute: true, driveLetter: "C",
+            kinds: [.regular, .regular, .regular])
+    ),
+
+    // Dotdot NOT special in verbatim: treated as regular component
+    PathTestCase(
+        input: #"\\?\C:\foo\..\bar"#,
+        unix: .singleComponent(#"\\?\C:\foo\..\bar"#),
+        windows: Expected(
+            anchor: #"\\?\C:\"#, components: ["foo", "..", "bar"],
+            printed: #"\\?\C:\foo\..\bar"#, isAbsolute: true, driveLetter: "C",
+            kinds: [.regular, .regular, .regular])
+    ),
+
+    PathTestCase(
+        input: #"\\?\UNC\server\share\foo"#,
+        unix: .singleComponent(#"\\?\UNC\server\share\foo"#),
+        windows: Expected(
+            anchor: #"\\?\UNC\server\share"#, components: ["foo"],
+            printed: #"\\?\UNC\server\share\foo"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: #"\\?\C:\"#,
+        unix: .singleComponent(#"\\?\C:\"#),
+        windows: Expected(
+            anchor: #"\\?\C:\"#, components: [],
+            printed: #"\\?\C:\"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"\\?\C:\foo\"#,
+        unix: .singleComponent(#"\\?\C:\foo\"#),
+        windows: Expected(
+            anchor: #"\\?\C:\"#, components: ["foo"], hasTrailingSeparator: true,
+            printed: #"\\?\C:\foo\"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // Separator coalescing still happens in verbatim (verbatim only affects dot/dotdot)
+    PathTestCase(
+        input: #"\\?\C:\foo\\bar"#,
+        unix: .singleComponent(#"\\?\C:\foo\\bar"#),
+        windows: Expected(
+            anchor: #"\\?\C:\"#, components: ["foo", "bar"],
+            printed: #"\\?\C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // MARK: - Forward slashes inside verbatim component content
+
+    // / inside verbatim component is a legal filename character, not a separator
+    PathTestCase(
+        input: #"\\?\C:\foo/bar"#,
+        unix: Expected(
+            anchor: nil, components: [#"\\?\C:\foo"#, "bar"],
+            printed: #"\\?\C:\foo/bar"#, isAbsolute: false),
+        windows: Expected(
+            anchor: #"\\?\C:\"#, components: ["foo/bar"],
+            printed: #"\\?\C:\foo/bar"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"\\?\C:\a/b/c"#,
+        unix: Expected(
+            anchor: nil, components: [#"\\?\C:\a"#, "b", "c"],
+            printed: #"\\?\C:\a/b/c"#, isAbsolute: false),
+        windows: Expected(
+            anchor: #"\\?\C:\"#, components: ["a/b/c"],
+            printed: #"\\?\C:\a/b/c"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"\\?\UNC\s\sh\a/b"#,
+        unix: Expected(
+            anchor: nil, components: [#"\\?\UNC\s\sh\a"#, "b"],
+            printed: #"\\?\UNC\s\sh\a/b"#, isAbsolute: false),
+        windows: Expected(
+            anchor: #"\\?\UNC\s\sh"#, components: ["a/b"],
+            printed: #"\\?\UNC\s\sh\a/b"#, isAbsolute: true)
+    ),
+
+    // //?/ is NOT verbatim — it's device-namespace (same as //./). All / converted.
+    PathTestCase(
+        input: "//?/C:/a/b",
+        unix: Expected(
+            anchor: "/", components: ["?", "C:", "a", "b"],
+            printed: "/?/C:/a/b", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\\.\C:\"#, components: ["a", "b"],
+            printed: #"\\.\C:\a\b"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // Non-verbatim device path: all / converted (regression check)
+    PathTestCase(
+        input: "//./C:/a/b",
+        unix: Expected(
+            anchor: "/", components: ["C:", "a", "b"],
+            printed: "/C:/a/b", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\\.\C:\"#, components: ["a", "b"],
+            printed: #"\\.\C:\a\b"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // MARK: - Windows forward slash normalization
+
+    // Triple slash: coalesces on both, rooted on Windows
+    PathTestCase(
+        input: "///foo/bar",
+        unix: Expected(
+            anchor: "/", components: ["foo", "bar"],
+            printed: "/foo/bar", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "bar"],
+            printed: #"\foo\bar"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // //./foo on Unix: dot dropped (rooted), "foo" is a regular component
+    // //./foo on Windows: device-namespace prefix, "foo" is device name
+    PathTestCase(
+        input: "//./foo",
+        unix: Expected(
+            anchor: "/", components: ["foo"],
+            printed: "/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\\.\foo"#, components: [],
+            printed: #"\\.\foo"#, isAbsolute: true)
+    ),
+
+    // //?/foo on Unix: regular components
+    // //?/foo on Windows: device-namespace (not verbatim), "foo" is device name
+    PathTestCase(
+        input: "//?/foo",
+        unix: Expected(
+            anchor: "/", components: ["?", "foo"],
+            printed: "/?/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\\.\foo"#, components: [],
+            printed: #"\\.\foo"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: "C:/foo/bar",
+        // Unix: "C:" is a component (colon is legal), "/" is separator
+        unix: Expected(
+            anchor: nil, components: ["C:", "foo", "bar"],
+            printed: "C:/foo/bar", isAbsolute: false),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar"],
+            printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: "C:/",
+        unix: Expected(
+            anchor: nil, components: ["C:"], hasTrailingSeparator: true,
+            printed: "C:/", isAbsolute: false),
+        windows: Expected(
+            anchor: #"C:\"#, components: [],
+            printed: #"C:\"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: "//server/share/foo",
+        unix: Expected(
+            anchor: "/", components: ["server", "share", "foo"],
+            printed: "/server/share/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\\server\share"#, components: ["foo"],
+            printed: #"\\server\share\foo"#, isAbsolute: true)
+    ),
+
+    // Dot dropped (rooted) on Unix, device-namespace on Windows
+    PathTestCase(
+        input: "//./C:/foo",
+        unix: Expected(
+            anchor: "/", components: ["C:", "foo"],
+            printed: "/C:/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\\.\C:\"#, components: ["foo"],
+            printed: #"\\.\C:\foo"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: "//?/C:/foo",
+        unix: Expected(
+            anchor: "/", components: ["?", "C:", "foo"],
+            printed: "/?/C:/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\\.\C:\"#, components: ["foo"],
+            printed: #"\\.\C:\foo"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // MARK: - Cross-platform mismatch
+
+    // Backslash is a legal filename char on Unix
+    PathTestCase(
+        input: #"foo\bar"#,
+        unix: .singleComponent(#"foo\bar"#),
+        windows: Expected(
+            anchor: nil, components: ["foo", "bar"],
+            printed: #"foo\bar"#, isAbsolute: false)
+    ),
+
+    // Dot-backslash: Unix sees single component, Windows sees dot + sep + component
+    PathTestCase(
+        input: #".\foo"#,
+        unix: .singleComponent(#".\foo"#),
+        windows: Expected(
+            anchor: nil, components: [".", "foo"],
+            printed: #".\foo"#, isAbsolute: false, kinds: [.currentDirectory, .regular])
+    ),
+
+    // Colon in component: legal on Unix, possible ADS marker on Windows
+    PathTestCase(
+        input: "foo:bar",
+        unix: Expected(
+            anchor: nil, components: ["foo:bar"],
+            printed: "foo:bar", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo:bar"],
+            printed: "foo:bar", isAbsolute: false)
+    ),
+
+    // Deeper relative with only backslashes
+    PathTestCase(
+        input: #"foo\bar\baz"#,
+        unix: .singleComponent(#"foo\bar\baz"#),
+        windows: Expected(
+            anchor: nil, components: ["foo", "bar", "baz"],
+            printed: #"foo\bar\baz"#, isAbsolute: false)
+    ),
+
+    // Multi-char before colon: not a drive letter
+    PathTestCase(
+        input: #"CC:\foo"#,
+        unix: .singleComponent(#"CC:\foo"#),
+        windows: Expected(
+            anchor: nil, components: ["CC:", "foo"],
+            printed: #"CC:\foo"#, isAbsolute: false)
+    ),
+
+    // MARK: - Mixed separators on Windows-style paths
+
+    // Forward slash splits on Unix (two components), both seps normalize on Windows
+    PathTestCase(
+        input: #"C:\foo/bar"#,
+        unix: Expected(
+            anchor: nil, components: [#"C:\foo"#, "bar"],
+            printed: #"C:\foo/bar"#, isAbsolute: false),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar"],
+            printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"C:\foo\bar/baz"#,
+        unix: Expected(
+            anchor: nil, components: [#"C:\foo\bar"#, "baz"],
+            printed: #"C:\foo\bar/baz"#, isAbsolute: false),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar", "baz"],
+            printed: #"C:\foo\bar\baz"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // UNC server\share then forward slash: Unix splits at /
+    PathTestCase(
+        input: #"\\server\share/foo"#,
+        unix: Expected(
+            anchor: nil, components: [#"\\server\share"#, "foo"],
+            printed: #"\\server\share/foo"#, isAbsolute: false),
+        windows: Expected(
+            anchor: #"\\server\share"#, components: ["foo"],
+            printed: #"\\server\share\foo"#, isAbsolute: true)
+    ),
+
+    // MARK: - Trailing forward slash on backslash paths
+
+    // Unix: forward slash IS a separator, splits the backslash-blob from trailing sep
+    PathTestCase(
+        input: #"C:\foo/"#,
+        unix: .singleComponent(#"C:\foo"#, hasTrailingSeparator: true),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo"], hasTrailingSeparator: true,
+            printed: #"C:\foo\"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"C:\foo\bar/"#,
+        unix: .singleComponent(#"C:\foo\bar"#, hasTrailingSeparator: true),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar"], hasTrailingSeparator: true,
+            printed: #"C:\foo\bar\"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"\\server\share/"#,
+        unix: .singleComponent(#"\\server\share"#, hasTrailingSeparator: true),
+        windows: Expected(
+            anchor: #"\\server\share"#, components: [], hasTrailingSeparator: true,
+            printed: #"\\server\share\"#, isAbsolute: true)
+    ),
+
+    // MARK: - Unicode in components
+
+    PathTestCase(
+        input: "/あ/🧟‍♀️",
+        unix: Expected(
+            anchor: "/", components: ["あ", "🧟‍♀️"],
+            printed: "/あ/🧟‍♀️", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["あ", "🧟‍♀️"],
+            printed: #"\あ\🧟‍♀️"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Additional dot/dotdot patterns
+
+    PathTestCase(
+        input: "./foo/bar",
+        unix: Expected(
+            anchor: nil, components: [".", "foo", "bar"],
+            printed: "./foo/bar", isAbsolute: false, kinds: [.currentDirectory, .regular, .regular]),
+        windows: Expected(
+            anchor: nil, components: [".", "foo", "bar"],
+            printed: #".\foo\bar"#, isAbsolute: false, kinds: [.currentDirectory, .regular, .regular])
+    ),
+
+    // Dot then double slash: coalesced, dot preserved as first
+    PathTestCase(
+        input: ".//foo",
+        unix: Expected(
+            anchor: nil, components: [".", "foo"],
+            printed: "./foo", isAbsolute: false, kinds: [.currentDirectory, .regular]),
+        windows: Expected(
+            anchor: nil, components: [".", "foo"],
+            printed: #".\foo"#, isAbsolute: false, kinds: [.currentDirectory, .regular])
+    ),
+
+    PathTestCase(
+        input: "foo/../../bar",
+        unix: Expected(
+            anchor: nil, components: ["foo", "..", "..", "bar"],
+            printed: "foo/../../bar", isAbsolute: false,
+            kinds: [.regular, .parentDirectory, .parentDirectory, .regular]),
+        windows: Expected(
+            anchor: nil, components: ["foo", "..", "..", "bar"],
+            printed: #"foo\..\..\bar"#, isAbsolute: false,
+            kinds: [.regular, .parentDirectory, .parentDirectory, .regular])
+    ),
+
+    PathTestCase(
+        input: "foo/../bar/../baz",
+        unix: Expected(
+            anchor: nil, components: ["foo", "..", "bar", "..", "baz"],
+            printed: "foo/../bar/../baz", isAbsolute: false,
+            kinds: [.regular, .parentDirectory, .regular, .parentDirectory, .regular]),
+        windows: Expected(
+            anchor: nil, components: ["foo", "..", "bar", "..", "baz"],
+            printed: #"foo\..\bar\..\baz"#, isAbsolute: false,
+            kinds: [.regular, .parentDirectory, .regular, .parentDirectory, .regular])
+    ),
+
+    PathTestCase(
+        input: "/foo//bar//baz",
+        unix: Expected(
+            anchor: "/", components: ["foo", "bar", "baz"],
+            printed: "/foo/bar/baz", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "bar", "baz"],
+            printed: #"\foo\bar\baz"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - More Windows edge cases
+
+    PathTestCase(
+        input: #"C:\.."#,
+        unix: .singleComponent(#"C:\.."#),
+        windows: Expected(
+            anchor: #"C:\"#, components: [".."],
+            printed: #"C:\.."#, isAbsolute: true, driveLetter: "C",
+            kinds: [.parentDirectory])
+    ),
+
+    // Double sep after drive root: coalesced
+    PathTestCase(
+        input: #"C:\\foo"#,
+        unix: .singleComponent(#"C:\\foo"#),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo"],
+            printed: #"C:\foo"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // Trailing dot dropped, becomes trailing sep
+    PathTestCase(
+        input: #"C:\foo\bar\."#,
+        unix: .singleComponent(#"C:\foo\bar\."#),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar"], hasTrailingSeparator: true,
+            printed: #"C:\foo\bar\"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    PathTestCase(
+        input: #"C:\foo\bar\.."#,
+        unix: .singleComponent(#"C:\foo\bar\.."#),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar", ".."],
+            printed: #"C:\foo\bar\.."#, isAbsolute: true, driveLetter: "C",
+            kinds: [.regular, .regular, .parentDirectory])
+    ),
+
+    PathTestCase(
+        input: #"\\server\share\..\foo"#,
+        unix: .singleComponent(#"\\server\share\..\foo"#),
+        windows: Expected(
+            anchor: #"\\server\share"#, components: ["..", "foo"],
+            printed: #"\\server\share\..\foo"#, isAbsolute: true,
+            kinds: [.parentDirectory, .regular])
+    ),
+
+    // Mixed separators: "/" is sep on Unix, both "/" and "\" are on Windows
+    PathTestCase(
+        input: #"C:/foo\bar"#,
+        unix: Expected(
+            anchor: nil, components: ["C:", #"foo\bar"#],
+            printed: #"C:/foo\bar"#, isAbsolute: false),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar"],
+            printed: #"C:\foo\bar"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // MARK: - Verbatim dot/dotdot at end
+
+    // In verbatim context, trailing dot is a regular component, NOT dropped
+    PathTestCase(
+        input: #"\\?\C:\foo\bar\."#,
+        unix: .singleComponent(#"\\?\C:\foo\bar\."#),
+        windows: Expected(
+            anchor: #"\\?\C:\"#, components: ["foo", "bar", "."],
+            printed: #"\\?\C:\foo\bar\."#, isAbsolute: true, driveLetter: "C",
+            kinds: [.regular, .regular, .regular])
+    ),
+
+    PathTestCase(
+        input: #"\\?\C:\foo\bar\.."#,
+        unix: .singleComponent(#"\\?\C:\foo\bar\.."#),
+        windows: Expected(
+            anchor: #"\\?\C:\"#, components: ["foo", "bar", ".."],
+            printed: #"\\?\C:\foo\bar\.."#, isAbsolute: true, driveLetter: "C",
+            kinds: [.regular, .regular, .regular])
+    ),
+
+    PathTestCase(
+        input: #"\\?\UNC\server\share\..\foo"#,
+        unix: .singleComponent(#"\\?\UNC\server\share\..\foo"#),
+        windows: Expected(
+            anchor: #"\\?\UNC\server\share"#, components: ["..", "foo"],
+            printed: #"\\?\UNC\server\share\..\foo"#, isAbsolute: true,
+            kinds: [.regular, .regular])
+    ),
+
+    // MARK: - Resolve prefix edge cases
+
+    // Prefix recognized with no components
+    PathTestCase(
+        input: "/.nofollow/",
+        linux: Expected(
+            anchor: "/", components: [".nofollow"], hasTrailingSeparator: true,
+            printed: "/.nofollow/", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/", components: [],
+            printed: "/.nofollow/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".nofollow"], hasTrailingSeparator: true,
+            printed: #"\.nofollow\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Prefix requires absolute path: not recognized on relative
+    PathTestCase(
+        input: "foo/.nofollow/bar",
+        unix: Expected(
+            anchor: nil, components: ["foo", ".nofollow", "bar"],
+            printed: "foo/.nofollow/bar", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo", ".nofollow", "bar"],
+            printed: #"foo\.nofollow\bar"#, isAbsolute: false)
+    ),
+
+    // Near-miss: wrong case
+    PathTestCase(
+        input: "/.NOFOLLOW/foo",
+        unix: Expected(
+            anchor: "/", components: [".NOFOLLOW", "foo"],
+            printed: "/.NOFOLLOW/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".NOFOLLOW", "foo"],
+            printed: #"\.NOFOLLOW\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Near-miss: extra char
+    PathTestCase(
+        input: "/.nofollowx/foo",
+        unix: Expected(
+            anchor: "/", components: [".nofollowx", "foo"],
+            printed: "/.nofollowx/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".nofollowx", "foo"],
+            printed: #"\.nofollowx\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - .vol degenerate cases
+
+    // Fewer than two components after .vol: not recognized as volfs
+    PathTestCase(
+        input: "/.vol",
+        unix: Expected(
+            anchor: "/", components: [".vol"],
+            printed: "/.vol", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol"],
+            printed: #"\.vol"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/.vol/",
+        linux: Expected(
+            anchor: "/", components: [".vol"], hasTrailingSeparator: true,
+            printed: "/.vol/", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/", components: [".vol"], hasTrailingSeparator: true,
+            printed: "/.vol/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol"], hasTrailingSeparator: true,
+            printed: #"\.vol\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Only one component after .vol: not enough
+    PathTestCase(
+        input: "/.vol/16777234",
+        linux: Expected(
+            anchor: "/", components: [".vol", "16777234"],
+            printed: "/.vol/16777234", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/", components: [".vol", "16777234"],
+            printed: "/.vol/16777234", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "16777234"],
+            printed: #"\.vol\16777234"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Wrong case: not volfs
+    PathTestCase(
+        input: "/.VOL/1234/5678",
+        unix: Expected(
+            anchor: "/", components: [".VOL", "1234", "5678"],
+            printed: "/.VOL/1234/5678", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".VOL", "1234", "5678"],
+            printed: #"\.VOL\1234\5678"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Extra char: not volfs
+    PathTestCase(
+        input: "/.volx/1234/5678",
+        unix: Expected(
+            anchor: "/", components: [".volx", "1234", "5678"],
+            printed: "/.volx/1234/5678", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".volx", "1234", "5678"],
+            printed: #"\.volx\1234\5678"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Non-numeric fsid: parser treats vol IDs opaquely
+    PathTestCase(
+        input: "/.vol/abc/12345",
+        linux: Expected(
+            anchor: "/", components: [".vol", "abc", "12345"],
+            printed: "/.vol/abc/12345", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/abc/12345", components: [],
+            printed: "/.vol/abc/12345", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "abc", "12345"],
+            printed: #"\.vol\abc\12345"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Dot after volfs anchor: dropped (volfs anchor is rooted)
+    PathTestCase(
+        input: "/.vol/1234/5678/./foo",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "5678", "foo"],
+            printed: "/.vol/1234/5678/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/5678", components: ["foo"],
+            printed: "/.vol/1234/5678/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "5678", "foo"],
+            printed: #"\.vol\1234\5678\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Dotdot after volfs anchor: presented, not collapsed
+    PathTestCase(
+        input: "/.vol/1234/5678/foo/../bar",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "5678", "foo", "..", "bar"],
+            printed: "/.vol/1234/5678/foo/../bar", isAbsolute: true,
+            kinds: [.regular, .regular, .regular, .regular, .parentDirectory, .regular]),
+        darwin: Expected(
+            anchor: "/.vol/1234/5678", components: ["foo", "..", "bar"],
+            printed: "/.vol/1234/5678/foo/../bar", isAbsolute: true,
+            kinds: [.regular, .parentDirectory, .regular]),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "5678", "foo", "..", "bar"],
+            printed: #"\.vol\1234\5678\foo\..\bar"#, isAbsolute: false, isRooted: true,
+            kinds: [.regular, .regular, .regular, .regular, .parentDirectory, .regular])
+    ),
+
+    // MARK: - Resource fork near-misses
+
+    PathTestCase(
+        input: "/foo/..namedfork/data",
+        unix: Expected(
+            anchor: "/", components: ["foo", "..namedfork", "data"],
+            printed: "/foo/..namedfork/data", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "..namedfork", "data"],
+            printed: #"\foo\..namedfork\data"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/foo/..namedfork",
+        unix: Expected(
+            anchor: "/", components: ["foo", "..namedfork"],
+            printed: "/foo/..namedfork", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "..namedfork"],
+            printed: #"\foo\..namedfork"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Extra path after rsrc: suffix too long, not matched
+    PathTestCase(
+        input: "/foo/..namedfork/rsrc/extra",
+        unix: Expected(
+            anchor: "/", components: ["foo", "..namedfork", "rsrc", "extra"],
+            printed: "/foo/..namedfork/rsrc/extra", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "..namedfork", "rsrc", "extra"],
+            printed: #"\foo\..namedfork\rsrc\extra"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Darwin double separators within anchor structures
+    //
+    // _StdlibFilePath coalesces repeated separators and decomposes the coalesced
+    // form; the only input it rejects (returns nil) is one containing NUL.
+    // For .vol, the coalesced form yields the normal volfs anchor. The
+    // .resolve and resource-fork cases further below remain flagged as known
+    // issues pending a parser-vs-proposal decision (see README open questions).
+
+    // Double slash after .vol coalesces to /.vol/1234/5678 (volfs anchor)
+    PathTestCase(
+        input: "/.vol//1234/5678",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "5678"],
+            printed: "/.vol/1234/5678", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/5678", components: [],
+            printed: "/.vol/1234/5678", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "5678"],
+            printed: #"\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Double slash between vol IDs coalesces to /.vol/1234/5678 (volfs anchor)
+    PathTestCase(
+        input: "/.vol/1234//5678",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "5678"],
+            printed: "/.vol/1234/5678", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/5678", components: [],
+            printed: "/.vol/1234/5678", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "5678"],
+            printed: #"\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // The resource-fork match is an emergent property of separator
+    // coalescing, consistent with the Darwin anchor cases: the whole
+    // string is coalesced before suffix detection, so the kernel only
+    // ever receives the coalesced form (/foo/..namedfork/rsrc) and there
+    // is no separate kernel-behavior question to confirm. See README
+    // "Design model: emergent semantics."
+    PathTestCase(
+        input: "/foo/..namedfork//rsrc",
+        linux: Expected(
+            anchor: "/", components: ["foo", "..namedfork", "rsrc"],
+            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/", components: ["foo"], isResourceFork: true,
+            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"],
+            printed: #"\foo\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Double slash BEFORE resource fork suffix: suffix IS the last 17 bytes,
+    // which are "/..namedfork/rsrc" regardless of earlier double slashes.
+    PathTestCase(
+        input: "/foo//..namedfork/rsrc",
+        linux: Expected(
+            anchor: "/", components: ["foo", "..namedfork", "rsrc"],
+            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/", components: ["foo"], isResourceFork: true,
+            printed: "/foo/..namedfork/rsrc", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "..namedfork", "rsrc"],
+            printed: #"\foo\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Double slash where the resolve flag number should be: coalesces to
+    // /.resolve/1/foo, which then canonicalizes to /.nofollow/foo on Darwin.
+    PathTestCase(
+        input: "/.resolve//1/foo",
+        linux: Expected(
+            anchor: "/", components: [".resolve", "1", "foo"],
+            printed: "/.resolve/1/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/", components: ["foo"],
+            printed: "/.nofollow/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".resolve", "1", "foo"],
+            printed: #"\.resolve\1\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // Double slash after nofollow prefix boundary: prefix matches (first 11
+    // bytes are "/.nofollow/"), extra slash is a redundant separator in the
+    // relative portion.
+    PathTestCase(
+        input: "/.nofollow//foo",
+        linux: Expected(
+            anchor: "/", components: [".nofollow", "foo"],
+            printed: "/.nofollow/foo", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/", components: ["foo"],
+            printed: "/.nofollow/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".nofollow", "foo"],
+            printed: #"\.nofollow\foo"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - .vol + resource fork
+
+    PathTestCase(
+        input: "/.vol/1234/5678/file/..namedfork/rsrc",
+        linux: Expected(
+            anchor: "/", components: [".vol", "1234", "5678", "file", "..namedfork", "rsrc"],
+            printed: "/.vol/1234/5678/file/..namedfork/rsrc", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.vol/1234/5678", components: ["file"], isResourceFork: true,
+            printed: "/.vol/1234/5678/file/..namedfork/rsrc", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".vol", "1234", "5678", "file", "..namedfork", "rsrc"],
+            printed: #"\.vol\1234\5678\file\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Resolve prefix + resource fork
+
+    PathTestCase(
+        input: "/.nofollow/path/to/file/..namedfork/rsrc",
+        linux: Expected(
+            anchor: "/", components: [".nofollow", "path", "to", "file", "..namedfork", "rsrc"],
+            printed: "/.nofollow/path/to/file/..namedfork/rsrc", isAbsolute: true),
+        darwin: Expected(
+            anchor: "/.nofollow/", components: ["path", "to", "file"], isResourceFork: true,
+            printed: "/.nofollow/path/to/file/..namedfork/rsrc", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [".nofollow", "path", "to", "file", "..namedfork", "rsrc"],
+            printed: #"\.nofollow\path\to\file\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Trailing sep on dot/dotdot after root
+
+    PathTestCase(
+        input: "/./",
+        unix: Expected(
+            anchor: "/", components: [],
+            printed: "/", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: [],
+            printed: #"\"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/../",
+        unix: Expected(
+            anchor: "/", components: [".."], hasTrailingSeparator: true,
+            printed: "/../", isAbsolute: true, kinds: [.parentDirectory]),
+        windows: Expected(
+            anchor: #"\"#, components: [".."], hasTrailingSeparator: true,
+            printed: #"\..\"#, isAbsolute: false, isRooted: true, kinds: [.parentDirectory])
+    ),
+
+    PathTestCase(
+        input: "/foo/bar/../../baz",
+        unix: Expected(
+            anchor: "/", components: ["foo", "bar", "..", "..", "baz"],
+            printed: "/foo/bar/../../baz", isAbsolute: true,
+            kinds: [.regular, .regular, .parentDirectory, .parentDirectory, .regular]),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "bar", "..", "..", "baz"],
+            printed: #"\foo\bar\..\..\baz"#, isAbsolute: false, isRooted: true,
+            kinds: [.regular, .regular, .parentDirectory, .parentDirectory, .regular])
+    ),
+
+    // MARK: - Deeper drive relative
+
+    PathTestCase(
+        input: #"C:foo\bar\baz"#,
+        unix: .singleComponent(#"C:foo\bar\baz"#),
+        windows: Expected(
+            anchor: "C:", components: ["foo", "bar", "baz"],
+            printed: #"C:foo\bar\baz"#, isAbsolute: false, driveLetter: "C")
+    ),
+
+    // MARK: - Windows device UNC
+
+    PathTestCase(
+        input: #"\\.\UNC\srv\share\foo"#,
+        unix: .singleComponent(#"\\.\UNC\srv\share\foo"#),
+        windows: Expected(
+            anchor: #"\\.\UNC"#, components: ["srv", "share", "foo"],
+            printed: #"\\.\UNC\srv\share\foo"#, isAbsolute: true)
+    ),
+
+    // \\.\UNC alone: device name only, no components
+    PathTestCase(
+        input: #"\\.\UNC"#,
+        unix: .singleComponent(#"\\.\UNC"#),
+        windows: Expected(
+            anchor: #"\\.\UNC"#, components: [],
+            printed: #"\\.\UNC"#, isAbsolute: true)
+    ),
+
+    // \\.\UNC\ trailing sep after device name
+    PathTestCase(
+        input: #"\\.\UNC\"#,
+        unix: .singleComponent(#"\\.\UNC\"#),
+        windows: Expected(
+            anchor: #"\\.\UNC"#, components: [], hasTrailingSeparator: true,
+            printed: #"\\.\UNC\"#, isAbsolute: true)
+    ),
+
+    // \\.\UNC\server: server is a component, NOT absorbed into anchor
+    PathTestCase(
+        input: #"\\.\UNC\server"#,
+        unix: .singleComponent(#"\\.\UNC\server"#),
+        windows: Expected(
+            anchor: #"\\.\UNC"#, components: ["server"],
+            printed: #"\\.\UNC\server"#, isAbsolute: true)
+    ),
+
+    // \\.\UNC\server\share: both are components (contrast with \\?\UNC\)
+    PathTestCase(
+        input: #"\\.\UNC\server\share"#,
+        unix: .singleComponent(#"\\.\UNC\server\share"#),
+        windows: Expected(
+            anchor: #"\\.\UNC"#, components: ["server", "share"],
+            printed: #"\\.\UNC\server\share"#, isAbsolute: true)
+    ),
+
+    // \\.\UNC\server\share\ trailing sep
+    PathTestCase(
+        input: #"\\.\UNC\server\share\"#,
+        unix: .singleComponent(#"\\.\UNC\server\share\"#),
+        windows: Expected(
+            anchor: #"\\.\UNC"#, components: ["server", "share"],
+            hasTrailingSeparator: true,
+            printed: #"\\.\UNC\server\share\"#, isAbsolute: true)
+    ),
+
+    // MARK: - Verbatim non-drive non-UNC
+
+    // Unknown device name is part of anchor
+    PathTestCase(
+        input: #"\\?\foo\bar"#,
+        unix: .singleComponent(#"\\?\foo\bar"#),
+        windows: Expected(
+            anchor: #"\\?\foo"#, components: ["bar"],
+            printed: #"\\?\foo\bar"#, isAbsolute: true)
+    ),
+
+    // GLOBALROOT (NT-namespace escape): name terminates at first backslash
+    PathTestCase(
+        input: #"\\?\GLOBALROOT\Device\HarddiskVolume1\foo"#,
+        unix: .singleComponent(#"\\?\GLOBALROOT\Device\HarddiskVolume1\foo"#),
+        windows: Expected(
+            anchor: #"\\?\GLOBALROOT"#,
+            components: ["Device", "HarddiskVolume1", "foo"],
+            printed: #"\\?\GLOBALROOT\Device\HarddiskVolume1\foo"#,
+            isAbsolute: true)
+    ),
+
+    // Volume GUID (volumes without a drive letter)
+    PathTestCase(
+        input: #"\\?\Volume{12345678-1234-1234-1234-123456789012}\foo\bar"#,
+        unix: .singleComponent(
+            #"\\?\Volume{12345678-1234-1234-1234-123456789012}\foo\bar"#),
+        windows: Expected(
+            anchor: #"\\?\Volume{12345678-1234-1234-1234-123456789012}"#,
+            components: ["foo", "bar"],
+            printed: #"\\?\Volume{12345678-1234-1234-1234-123456789012}\foo\bar"#,
+            isAbsolute: true)
+    ),
+
+    // DosDevices symlink (e.g. PIPE)
+    PathTestCase(
+        input: #"\\?\PIPE\mypipe"#,
+        unix: .singleComponent(#"\\?\PIPE\mypipe"#),
+        windows: Expected(
+            anchor: #"\\?\PIPE"#, components: ["mypipe"],
+            printed: #"\\?\PIPE\mypipe"#, isAbsolute: true)
+    ),
+
+    // .. NOT special in verbatim plain: regular component
+    PathTestCase(
+        input: #"\\?\GLOBALROOT\..\foo"#,
+        unix: .singleComponent(#"\\?\GLOBALROOT\..\foo"#),
+        windows: Expected(
+            anchor: #"\\?\GLOBALROOT"#, components: ["..", "foo"],
+            printed: #"\\?\GLOBALROOT\..\foo"#, isAbsolute: true,
+            kinds: [.regular, .regular])
+    ),
+
+    // . NOT special in verbatim plain: regular component (not dropped)
+    PathTestCase(
+        input: #"\\?\GLOBALROOT\.\foo"#,
+        unix: .singleComponent(#"\\?\GLOBALROOT\.\foo"#),
+        windows: Expected(
+            anchor: #"\\?\GLOBALROOT"#, components: [".", "foo"],
+            printed: #"\\?\GLOBALROOT\.\foo"#, isAbsolute: true,
+            kinds: [.regular, .regular])
+    ),
+
+    // / inside verbatim plain component is a regular byte, not a separator
+    PathTestCase(
+        input: #"\\?\GLOBALROOT\foo/bar"#,
+        unix: Expected(
+            anchor: nil, components: [#"\\?\GLOBALROOT\foo"#, "bar"],
+            printed: #"\\?\GLOBALROOT\foo/bar"#, isAbsolute: false),
+        windows: Expected(
+            anchor: #"\\?\GLOBALROOT"#, components: ["foo/bar"],
+            printed: #"\\?\GLOBALROOT\foo/bar"#, isAbsolute: true)
+    ),
+
+    // MARK: - Device path forward slashes for pipes
+
+    // Dot dropped (rooted) on Unix, device-namespace pipe on Windows
+    PathTestCase(
+        input: "//./pipe/foo",
+        unix: Expected(
+            anchor: "/", components: ["pipe", "foo"],
+            printed: "/pipe/foo", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\\.\pipe"#, components: ["foo"],
+            printed: #"\\.\pipe\foo"#, isAbsolute: true)
+    ),
+
+    // MARK: - Dotfile components (not special, always regular)
+
+    PathTestCase(
+        input: "/foo/.hidden",
+        unix: Expected(
+            anchor: "/", components: ["foo", ".hidden"],
+            printed: "/foo/.hidden", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", ".hidden"],
+            printed: #"\foo\.hidden"#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Double extension and trailing dot
+
+    PathTestCase(
+        input: "/foo/bar.tar.gz",
+        unix: Expected(
+            anchor: "/", components: ["foo", "bar.tar.gz"],
+            printed: "/foo/bar.tar.gz", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "bar.tar.gz"],
+            printed: #"\foo\bar.tar.gz"#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/foo/bar.",
+        unix: Expected(
+            anchor: "/", components: ["foo", "bar."],
+            printed: "/foo/bar.", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "bar."],
+            printed: #"\foo\bar."#, isAbsolute: false, isRooted: true)
+    ),
+
+    PathTestCase(
+        input: "/foo/...",
+        unix: Expected(
+            anchor: "/", components: ["foo", "..."],
+            printed: "/foo/...", isAbsolute: true),
+        windows: Expected(
+            anchor: #"\"#, components: ["foo", "..."],
+            printed: #"\foo\..."#, isAbsolute: false, isRooted: true)
+    ),
+
+    // MARK: - Windows IP address as UNC server
+
+    PathTestCase(
+        input: #"\\192.168.1.1\share\foo"#,
+        unix: .singleComponent(#"\\192.168.1.1\share\foo"#),
+        windows: Expected(
+            anchor: #"\\192.168.1.1\share"#, components: ["foo"],
+            printed: #"\\192.168.1.1\share\foo"#, isAbsolute: true)
+    ),
+
+    // MARK: - Windows drive dot and dotdot
+
+    PathTestCase(
+        input: "C:.",
+        unix: Expected(
+            anchor: nil, components: ["C:."],
+            printed: "C:.", isAbsolute: false),
+        windows: Expected(
+            anchor: "C:", components: ["."],
+            printed: "C:.", isAbsolute: false, driveLetter: "C",
+            kinds: [.currentDirectory])
+    ),
+
+    PathTestCase(
+        input: "C:..",
+        unix: Expected(
+            anchor: nil, components: ["C:.."],
+            printed: "C:..", isAbsolute: false),
+        windows: Expected(
+            anchor: "C:", components: [".."],
+            printed: "C:..", isAbsolute: false, driveLetter: "C",
+            kinds: [.parentDirectory])
+    ),
+
+    // MARK: - Windows non-letter drive
+
+    // A drive letter is any single non-separator code unit followed by a
+    // colon (matching RtlDetermineDosPathNameType_U, which keys on the
+    // second character being a colon and does not validate the first).
+    // A digit is a valid drive letter: "1:\foo" is drive-absolute.
+    PathTestCase(
+        input: #"1:\foo"#,
+        unix: .singleComponent(#"1:\foo"#),
+        windows: Expected(
+            anchor: #"1:\"#, components: ["foo"],
+            printed: #"1:\foo"#, isAbsolute: true, driveLetter: "1")
+    ),
+
+    // A colon is itself a non-separator, so "::foo" parses as drive ":"
+    // (the documented basis for the "=::" environment variable Windows
+    // creates). Like "C:foo", it is drive-relative: not rooted, not
+    // absolute.
+    PathTestCase(
+        input: "::foo",
+        unix: Expected(
+            anchor: nil, components: ["::foo"],
+            printed: "::foo", isAbsolute: false),
+        windows: Expected(
+            anchor: "::", components: ["foo"],
+            printed: "::foo", isAbsolute: false, driveLetter: ":")
+    ),
+
+    // The non-separator rule extends to device-namespace drives:
+    // "\\.\1:" exposes drive "1" just as "\\.\C:" exposes "C".
+    PathTestCase(
+        input: #"\\.\1:"#,
+        unix: .singleComponent(#"\\.\1:"#),
+        windows: Expected(
+            anchor: #"\\.\1:"#, components: [],
+            printed: #"\\.\1:"#, isAbsolute: true, driveLetter: "1")
+    ),
+
+    // ...and to verbatim drives: "\\?\1:\" exposes drive "1".
+    PathTestCase(
+        input: #"\\?\1:\"#,
+        unix: .singleComponent(#"\\?\1:\"#),
+        windows: Expected(
+            anchor: #"\\?\1:\"#, components: [],
+            printed: #"\\?\1:\"#, isAbsolute: true, driveLetter: "1")
+    ),
+
+    // Verbatim paths take bytes as written: separators are not normalized,
+    // so "/" is a legal (non-separator) drive letter and "\\?\/:" has
+    // drive "/".
+    PathTestCase(
+        input: #"\\?\/:"#,
+        unix: Expected(
+            anchor: nil, components: [#"\\?\"#, ":"],
+            printed: #"\\?\/:"#, isAbsolute: false),
+        windows: Expected(
+            anchor: #"\\?\/:"#, components: [],
+            printed: #"\\?\/:"#, isAbsolute: true, driveLetter: "/")
+    ),
+
+    // MARK: - Trailing sep on deeper paths
+
+    PathTestCase(
+        input: "foo/bar/",
+        unix: Expected(
+            anchor: nil, components: ["foo", "bar"], hasTrailingSeparator: true,
+            printed: "foo/bar/", isAbsolute: false),
+        windows: Expected(
+            anchor: nil, components: ["foo", "bar"], hasTrailingSeparator: true,
+            printed: #"foo\bar\"#, isAbsolute: false)
+    ),
+
+    // MARK: - Windows dotdot/dot + trailing sep
+
+    PathTestCase(
+        input: #"C:\foo\bar\..\"#,
+        unix: .singleComponent(#"C:\foo\bar\..\"#),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar", ".."], hasTrailingSeparator: true,
+            printed: #"C:\foo\bar\..\"#, isAbsolute: true, driveLetter: "C",
+            kinds: [.regular, .regular, .parentDirectory])
+    ),
+
+    // Trailing dot dropped + trailing sep coalesced
+    PathTestCase(
+        input: #"C:\foo\bar\.\"#,
+        unix: .singleComponent(#"C:\foo\bar\.\"#),
+        windows: Expected(
+            anchor: #"C:\"#, components: ["foo", "bar"], hasTrailingSeparator: true,
+            printed: #"C:\foo\bar\"#, isAbsolute: true, driveLetter: "C")
+    ),
+
+    // MARK: - Degenerate Windows UNC / device paths
+    //
+    // These start with `\\` but are incomplete or have doubled separators.
+    // Each is well-defined: the parser pads incomplete UNC forms with a
+    // synthesized backslash and coalesces interior doubled separators.
+
+    PathTestCase(
+        input: #"\\server"#,
+        // Incomplete UNC: server with no share. Padded to `\\server\`.
+        unix: .singleComponent(#"\\server"#),
+        windows: Expected(
+            anchor: #"\\server\"#, components: [],
+            printed: #"\\server\"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: #"\\server\"#,
+        // Server with empty share — same final form as `\\server`.
+        unix: .singleComponent(#"\\server\"#),
+        windows: Expected(
+            anchor: #"\\server\"#, components: [],
+            printed: #"\\server\"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: #"\\"#,
+        // Bare double backslash: padded to a degraded `\\\` root.
+        unix: .singleComponent(#"\\"#),
+        windows: Expected(
+            anchor: #"\\\"#, components: [],
+            printed: #"\\\"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: #"\\server\share\\foo"#,
+        // Doubled separator between share and first component coalesces.
+        unix: .singleComponent(#"\\server\share\\foo"#),
+        windows: Expected(
+            anchor: #"\\server\share"#, components: ["foo"],
+            printed: #"\\server\share\foo"#, isAbsolute: true)
+    ),
+
+    PathTestCase(
+        input: #"\\srv\\share\foo"#,
+        // Doubled separator between server and share coalesces.
+        unix: .singleComponent(#"\\srv\\share\foo"#),
+        windows: Expected(
+            anchor: #"\\srv\share"#, components: ["foo"],
+            printed: #"\\srv\share\foo"#, isAbsolute: true)
+    ),
+]

--- a/Tests/SystemTests/StdlibFilePathTests/PathTestCases.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/PathTestCases.swift
@@ -1,12 +1,20 @@
-// PathTestCases.swift
-// Comprehensive test data for _StdlibFilePath parsing across Linux, Darwin, and Windows.
+/*
+ This source file is part of the Swift System open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+// Test data for _StdlibFilePath parsing across Linux, Darwin, and Windows.
+// Each case gives the expected decomposition on all three platforms, and
+// DecompositionTests also reconstructs from that decomposition and checks the
+// result equals the original.
 //
-// Each test case specifies the expected decomposition on all three platforms.
-// Round-trip assertion: construct from input, decompose, reconstruct, check equality.
-//
-// Formatting: decomposition fields (anchor, components, hasTrailingSeparator,
-// isResourceFork) on one line. Derived fields (printed, isAbsolute, isRooted,
-// driveLetter, kinds) on the next.
+// Formatting: the decomposition fields (anchor, components,
+// hasTrailingSeparator, isResourceFork) go on one line, and the derived fields
+// (printed, isAbsolute, isRooted, driveLetter, kinds) on the next.
 
 extension Expected {
     /// Unix parses a backslash-containing path as a single component
@@ -66,7 +74,7 @@ let pathTestCases: [PathTestCase] = [
             anchor: "/", components: [],
             printed: "/", isAbsolute: true),
         windows: Expected(
-            // `///` -> `\\\`: 3+ leading backslashes are NOT a UNC/device
+            // `///` -> `\\\`: 3+ leading backslashes are not a UNC/device
             // path; reduce to a single current-drive root.
             anchor: #"\"#, components: [],
             printed: #"\"#, isAbsolute: false, isRooted: true)
@@ -560,7 +568,7 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\.resolve\999999\foo"#, isAbsolute: false, isRooted: true)
     ),
 
-    // Without trailing slash: NOT a resolve prefix, regular component
+    // Without trailing slash: not a resolve prefix, regular component
     PathTestCase(
         input: "/.nofollow",
         unix: Expected(
@@ -571,7 +579,7 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\.nofollow"#, isAbsolute: false, isRooted: true)
     ),
 
-    // Without trailing slash on resolve: NOT a prefix, regular components
+    // Without trailing slash on resolve: not a prefix, regular components
     PathTestCase(
         input: "/.resolve/0",
         unix: Expected(
@@ -756,7 +764,7 @@ let pathTestCases: [PathTestCase] = [
 
     // MARK: - Darwin combined anchors (resolve flag + volume identifier)
     //
-    // Per proposal line 111: an anchor may include resolve flags AND/OR
+    // An anchor may include resolve flags and/or
     // a volume identifier; resolve always precedes vol. The combined form
     // `[/.nofollow/ | /.resolve/N/].vol/FSID/FILEID` is a single anchor.
     // Both canonicalizations (`/.resolve/1/` -> `/.nofollow/`, `2` -> `@`)
@@ -835,7 +843,7 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\.resolve\3\.vol\1234\5678"#, isAbsolute: false, isRooted: true)
     ),
 
-    // Combined resolve/3 + vol with FILEID canon — only the FILEID rule
+    // Combined resolve/3 + vol with FILEID canon: only the FILEID rule
     // fires; `.resolve/3/` is preserved as written.
     PathTestCase(
         input: "/.resolve/3/.vol/1234/2/",
@@ -853,8 +861,8 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\.resolve\3\.vol\1234\2\"#, isAbsolute: false, isRooted: true)
     ),
 
-    // Combined resolve/1 + vol — BOTH canonicalizations fire:
-    // `/.resolve/1/` -> `/.nofollow/` AND FILEID `2` -> `@`.
+    // Combined resolve/1 + vol, where both canonicalizations fire:
+    // `/.resolve/1/` -> `/.nofollow/` and FILEID `2` -> `@`.
     PathTestCase(
         input: "/.resolve/1/.vol/1234/2/",
         linux: Expected(
@@ -871,7 +879,7 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\.resolve\1\.vol\1234\2\"#, isAbsolute: false, isRooted: true)
     ),
 
-    // Combined resolve/1 + vol with relative content — both canons + relative.
+    // Combined resolve/1 + vol with relative content: both canons, plus relative.
     PathTestCase(
         input: "/.resolve/1/.vol/1234/2/foo/bar",
         linux: Expected(
@@ -1128,7 +1136,7 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\\.\C:"#, isAbsolute: true, driveLetter: "C")
     ),
 
-    // Dot IS dropped on non-verbatim device paths
+    // Dot is dropped on non-verbatim device paths
     PathTestCase(
         input: #"\\.\C:\foo\.\bar"#,
         unix: .singleComponent(#"\\.\C:\foo\.\bar"#),
@@ -1157,7 +1165,7 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\\?\C:"#, isAbsolute: true, driveLetter: "C")
     ),
 
-    // Dot NOT dropped in verbatim: treated as regular component
+    // Dot not dropped in verbatim: treated as regular component
     PathTestCase(
         input: #"\\?\C:\foo\.\bar"#,
         unix: .singleComponent(#"\\?\C:\foo\.\bar"#),
@@ -1167,7 +1175,7 @@ let pathTestCases: [PathTestCase] = [
             kinds: [.regular, .regular, .regular])
     ),
 
-    // Dotdot NOT special in verbatim: treated as regular component
+    // Dotdot not special in verbatim: treated as regular component
     PathTestCase(
         input: #"\\?\C:\foo\..\bar"#,
         unix: .singleComponent(#"\\?\C:\foo\..\bar"#),
@@ -1243,7 +1251,7 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\\?\UNC\s\sh\a/b"#, isAbsolute: true)
     ),
 
-    // //?/ is NOT verbatim — it's device-namespace (same as //./). All / converted.
+    // //?/ is not verbatim; it is device-namespace (same as //./). All / converted.
     PathTestCase(
         input: "//?/C:/a/b",
         unix: Expected(
@@ -1439,7 +1447,7 @@ let pathTestCases: [PathTestCase] = [
 
     // MARK: - Trailing forward slash on backslash paths
 
-    // Unix: forward slash IS a separator, splits the backslash-blob from trailing sep
+    // Unix: forward slash is a separator, splits the backslash-blob from trailing sep
     PathTestCase(
         input: #"C:\foo/"#,
         unix: .singleComponent(#"C:\foo"#, hasTrailingSeparator: true),
@@ -1593,7 +1601,7 @@ let pathTestCases: [PathTestCase] = [
 
     // MARK: - Verbatim dot/dotdot at end
 
-    // In verbatim context, trailing dot is a regular component, NOT dropped
+    // In verbatim context, trailing dot is a regular component, not dropped
     PathTestCase(
         input: #"\\?\C:\foo\bar\."#,
         unix: .singleComponent(#"\\?\C:\foo\bar\."#),
@@ -1812,11 +1820,10 @@ let pathTestCases: [PathTestCase] = [
 
     // MARK: - Darwin double separators within anchor structures
     //
-    // _StdlibFilePath coalesces repeated separators and decomposes the coalesced
-    // form; the only input it rejects (returns nil) is one containing NUL.
-    // For .vol, the coalesced form yields the normal volfs anchor. The
-    // .resolve and resource-fork cases further below remain flagged as known
-    // issues pending a parser-vs-proposal decision (see README open questions).
+    // _StdlibFilePath coalesces repeated separators and decomposes the
+    // coalesced form; the only input it rejects (returns nil) is one
+    // containing NUL. For .vol, the coalesced form yields the normal volfs
+    // anchor.
 
     // Double slash after .vol coalesces to /.vol/1234/5678 (volfs anchor)
     PathTestCase(
@@ -1847,11 +1854,10 @@ let pathTestCases: [PathTestCase] = [
     ),
 
     // The resource-fork match is an emergent property of separator
-    // coalescing, consistent with the Darwin anchor cases: the whole
-    // string is coalesced before suffix detection, so the kernel only
-    // ever receives the coalesced form (/foo/..namedfork/rsrc) and there
-    // is no separate kernel-behavior question to confirm. See README
-    // "Design model: emergent semantics."
+    // coalescing, consistent with the Darwin anchor cases: the whole string is
+    // coalesced before suffix detection, so the kernel only ever receives the
+    // coalesced form (/foo/..namedfork/rsrc). There is no separate
+    // kernel-behavior question to confirm.
     PathTestCase(
         input: "/foo/..namedfork//rsrc",
         linux: Expected(
@@ -1865,7 +1871,7 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\foo\..namedfork\rsrc"#, isAbsolute: false, isRooted: true)
     ),
 
-    // Double slash BEFORE resource fork suffix: suffix IS the last 17 bytes,
+    // Double slash before resource fork suffix: suffix is the last 17 bytes,
     // which are "/..namedfork/rsrc" regardless of earlier double slashes.
     PathTestCase(
         input: "/foo//..namedfork/rsrc",
@@ -2013,7 +2019,7 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\\.\UNC\"#, isAbsolute: true)
     ),
 
-    // \\.\UNC\server: server is a component, NOT absorbed into anchor
+    // \\.\UNC\server: server is a component, not absorbed into anchor
     PathTestCase(
         input: #"\\.\UNC\server"#,
         unix: .singleComponent(#"\\.\UNC\server"#),
@@ -2084,7 +2090,7 @@ let pathTestCases: [PathTestCase] = [
             printed: #"\\?\PIPE\mypipe"#, isAbsolute: true)
     ),
 
-    // .. NOT special in verbatim plain: regular component
+    // .. not special in verbatim plain: regular component
     PathTestCase(
         input: #"\\?\GLOBALROOT\..\foo"#,
         unix: .singleComponent(#"\\?\GLOBALROOT\..\foo"#),
@@ -2094,7 +2100,7 @@ let pathTestCases: [PathTestCase] = [
             kinds: [.regular, .regular])
     ),
 
-    // . NOT special in verbatim plain: regular component (not dropped)
+    // . not special in verbatim plain: regular component (not dropped)
     PathTestCase(
         input: #"\\?\GLOBALROOT\.\foo"#,
         unix: .singleComponent(#"\\?\GLOBALROOT\.\foo"#),
@@ -2315,7 +2321,7 @@ let pathTestCases: [PathTestCase] = [
 
     PathTestCase(
         input: #"\\server\"#,
-        // Server with empty share — same final form as `\\server`.
+        // Server with empty share: same final form as `\\server`.
         unix: .singleComponent(#"\\server\"#),
         windows: Expected(
             anchor: #"\\server\"#, components: [],

--- a/Tests/SystemTests/StdlibFilePathTests/ProbeTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ProbeTests.swift
@@ -1,0 +1,240 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// Edge-case decomposition checks: each `@Test` pins the decomposition of a
+// degenerate / boundary input that the table-driven `pathTestCases` doesn't
+// cover (Darwin anchor reparse, bare resolve/vol forms, Windows
+// multi-backslash roots, Windows empty-device sigils, prefix near-misses).
+// Nested in `AllTests.DecompositionTests` so they share the same
+// `@Suite(.serialized)` umbrella as the table-driven cases.
+
+extension AllTests.DecompositionTests {
+
+  /// Pin the four primary decomposition fields for `input` on `platform`.
+  /// The default `#_sourceLocation` captures the *caller's* location, so a
+  /// failure points at the assertion row rather than this helper.
+  private func expectDecomposition(
+    _ input: String,
+    platform: _Platform,
+    anchor: String?,
+    components: [String],
+    trailingSeparator: Bool = false,
+    printed: String,
+    sourceLocation: SourceLocation = #_sourceLocation
+  ) {
+    withPlatform(platform) {
+      guard let path = _StdlibFilePath(input) else {
+        expectNotNil(Optional<Int>.none,
+          "[\(platform)] \(input.debugDescription) _StdlibFilePath init returned nil",
+          sourceLocation: sourceLocation)
+        return
+      }
+      expectEqual(path.anchor?.description, anchor,
+        "[\(platform)] \(input.debugDescription) anchor: got \(path.anchor?.description.debugDescription ?? "nil")",
+        sourceLocation: sourceLocation)
+      expectEqual(path.components.map(\.description), components,
+        "[\(platform)] \(input.debugDescription) components: got \(path.components.map(\.description))",
+        sourceLocation: sourceLocation)
+      expectEqual(path.hasTrailingSeparator, trailingSeparator,
+        "[\(platform)] \(input.debugDescription) trailingSeparator: got \(path.hasTrailingSeparator)",
+        sourceLocation: sourceLocation)
+      expectEqual(path.description, printed,
+        "[\(platform)] \(input.debugDescription) printed: got \(path.description.debugDescription)",
+        sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - Darwin relative-portion re-parse vs combined anchors
+  //
+  // `_normalizeDarwin` extracts the relative portion into a fresh string and
+  // dot-normalizes it; that path re-runs `_parseRoot()` on the slice. This
+  // pins which token-shaped sequences AFTER a leading anchor extend the
+  // anchor and which fall back to plain components.
+  //
+  // An anchor may include resolve flags AND/OR a volume identifier; resolve
+  // always precedes vol. So:
+  // - `.vol` after a leading vol/nofollow/resolve flag: the only valid
+  //   continuation. `/.nofollow/.vol/N/M` is a single combined anchor.
+  // - Anything else after a leading anchor (vol after vol, nofollow after
+  //   anything, resolve after anything): the leading anchor stands and the
+  //   token-named bytes remain plain components.
+  @Test
+  func darwinRelativeReparse() {
+    // .vol token as a relative component under a volfs anchor.
+    expectDecomposition("/.vol/1234/5678/.vol/x", platform: .darwin,
+      anchor: "/.vol/1234/5678", components: [".vol", "x"],
+      printed: "/.vol/1234/5678/.vol/x")
+    // .nofollow token as a relative component under a volfs anchor.
+    expectDecomposition("/.vol/1234/5678/.nofollow/x", platform: .darwin,
+      anchor: "/.vol/1234/5678", components: [".nofollow", "x"],
+      printed: "/.vol/1234/5678/.nofollow/x")
+    // .resolve/3 tokens as relative components under a volfs anchor.
+    expectDecomposition("/.vol/1234/5678/.resolve/3/x", platform: .darwin,
+      anchor: "/.vol/1234/5678", components: [".resolve", "3", "x"],
+      printed: "/.vol/1234/5678/.resolve/3/x")
+    // .vol AFTER .nofollow forms a combined anchor — proposal line 111:
+    // an anchor may include resolve flags AND/OR a volume identifier.
+    expectDecomposition("/.nofollow/.vol/1234/5678", platform: .darwin,
+      anchor: "/.nofollow/.vol/1234/5678", components: [],
+      printed: "/.nofollow/.vol/1234/5678")
+    // .nofollow token as a relative component under a .nofollow anchor.
+    expectDecomposition("/.nofollow/.nofollow/x", platform: .darwin,
+      anchor: "/.nofollow/", components: [".nofollow", "x"],
+      printed: "/.nofollow/.nofollow/x")
+    // Inner `.resolve/1` is NOT canonicalized: canonicalization is anchor-only,
+    // and here `.resolve/1` is in component position under a `.resolve/3/`
+    // anchor.
+    expectDecomposition("/.resolve/3/.resolve/1/x", platform: .darwin,
+      anchor: "/.resolve/3/", components: [".resolve", "1", "x"],
+      printed: "/.resolve/3/.resolve/1/x")
+  }
+
+  // MARK: - Bare resolve/vol anchors without trailing content
+  //
+  // The parser treats volfs anchors and resolve/nofollow anchors
+  // asymmetrically:
+  //   * `_parseVol` recognizes `/.vol/F/I` WITHOUT a trailing slash; the
+  //     `2`->`@` canonicalization also fires without one.
+  //   * `_parseResolve`/`_parseNofollow` REQUIRE the trailing slash; bare
+  //     `/.resolve/N` and `/.nofollow` fall through to a plain `/` root with
+  //     the bytes as regular components, and `_canonicalizeDarwinAnchor` does
+  //     NOT fire on `/.resolve/1` (it matches the literal `/.resolve/1/`).
+  //
+  // The asymmetry is principled per XNU — a volfs anchor is a complete inode
+  // reference, while resolve/nofollow are prefixes that modify a FOLLOWING
+  // path.
+  //
+  // Already pinned in PathTestCases.swift (NOT re-asserted): `/.nofollow`,
+  // `/.resolve/0`, `/.vol/1234/5678`, `/.vol/1234/2`.
+  @Test
+  func bareResolveVolAnchors() {
+    // Bare `/.resolve/1` is NOT a resolve anchor — `_parseResolve` requires
+    // the trailing slash, so this falls through to a plain `/` root.
+    expectDecomposition("/.resolve/1", platform: .darwin,
+      anchor: "/", components: [".resolve", "1"],
+      printed: "/.resolve/1")
+    // `/.resolve/1/` canonicalizes to `/.nofollow/`. Here with NO following
+    // path -> anchor only, no components.
+    expectDecomposition("/.resolve/1/", platform: .darwin,
+      anchor: "/.nofollow/", components: [],
+      printed: "/.nofollow/")
+    // Bare `/.resolve/3` (non-canonicalizing flag) — same fall-through.
+    expectDecomposition("/.resolve/3", platform: .darwin,
+      anchor: "/", components: [".resolve", "3"],
+      printed: "/.resolve/3")
+    // `/.vol/1234/2/` — the `2`->`@` canonicalization fires, and the trailing
+    // slash is a separator (the volfs anchor itself is not slash-terminated).
+    expectDecomposition("/.vol/1234/2/", platform: .darwin,
+      anchor: "/.vol/1234/@", components: [], trailingSeparator: true,
+      printed: "/.vol/1234/@/")
+    // Linux contrast for the same bytes: no Darwin anchor magic at all.
+    expectDecomposition("/.resolve/1", platform: .linux,
+      anchor: "/", components: [".resolve", "1"],
+      printed: "/.resolve/1")
+  }
+
+  // MARK: - Windows three-or-more leading backslashes
+  //
+  // `_prenormalizeWindowsRoots` returns after the FIRST backslash for 3+
+  // leading backslashes ("NOT a UNC/device path"), and separator coalescing
+  // collapses the rest. Result: a single `\` current-drive root with the
+  // remainder as components.
+  @Test
+  func windowsThreePlusBackslashes() {
+    expectDecomposition(#"\\\server\share"#, platform: .windows,
+      anchor: #"\"#, components: ["server", "share"],
+      printed: #"\server\share"#)
+    expectDecomposition(#"\\\\server"#, platform: .windows,
+      anchor: #"\"#, components: ["server"],
+      printed: #"\server"#)
+    expectDecomposition(#"\\\"#, platform: .windows,
+      anchor: #"\"#, components: [],
+      printed: #"\"#)
+  }
+
+  // MARK: - Windows degenerate device/sigil forms
+  //
+  // A `\\.` or `\\?` with NO trailing backslash and NO device name gets a
+  // backslash SYNTHESIZED by `_prenormalizeWindowsRoots` (`expectBackslash`
+  // inserts one), yielding the empty-device anchors `\\.\` / `\\?\`. Both
+  // are absolute; `\\?` becomes verbatim-component. (The trailing-backslash
+  // variants `\\.\` and `\\?\` already have rows in PathTestCases.swift and
+  // are not re-asserted.)
+  @Test
+  func windowsDegenerateDeviceSigil() {
+    expectDecomposition(#"\\."#, platform: .windows,
+      anchor: #"\\.\"#, components: [],
+      printed: #"\\.\"#)
+    expectDecomposition(#"\\?"#, platform: .windows,
+      anchor: #"\\?\"#, components: [],
+      printed: #"\\?\"#)
+
+    // Same inputs, additional structural assertions.
+    // Route through String-typed locals so the failable `init?(_:)` is
+    // selected (a bare string literal would bind the non-failable
+    // ExpressibleByStringLiteral `init`, which is not optional).
+    withPlatform(.windows) {
+      let dotInput: String = #"\\."#
+      let dot = _StdlibFilePath(dotInput)!
+      expectTrue(dot.isAbsolute, #"\\. is absolute"#)
+      expectFalse(dot.anchor?._isVerbatimComponent ?? true,
+        #"\\. is device-namespace, not verbatim"#)
+
+      let qInput: String = #"\\?"#
+      let q = _StdlibFilePath(qInput)!
+      expectTrue(q.isAbsolute, #"\\? is absolute"#)
+      expectTrue(q.anchor?._isVerbatimComponent ?? false,
+        #"\\? is verbatim-component"#)
+    }
+  }
+
+  // MARK: - _matches* prefix pre-filter near-misses
+  //
+  // `_matchesNofollow`/`_matchesResolve`/`_matchesVol` are prefix
+  // PRE-FILTERS; the real validation (the required trailing `/` after the
+  // keyword, the FSID/FILEID slashes) lives in `_parseNofollow`/
+  // `_parseResolve`/`_parseVol`. A near-miss whose keyword is only a PREFIX
+  // of the component (`/.nofollowing`, `/.resolved`, `/.volume`,
+  // `/.resolvex`) therefore fails the parser and falls through to a plain
+  // `/` root with the bytes as regular components.
+  //
+  // Analogous rows for inputs without prefix overlap (e.g. `/.hidden/foo`,
+  // `/.Resolve/0/foo`) live in PathTestCases.swift; the prefix-overlap
+  // near-misses are pinned here.
+  @Test
+  func matchesPrefixNearMisses() {
+    expectDecomposition("/.nofollowing/bar", platform: .darwin,
+      anchor: "/", components: [".nofollowing", "bar"],
+      printed: "/.nofollowing/bar")
+    expectDecomposition("/.resolved/x", platform: .darwin,
+      anchor: "/", components: [".resolved", "x"],
+      printed: "/.resolved/x")
+    expectDecomposition("/.volume/x", platform: .darwin,
+      anchor: "/", components: [".volume", "x"],
+      printed: "/.volume/x")
+    expectDecomposition("/.resolvex/1/y", platform: .darwin,
+      anchor: "/", components: [".resolvex", "1", "y"],
+      printed: "/.resolvex/1/y")
+    // Keyword present but missing the structural slashes:
+    // `.vol` with no FSID/FILEID, and FSID but no FILEID.
+    expectDecomposition("/.vol", platform: .darwin,
+      anchor: "/", components: [".vol"],
+      printed: "/.vol")
+    expectDecomposition("/.vol/1234", platform: .darwin,
+      anchor: "/", components: [".vol", "1234"],
+      printed: "/.vol/1234")
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/ProbeTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ProbeTests.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -26,6 +26,11 @@ extension AllTests.DecompositionTests {
   /// Pin the four primary decomposition fields for `input` on `platform`.
   /// The default `#_sourceLocation` captures the *caller's* location, so a
   /// failure points at the assertion row rather than this helper.
+  ///
+  /// The `withPlatform` gate selects rows per platform for the one test here
+  /// that asserts on both Linux and Darwin. Single-platform tests carry a
+  /// `.darwinOnly` / `.windowsOnly` trait instead, so they report as skipped
+  /// rather than passing without asserting.
   private func expectDecomposition(
     _ input: String,
     platform: _Platform,
@@ -61,17 +66,17 @@ extension AllTests.DecompositionTests {
   //
   // `_normalizeDarwin` extracts the relative portion into a fresh string and
   // dot-normalizes it; that path re-runs `_parseRoot()` on the slice. This
-  // pins which token-shaped sequences AFTER a leading anchor extend the
+  // pins which token-shaped sequences after a leading anchor extend the
   // anchor and which fall back to plain components.
   //
-  // An anchor may include resolve flags AND/OR a volume identifier; resolve
+  // An anchor may include resolve flags and/or a volume identifier; resolve
   // always precedes vol. So:
   // - `.vol` after a leading vol/nofollow/resolve flag: the only valid
   //   continuation. `/.nofollow/.vol/N/M` is a single combined anchor.
   // - Anything else after a leading anchor (vol after vol, nofollow after
   //   anything, resolve after anything): the leading anchor stands and the
   //   token-named bytes remain plain components.
-  @Test
+  @Test(.darwinOnly)
   func darwinRelativeReparse() {
     // .vol token as a relative component under a volfs anchor.
     expectDecomposition("/.vol/1234/5678/.vol/x", platform: .darwin,
@@ -85,8 +90,8 @@ extension AllTests.DecompositionTests {
     expectDecomposition("/.vol/1234/5678/.resolve/3/x", platform: .darwin,
       anchor: "/.vol/1234/5678", components: [".resolve", "3", "x"],
       printed: "/.vol/1234/5678/.resolve/3/x")
-    // .vol AFTER .nofollow forms a combined anchor — proposal line 111:
-    // an anchor may include resolve flags AND/OR a volume identifier.
+    // .vol after .nofollow forms a combined anchor: an anchor may include
+    // resolve flags and/or a volume identifier.
     expectDecomposition("/.nofollow/.vol/1234/5678", platform: .darwin,
       anchor: "/.nofollow/.vol/1234/5678", components: [],
       printed: "/.nofollow/.vol/1234/5678")
@@ -94,7 +99,7 @@ extension AllTests.DecompositionTests {
     expectDecomposition("/.nofollow/.nofollow/x", platform: .darwin,
       anchor: "/.nofollow/", components: [".nofollow", "x"],
       printed: "/.nofollow/.nofollow/x")
-    // Inner `.resolve/1` is NOT canonicalized: canonicalization is anchor-only,
+    // Inner `.resolve/1` is not canonicalized: canonicalization is anchor-only,
     // and here `.resolve/1` is in component position under a `.resolve/3/`
     // anchor.
     expectDecomposition("/.resolve/3/.resolve/1/x", platform: .darwin,
@@ -106,36 +111,36 @@ extension AllTests.DecompositionTests {
   //
   // The parser treats volfs anchors and resolve/nofollow anchors
   // asymmetrically:
-  //   * `_parseVol` recognizes `/.vol/F/I` WITHOUT a trailing slash; the
+  //   * `_parseVol` recognizes `/.vol/F/I` without a trailing slash; the
   //     `2`->`@` canonicalization also fires without one.
-  //   * `_parseResolve`/`_parseNofollow` REQUIRE the trailing slash; bare
+  //   * `_parseResolve`/`_parseNofollow` require the trailing slash; bare
   //     `/.resolve/N` and `/.nofollow` fall through to a plain `/` root with
   //     the bytes as regular components, and `_canonicalizeDarwinAnchor` does
-  //     NOT fire on `/.resolve/1` (it matches the literal `/.resolve/1/`).
+  //     not fire on `/.resolve/1` (it matches the literal `/.resolve/1/`).
   //
-  // The asymmetry is principled per XNU — a volfs anchor is a complete inode
-  // reference, while resolve/nofollow are prefixes that modify a FOLLOWING
+  // The asymmetry is principled per XNU: a volfs anchor is a complete inode
+  // reference, while resolve/nofollow are prefixes that modify a following
   // path.
   //
-  // Already pinned in PathTestCases.swift (NOT re-asserted): `/.nofollow`,
+  // Already pinned in PathTestCases.swift (not re-asserted): `/.nofollow`,
   // `/.resolve/0`, `/.vol/1234/5678`, `/.vol/1234/2`.
-  @Test
+  @Test(.unixOnly)
   func bareResolveVolAnchors() {
-    // Bare `/.resolve/1` is NOT a resolve anchor — `_parseResolve` requires
+    // Bare `/.resolve/1` is not a resolve anchor, since `_parseResolve` requires
     // the trailing slash, so this falls through to a plain `/` root.
     expectDecomposition("/.resolve/1", platform: .darwin,
       anchor: "/", components: [".resolve", "1"],
       printed: "/.resolve/1")
-    // `/.resolve/1/` canonicalizes to `/.nofollow/`. Here with NO following
+    // `/.resolve/1/` canonicalizes to `/.nofollow/`. Here with no following
     // path -> anchor only, no components.
     expectDecomposition("/.resolve/1/", platform: .darwin,
       anchor: "/.nofollow/", components: [],
       printed: "/.nofollow/")
-    // Bare `/.resolve/3` (non-canonicalizing flag) — same fall-through.
+    // Bare `/.resolve/3` (non-canonicalizing flag): same fall-through.
     expectDecomposition("/.resolve/3", platform: .darwin,
       anchor: "/", components: [".resolve", "3"],
       printed: "/.resolve/3")
-    // `/.vol/1234/2/` — the `2`->`@` canonicalization fires, and the trailing
+    // `/.vol/1234/2/`: the `2`->`@` canonicalization fires, and the trailing
     // slash is a separator (the volfs anchor itself is not slash-terminated).
     expectDecomposition("/.vol/1234/2/", platform: .darwin,
       anchor: "/.vol/1234/@", components: [], trailingSeparator: true,
@@ -148,11 +153,11 @@ extension AllTests.DecompositionTests {
 
   // MARK: - Windows three-or-more leading backslashes
   //
-  // `_prenormalizeWindowsRoots` returns after the FIRST backslash for 3+
+  // `_prenormalizeWindowsRoots` returns after the first backslash for 3+
   // leading backslashes ("NOT a UNC/device path"), and separator coalescing
   // collapses the rest. Result: a single `\` current-drive root with the
   // remainder as components.
-  @Test
+  @Test(.windowsOnly)
   func windowsThreePlusBackslashes() {
     expectDecomposition(#"\\\server\share"#, platform: .windows,
       anchor: #"\"#, components: ["server", "share"],
@@ -167,13 +172,13 @@ extension AllTests.DecompositionTests {
 
   // MARK: - Windows degenerate device/sigil forms
   //
-  // A `\\.` or `\\?` with NO trailing backslash and NO device name gets a
-  // backslash SYNTHESIZED by `_prenormalizeWindowsRoots` (`expectBackslash`
+  // A `\\.` or `\\?` with no trailing backslash and no device name gets a
+  // backslash synthesized by `_prenormalizeWindowsRoots` (`expectBackslash`
   // inserts one), yielding the empty-device anchors `\\.\` / `\\?\`. Both
   // are absolute; `\\?` becomes verbatim-component. (The trailing-backslash
   // variants `\\.\` and `\\?\` already have rows in PathTestCases.swift and
   // are not re-asserted.)
-  @Test
+  @Test(.windowsOnly)
   func windowsDegenerateDeviceSigil() {
     expectDecomposition(#"\\."#, platform: .windows,
       anchor: #"\\.\"#, components: [],
@@ -186,27 +191,25 @@ extension AllTests.DecompositionTests {
     // Route through String-typed locals so the failable `init?(_:)` is
     // selected (a bare string literal would bind the non-failable
     // ExpressibleByStringLiteral `init`, which is not optional).
-    withPlatform(.windows) {
-      let dotInput: String = #"\\."#
-      let dot = _StdlibFilePath(dotInput)!
-      expectTrue(dot.isAbsolute, #"\\. is absolute"#)
-      expectFalse(dot.anchor?._isVerbatimComponent ?? true,
-        #"\\. is device-namespace, not verbatim"#)
+    let dotInput: String = #"\\."#
+    let dot = _StdlibFilePath(dotInput)!
+    expectTrue(dot.isAbsolute, #"\\. is absolute"#)
+    expectFalse(dot.anchor?._isVerbatimComponent ?? true,
+      #"\\. is device-namespace, not verbatim"#)
 
-      let qInput: String = #"\\?"#
-      let q = _StdlibFilePath(qInput)!
-      expectTrue(q.isAbsolute, #"\\? is absolute"#)
-      expectTrue(q.anchor?._isVerbatimComponent ?? false,
-        #"\\? is verbatim-component"#)
-    }
+    let qInput: String = #"\\?"#
+    let q = _StdlibFilePath(qInput)!
+    expectTrue(q.isAbsolute, #"\\? is absolute"#)
+    expectTrue(q.anchor?._isVerbatimComponent ?? false,
+      #"\\? is verbatim-component"#)
   }
 
   // MARK: - _matches* prefix pre-filter near-misses
   //
   // `_matchesNofollow`/`_matchesResolve`/`_matchesVol` are prefix
-  // PRE-FILTERS; the real validation (the required trailing `/` after the
+  // pre-filters; the real validation (the required trailing `/` after the
   // keyword, the FSID/FILEID slashes) lives in `_parseNofollow`/
-  // `_parseResolve`/`_parseVol`. A near-miss whose keyword is only a PREFIX
+  // `_parseResolve`/`_parseVol`. A near-miss whose keyword is only a prefix
   // of the component (`/.nofollowing`, `/.resolved`, `/.volume`,
   // `/.resolvex`) therefore fails the parser and falls through to a plain
   // `/` root with the bytes as regular components.
@@ -214,7 +217,7 @@ extension AllTests.DecompositionTests {
   // Analogous rows for inputs without prefix overlap (e.g. `/.hidden/foo`,
   // `/.Resolve/0/foo`) live in PathTestCases.swift; the prefix-overlap
   // near-misses are pinned here.
-  @Test
+  @Test(.darwinOnly)
   func matchesPrefixNearMisses() {
     expectDecomposition("/.nofollowing/bar", platform: .darwin,
       anchor: "/", components: [".nofollowing", "bar"],

--- a/Tests/SystemTests/StdlibFilePathTests/ProbeTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ProbeTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -27,10 +27,10 @@ extension AllTests.DecompositionTests {
   /// The default `#_sourceLocation` captures the *caller's* location, so a
   /// failure points at the assertion row rather than this helper.
   ///
-  /// The `withPlatform` gate selects rows per platform for the one test here
-  /// that asserts on both Linux and Darwin. Single-platform tests carry a
-  /// `.darwinOnly` / `.windowsOnly` trait instead, so they report as skipped
-  /// rather than passing without asserting.
+  /// `platform` names whose expectations the row encodes, for the failure
+  /// message. It does not gate the assertion: the caller carries the matching
+  /// trait, so a row asserted on the wrong build fails rather than being
+  /// quietly skipped.
   private func expectDecomposition(
     _ input: String,
     platform: _Platform,
@@ -40,26 +40,24 @@ extension AllTests.DecompositionTests {
     printed: String,
     sourceLocation: SourceLocation = #_sourceLocation
   ) {
-    withPlatform(platform) {
-      guard let path = _StdlibFilePath(input) else {
-        expectNotNil(Optional<Int>.none,
-          "[\(platform)] \(input.debugDescription) _StdlibFilePath init returned nil",
-          sourceLocation: sourceLocation)
-        return
-      }
-      expectEqual(path.anchor?.description, anchor,
-        "[\(platform)] \(input.debugDescription) anchor: got \(path.anchor?.description.debugDescription ?? "nil")",
+    guard let path = _StdlibFilePath(input) else {
+      expectNotNil(Optional<Int>.none,
+        "[\(platform)] \(input.debugDescription) _StdlibFilePath init returned nil",
         sourceLocation: sourceLocation)
-      expectEqual(path.components.map(\.description), components,
-        "[\(platform)] \(input.debugDescription) components: got \(path.components.map(\.description))",
-        sourceLocation: sourceLocation)
-      expectEqual(path.hasTrailingSeparator, trailingSeparator,
-        "[\(platform)] \(input.debugDescription) trailingSeparator: got \(path.hasTrailingSeparator)",
-        sourceLocation: sourceLocation)
-      expectEqual(path.description, printed,
-        "[\(platform)] \(input.debugDescription) printed: got \(path.description.debugDescription)",
-        sourceLocation: sourceLocation)
+      return
     }
+    expectEqual(path.anchor?.description, anchor,
+      "[\(platform)] \(input.debugDescription) anchor: got \(path.anchor?.description.debugDescription ?? "nil")",
+      sourceLocation: sourceLocation)
+    expectEqual(path.components.map(\.description), components,
+      "[\(platform)] \(input.debugDescription) components: got \(path.components.map(\.description))",
+      sourceLocation: sourceLocation)
+    expectEqual(path.hasTrailingSeparator, trailingSeparator,
+      "[\(platform)] \(input.debugDescription) trailingSeparator: got \(path.hasTrailingSeparator)",
+      sourceLocation: sourceLocation)
+    expectEqual(path.description, printed,
+      "[\(platform)] \(input.debugDescription) printed: got \(path.description.debugDescription)",
+      sourceLocation: sourceLocation)
   }
 
   // MARK: - Darwin relative-portion re-parse vs combined anchors
@@ -124,10 +122,10 @@ extension AllTests.DecompositionTests {
   //
   // Already pinned in PathTestCases.swift (not re-asserted): `/.nofollow`,
   // `/.resolve/0`, `/.vol/1234/5678`, `/.vol/1234/2`.
-  @Test(.unixOnly)
+  @Test(.darwinOnly)
   func bareResolveVolAnchors() {
-    // Bare `/.resolve/1` is not a resolve anchor, since `_parseResolve` requires
-    // the trailing slash, so this falls through to a plain `/` root.
+    // Bare `/.resolve/1` is not a resolve anchor: `_parseResolve` requires the
+    // trailing slash, so this falls through to a plain `/` root.
     expectDecomposition("/.resolve/1", platform: .darwin,
       anchor: "/", components: [".resolve", "1"],
       printed: "/.resolve/1")
@@ -145,7 +143,11 @@ extension AllTests.DecompositionTests {
     expectDecomposition("/.vol/1234/2/", platform: .darwin,
       anchor: "/.vol/1234/@", components: [], trailingSeparator: true,
       printed: "/.vol/1234/@/")
-    // Linux contrast for the same bytes: no Darwin anchor magic at all.
+  }
+
+  /// Linux contrast for the same bytes: none of the Darwin anchor forms apply.
+  @Test(.linuxOnly)
+  func bareResolveVolAnchorsLinux() {
     expectDecomposition("/.resolve/1", platform: .linux,
       anchor: "/", components: [".resolve", "1"],
       printed: "/.resolve/1")
@@ -204,15 +206,14 @@ extension AllTests.DecompositionTests {
       #"\\? is verbatim-component"#)
   }
 
-  // MARK: - _matches* prefix pre-filter near-misses
+  // MARK: - Keyword near-misses
   //
-  // `_matchesNofollow`/`_matchesResolve`/`_matchesVol` are prefix
-  // pre-filters; the real validation (the required trailing `/` after the
-  // keyword, the FSID/FILEID slashes) lives in `_parseNofollow`/
-  // `_parseResolve`/`_parseVol`. A near-miss whose keyword is only a prefix
-  // of the component (`/.nofollowing`, `/.resolved`, `/.volume`,
-  // `/.resolvex`) therefore fails the parser and falls through to a plain
-  // `/` root with the bytes as regular components.
+  // `_parseNofollow` / `_parseResolve` / `_parseVol` each begin by eating the
+  // keyword together with its trailing slash (`".nofollow/"`, `".resolve/"`,
+  // `".vol/"`), so a component that merely starts with a keyword
+  // (`/.nofollowing`, `/.resolved`, `/.volume`, `/.resolvex`) fails the parse
+  // and falls through to a plain `/` root with the bytes as regular
+  // components.
   //
   // Analogous rows for inputs without prefix overlap (e.g. `/.hidden/foo`,
   // `/.Resolve/0/foo`) live in PathTestCases.swift; the prefix-overlap

--- a/Tests/SystemTests/StdlibFilePathTests/ReconstructionTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ReconstructionTests.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,20 +14,20 @@ import Testing
 @testable import System
 #endif
 
-// Reconstruction and the suffix/anchor setters as direct API. These were
-// previously exercised only as the round-trip tail of decomposition
-// (DecompositionTests.runCase). Here they are driven directly with
-// caller-built parts. Expectations from SE-0529:
-//   * "Path reconstruction" (477-517): `init(anchor:_:hasTrailingSeparator:)`
-//     and the Darwin `init(anchor:_:resourceFork:)`. The reconstructed path
-//     "parses and normalizes exactly as if the equivalent string literal had
-//     been provided."
-//   * "Trailing separators" (400-427): `hasTrailingSeparator` get/set,
+// Reconstruction and the suffix/anchor setters, driven directly with
+// caller-built parts rather than as the round-trip tail of a decomposition
+// (which is what DecompositionTests.runCase covers). Expectations from
+// SE-0529:
+//   * "Path reconstruction": `init(anchor:_:hasTrailingSeparator:)` and the
+//     Darwin `init(anchor:_:resourceFork:)`. The reconstructed path "parses
+//     and normalizes exactly as if the equivalent string literal had been
+//     provided."
+//   * "Trailing separators": `hasTrailingSeparator` get/set,
 //     `withTrailingSeparator()`, `withoutTrailingSeparator()`.
-//   * "Resource forks" (438-472): `isResourceFork` get/set,
-//     `withResourceFork()`, `withoutResourceFork()`, and the documented
-//     trailing-separator <-> resource-fork swap.
-//   * `anchor` get/set (174-201; examples at 46-55).
+//   * "Resource forks": `isResourceFork` get/set, `withResourceFork()`,
+//     `withoutResourceFork()`, and the documented trailing-separator to
+//     resource-fork swap.
+//   * `anchor` get/set.
 
 extension AllTests.ReconstructionTests {
 
@@ -59,37 +59,31 @@ extension AllTests.ReconstructionTests {
     expectEqual(p.components.map(\.description), ["foo", "bar"])
   }
 
-  @Test
+  @Test(.windowsOnly)
   func reconstructWindowsDriveAbsolute() {
-    withPlatform(.windows) {
-      let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor(#"C:\"#), comps("foo", "bar"))
-      // Anchor ends in a separator, so no gap separator is inserted.
-      expectEqual(p.description, #"C:\foo\bar"#, "C:\\ reconstruction")
-      expectTrue(p.anchor?.description == #"C:\"#, "anchor is C:\\")
-    }
-  }
+    let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor(#"C:\"#), comps("foo", "bar"))
+    // Anchor ends in a separator, so no gap separator is inserted.
+    expectEqual(p.description, #"C:\foo\bar"#, "C:\\ reconstruction")
+    expectTrue(p.anchor?.description == #"C:\"#, "anchor is C:\\")
+}
 
-  @Test
+  @Test(.windowsOnly)
   func reconstructWindowsDriveRelative() {
-    withPlatform(.windows) {
-      let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("C:"), comps("foo", "bar"))
-      // Drive-relative `C:`: the colon is the boundary, so NO gap separator —
-      // `C:foo\bar`, not `C:\foo\bar` (which is a different anchor).
-      expectEqual(p.description, #"C:foo\bar"#, "C: (drive-relative) reconstruction")
-      expectTrue(p.anchor?.description == "C:", "anchor is C:")
-      expectFalse(p.isAbsolute, "C:foo\\bar is relative")
-    }
-  }
+    let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("C:"), comps("foo", "bar"))
+    // Drive-relative `C:`: the colon is the boundary, so no gap separator,
+    // `C:foo\bar`, not `C:\foo\bar` (which is a different anchor).
+    expectEqual(p.description, #"C:foo\bar"#, "C: (drive-relative) reconstruction")
+    expectTrue(p.anchor?.description == "C:", "anchor is C:")
+    expectFalse(p.isAbsolute, "C:foo\\bar is relative")
+}
 
-  @Test
+  @Test(.darwinOnly)
   func reconstructDarwinNofollow() {
-    withPlatform(.darwin) {
-      let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("/.nofollow/"), comps("foo", "bar"))
-      expectEqual(p.description, "/.nofollow/foo/bar", "/.nofollow/ reconstruction")
-      expectTrue(p.anchor?.description == "/.nofollow/", "anchor is /.nofollow/")
-      expectEqual(p.components.map(\.description), ["foo", "bar"])
-    }
-  }
+    let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("/.nofollow/"), comps("foo", "bar"))
+    expectEqual(p.description, "/.nofollow/foo/bar", "/.nofollow/ reconstruction")
+    expectTrue(p.anchor?.description == "/.nofollow/", "anchor is /.nofollow/")
+    expectEqual(p.components.map(\.description), ["foo", "bar"])
+}
 
   @Test
   func reconstructTrailingSeparatorFlag() {
@@ -119,7 +113,7 @@ extension AllTests.ReconstructionTests {
 
       // Trailing separator on an anchor that doesn't already end in one:
       // \\server\share is a complete root, so the appended `\` is a trailing
-      // separator (proposal line 561).
+      // separator.
       let unc = _StdlibFilePath(
         anchor: _StdlibFilePath.Anchor(#"\\server\share"#),
         [] as [_StdlibFilePath.Component],
@@ -131,44 +125,40 @@ extension AllTests.ReconstructionTests {
 
   // MARK: - Darwin init(anchor:_:resourceFork:)
 
-  @Test
+  @Test(.darwinOnly)
   func reconstructDarwinResourceFork() {
-    withPlatform(.darwin) {
-      let p = _StdlibFilePath(
-        anchor: _StdlibFilePath.Anchor("/"), comps("foo", "bar"), resourceFork: true)
-      expectEqual(p.description, "/foo/bar/..namedfork/rsrc",
-        "resource-fork reconstruction")
-      expectTrue(p.isResourceFork, "isResourceFork is true")
-      // Mutual exclusivity with a trailing separator.
-      expectFalse(p.hasTrailingSeparator,
-        "resource fork excludes trailing separator")
-      // The suffix is not presented as components.
-      expectEqual(p.components.map(\.description), ["foo", "bar"],
-        "suffix is not a component")
-    }
-  }
+    let p = _StdlibFilePath(
+      anchor: _StdlibFilePath.Anchor("/"), comps("foo", "bar"), resourceFork: true)
+    expectEqual(p.description, "/foo/bar/..namedfork/rsrc",
+      "resource-fork reconstruction")
+    expectTrue(p.isResourceFork, "isResourceFork is true")
+    // Mutual exclusivity with a trailing separator.
+    expectFalse(p.hasTrailingSeparator,
+      "resource fork excludes trailing separator")
+    // The suffix is not presented as components.
+    expectEqual(p.components.map(\.description), ["foo", "bar"],
+      "suffix is not a component")
+}
 
   // MARK: - Emergent semantics under reconstruction
 
   // The reconstructed path normalizes as if the equivalent string literal were
-  // provided (proposal line 481). Building `/` + [".nofollow", "foo"] yields the
-  // bytes `/.nofollow/foo`, which re-decompose so the `.nofollow` is ABSORBED
-  // into the anchor — exactly as _StdlibFilePath("/.nofollow/foo") would.
-  @Test
+  // provided. Building `/` + [".nofollow", "foo"] yields the
+  // bytes `/.nofollow/foo`, which re-decompose so the `.nofollow` is absorbed
+  // into the anchor, exactly as _StdlibFilePath("/.nofollow/foo") would.
+  @Test(.darwinOnly)
   func reconstructDarwinAnchorAbsorption() {
-    withPlatform(.darwin) {
-      let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("/"), comps(".nofollow", "foo"))
-      // Proposal-derived expectation (NOT read from the implementation first):
-      expectEqual(p.description, "/.nofollow/foo", "absorbed printed form")
-      expectTrue(p.anchor?.description == "/.nofollow/",
-        ".nofollow absorbed into anchor")
-      expectEqual(p.components.map(\.description), ["foo"],
-        "only foo remains a component")
-      // Equivalent to constructing from the string literal.
-      expectEqual(p, _StdlibFilePath("/.nofollow/foo"),
-        "reconstruction == equivalent string literal")
-    }
-  }
+    let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("/"), comps(".nofollow", "foo"))
+    // Proposal-derived expectation (not read from the implementation first):
+    expectEqual(p.description, "/.nofollow/foo", "absorbed printed form")
+    expectTrue(p.anchor?.description == "/.nofollow/",
+      ".nofollow absorbed into anchor")
+    expectEqual(p.components.map(\.description), ["foo"],
+      "only foo remains a component")
+    // Equivalent to constructing from the string literal.
+    expectEqual(p, _StdlibFilePath("/.nofollow/foo"),
+      "reconstruction == equivalent string literal")
+}
 
   // MARK: - hasTrailingSeparator setter + with/without
 
@@ -205,7 +195,7 @@ extension AllTests.ReconstructionTests {
   @Test
   func trailingSeparatorAnchorOnly() {
     // The basic root's separator is structural (part of the anchor), so it is
-    // NOT a trailing separator and cannot be "added".
+    // not a trailing separator and cannot be "added".
     let root = _StdlibFilePath("/")
     expectFalse(root.hasTrailingSeparator,
       "basic root has no trailing separator")
@@ -214,7 +204,7 @@ extension AllTests.ReconstructionTests {
 
     withPlatform(.windows) {
       // \\server\share is a complete root; adding a separator yields a real
-      // trailing separator (proposal lines 561, 573).
+      // trailing separator.
       let unc = _StdlibFilePath(#"\\server\share"#)
       expectFalse(unc.hasTrailingSeparator, "bare UNC has no trailing separator")
       let withSep = unc.withTrailingSeparator()
@@ -225,80 +215,70 @@ extension AllTests.ReconstructionTests {
 
   // MARK: - Darwin isResourceFork setter + with/without + suffix swap
 
-  @Test
+  @Test(.darwinOnly)
   func resourceForkSetter() {
-    withPlatform(.darwin) {
-      let base = _StdlibFilePath("/foo")
-      expectFalse(base.isResourceFork, "plain path is not a resource fork")
+    let base = _StdlibFilePath("/foo")
+    expectFalse(base.isResourceFork, "plain path is not a resource fork")
 
-      let forked = base.withResourceFork()
-      expectEqual(forked.description, "/foo/..namedfork/rsrc", "adds suffix")
-      expectTrue(forked.isResourceFork, "isResourceFork true")
+    let forked = base.withResourceFork()
+    expectEqual(forked.description, "/foo/..namedfork/rsrc", "adds suffix")
+    expectTrue(forked.isResourceFork, "isResourceFork true")
 
-      let unforked = forked.withoutResourceFork()
-      expectEqual(unforked.description, "/foo", "removes suffix")
-      expectFalse(unforked.isResourceFork, "isResourceFork false")
-      // withoutResourceFork on a plain path is a no-op.
-      expectEqual(base.withoutResourceFork().description, "/foo", "no-op")
-    }
-  }
+    let unforked = forked.withoutResourceFork()
+    expectEqual(unforked.description, "/foo", "removes suffix")
+    expectFalse(unforked.isResourceFork, "isResourceFork false")
+    // withoutResourceFork on a plain path is a no-op.
+    expectEqual(base.withoutResourceFork().description, "/foo", "no-op")
+}
 
-  @Test
+  @Test(.darwinOnly)
   func suffixSwapTrailingToResourceFork() {
-    withPlatform(.darwin) {
-      // Setting isResourceFork on a path with a trailing separator REPLACES the
-      // separator with the resource-fork suffix (proposal lines 449-452).
-      var p = _StdlibFilePath("/foo/")
-      expectTrue(p.hasTrailingSeparator, "starts with trailing separator")
-      p.isResourceFork = true
-      expectEqual(p.description, "/foo/..namedfork/rsrc", "separator -> resource fork")
-      expectTrue(p.isResourceFork, "now a resource fork")
-      expectFalse(p.hasTrailingSeparator, "no longer a trailing separator")
-    }
-  }
+    // Setting isResourceFork on a path with a trailing separator replaces the
+    // separator with the resource-fork suffix.
+    var p = _StdlibFilePath("/foo/")
+    expectTrue(p.hasTrailingSeparator, "starts with trailing separator")
+    p.isResourceFork = true
+    expectEqual(p.description, "/foo/..namedfork/rsrc", "separator -> resource fork")
+    expectTrue(p.isResourceFork, "now a resource fork")
+    expectFalse(p.hasTrailingSeparator, "no longer a trailing separator")
+}
 
-  @Test
+  @Test(.darwinOnly)
   func suffixSwapResourceForkToTrailing() {
-    withPlatform(.darwin) {
-      // Setting hasTrailingSeparator on a resource-fork path REPLACES the suffix
-      // with a trailing separator (proposal lines 413-415).
-      var p = _StdlibFilePath("/foo/..namedfork/rsrc")
-      expectTrue(p.isResourceFork, "starts as resource fork")
-      p.hasTrailingSeparator = true
-      expectEqual(p.description, "/foo/", "resource fork -> separator")
-      expectTrue(p.hasTrailingSeparator, "now a trailing separator")
-      expectFalse(p.isResourceFork, "no longer a resource fork")
-    }
-  }
+    // Setting hasTrailingSeparator on a resource-fork path replaces the suffix
+    // with a trailing separator.
+    var p = _StdlibFilePath("/foo/..namedfork/rsrc")
+    expectTrue(p.isResourceFork, "starts as resource fork")
+    p.hasTrailingSeparator = true
+    expectEqual(p.description, "/foo/", "resource fork -> separator")
+    expectTrue(p.hasTrailingSeparator, "now a trailing separator")
+    expectFalse(p.isResourceFork, "no longer a resource fork")
+}
 
   // MARK: - anchor get/set
 
-  @Test
+  @Test(.windowsOnly)
   func anchorTransplantToVerbatim() {
-    withPlatform(.windows) {
-      // Proposal example (lines 46-50).
-      var p = _StdlibFilePath(#"C:\Users\dev\project"#)
-      expectTrue(p.anchor?.description == #"C:\"#, "starts as C:\\")
-      expectTrue(p.anchor?._isVerbatimComponent == false, "not verbatim initially")
+    // Example from SE-0529.
+    var p = _StdlibFilePath(#"C:\Users\dev\project"#)
+    expectTrue(p.anchor?.description == #"C:\"#, "starts as C:\\")
+    expectTrue(p.anchor?._isVerbatimComponent == false, "not verbatim initially")
 
-      p.anchor = _StdlibFilePath.Anchor(#"\\?\C:\"#)
-      expectEqual(p.description, #"\\?\C:\Users\dev\project"#, "transplanted to verbatim")
-      expectTrue(p.anchor?._isVerbatimComponent == true, "now verbatim")
-      expectTrue(p.anchor?._driveLetter == "C", "drive letter preserved")
-    }
-  }
+    p.anchor = _StdlibFilePath.Anchor(#"\\?\C:\"#)
+    expectEqual(p.description, #"\\?\C:\Users\dev\project"#, "transplanted to verbatim")
+    expectTrue(p.anchor?._isVerbatimComponent == true, "now verbatim")
+    expectTrue(p.anchor?._driveLetter == "C", "drive letter preserved")
+}
 
-  @Test
+  @Test(.darwinOnly)
   func anchorStripDarwinToRoot() {
-    withPlatform(.darwin) {
-      // Proposal example (lines 52-55).
-      var p = _StdlibFilePath("/.nofollow/etc/passwd")
-      expectTrue(p.anchor?.description == "/.nofollow/", "starts as /.nofollow/")
-      p.anchor = _StdlibFilePath.Anchor("/")
-      expectEqual(p.description, "/etc/passwd", "stripped to /")
-      expectTrue(p.anchor?.description == "/", "anchor now /")
-    }
-  }
+    // Example from SE-0529.
+    var p = _StdlibFilePath("/.nofollow/etc/passwd")
+    expectTrue(p.anchor?.description == "/.nofollow/", "starts as /.nofollow/")
+    p.anchor = _StdlibFilePath.Anchor("/")
+    expectEqual(p.description, "/etc/passwd", "stripped to /")
+    expectTrue(p.anchor?.description == "/", "anchor now /")
+}
 
   @Test
   func anchorSetToNil() {

--- a/Tests/SystemTests/StdlibFilePathTests/ReconstructionTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ReconstructionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -65,7 +65,7 @@ extension AllTests.ReconstructionTests {
     // Anchor ends in a separator, so no gap separator is inserted.
     expectEqual(p.description, #"C:\foo\bar"#, "C:\\ reconstruction")
     expectTrue(p.anchor?.description == #"C:\"#, "anchor is C:\\")
-}
+  }
 
   @Test(.windowsOnly)
   func reconstructWindowsDriveRelative() {
@@ -75,7 +75,7 @@ extension AllTests.ReconstructionTests {
     expectEqual(p.description, #"C:foo\bar"#, "C: (drive-relative) reconstruction")
     expectTrue(p.anchor?.description == "C:", "anchor is C:")
     expectFalse(p.isAbsolute, "C:foo\\bar is relative")
-}
+  }
 
   @Test(.darwinOnly)
   func reconstructDarwinNofollow() {
@@ -83,7 +83,7 @@ extension AllTests.ReconstructionTests {
     expectEqual(p.description, "/.nofollow/foo/bar", "/.nofollow/ reconstruction")
     expectTrue(p.anchor?.description == "/.nofollow/", "anchor is /.nofollow/")
     expectEqual(p.components.map(\.description), ["foo", "bar"])
-}
+  }
 
   @Test
   func reconstructTrailingSeparatorFlag() {
@@ -138,14 +138,14 @@ extension AllTests.ReconstructionTests {
     // The suffix is not presented as components.
     expectEqual(p.components.map(\.description), ["foo", "bar"],
       "suffix is not a component")
-}
+  }
 
   // MARK: - Emergent semantics under reconstruction
 
   // The reconstructed path normalizes as if the equivalent string literal were
-  // provided. Building `/` + [".nofollow", "foo"] yields the
-  // bytes `/.nofollow/foo`, which re-decompose so the `.nofollow` is absorbed
-  // into the anchor, exactly as _StdlibFilePath("/.nofollow/foo") would.
+  // provided. Building `/` + [".nofollow", "foo"] yields the bytes
+  // `/.nofollow/foo`, which re-decompose so the `.nofollow` is absorbed into
+  // the anchor, exactly as _StdlibFilePath("/.nofollow/foo") would.
   @Test(.darwinOnly)
   func reconstructDarwinAnchorAbsorption() {
     let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("/"), comps(".nofollow", "foo"))
@@ -158,7 +158,7 @@ extension AllTests.ReconstructionTests {
     // Equivalent to constructing from the string literal.
     expectEqual(p, _StdlibFilePath("/.nofollow/foo"),
       "reconstruction == equivalent string literal")
-}
+  }
 
   // MARK: - hasTrailingSeparator setter + with/without
 
@@ -229,7 +229,7 @@ extension AllTests.ReconstructionTests {
     expectFalse(unforked.isResourceFork, "isResourceFork false")
     // withoutResourceFork on a plain path is a no-op.
     expectEqual(base.withoutResourceFork().description, "/foo", "no-op")
-}
+  }
 
   @Test(.darwinOnly)
   func suffixSwapTrailingToResourceFork() {
@@ -241,7 +241,7 @@ extension AllTests.ReconstructionTests {
     expectEqual(p.description, "/foo/..namedfork/rsrc", "separator -> resource fork")
     expectTrue(p.isResourceFork, "now a resource fork")
     expectFalse(p.hasTrailingSeparator, "no longer a trailing separator")
-}
+  }
 
   @Test(.darwinOnly)
   func suffixSwapResourceForkToTrailing() {
@@ -253,7 +253,7 @@ extension AllTests.ReconstructionTests {
     expectEqual(p.description, "/foo/", "resource fork -> separator")
     expectTrue(p.hasTrailingSeparator, "now a trailing separator")
     expectFalse(p.isResourceFork, "no longer a resource fork")
-}
+  }
 
   // MARK: - anchor get/set
 
@@ -268,7 +268,7 @@ extension AllTests.ReconstructionTests {
     expectEqual(p.description, #"\\?\C:\Users\dev\project"#, "transplanted to verbatim")
     expectTrue(p.anchor?._isVerbatimComponent == true, "now verbatim")
     expectTrue(p.anchor?._driveLetter == "C", "drive letter preserved")
-}
+  }
 
   @Test(.darwinOnly)
   func anchorStripDarwinToRoot() {
@@ -278,7 +278,7 @@ extension AllTests.ReconstructionTests {
     p.anchor = _StdlibFilePath.Anchor("/")
     expectEqual(p.description, "/etc/passwd", "stripped to /")
     expectTrue(p.anchor?.description == "/", "anchor now /")
-}
+  }
 
   @Test
   func anchorSetToNil() {

--- a/Tests/SystemTests/StdlibFilePathTests/ReconstructionTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ReconstructionTests.swift
@@ -1,0 +1,334 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// Reconstruction and the suffix/anchor setters as direct API. These were
+// previously exercised only as the round-trip tail of decomposition
+// (DecompositionTests.runCase). Here they are driven directly with
+// caller-built parts. Expectations from SE-0529:
+//   * "Path reconstruction" (477-517): `init(anchor:_:hasTrailingSeparator:)`
+//     and the Darwin `init(anchor:_:resourceFork:)`. The reconstructed path
+//     "parses and normalizes exactly as if the equivalent string literal had
+//     been provided."
+//   * "Trailing separators" (400-427): `hasTrailingSeparator` get/set,
+//     `withTrailingSeparator()`, `withoutTrailingSeparator()`.
+//   * "Resource forks" (438-472): `isResourceFork` get/set,
+//     `withResourceFork()`, `withoutResourceFork()`, and the documented
+//     trailing-separator <-> resource-fork swap.
+//   * `anchor` get/set (174-201; examples at 46-55).
+
+extension AllTests.ReconstructionTests {
+
+  // Build component arrays inside the active platform (Component init consults
+  // the platform for its separator check).
+  private func comps(_ names: String...) -> [_StdlibFilePath.Component] {
+    names.map { _StdlibFilePath.Component($0)! }
+  }
+
+  // MARK: - init(anchor:_:hasTrailingSeparator:)
+
+  @Test
+  func reconstructRelativeNilAnchor() {
+    let p = _StdlibFilePath(anchor: nil, comps("foo", "bar"))
+    expectEqual(p.description, universal("foo/bar"), "relative reconstruction")
+    expectNil(p.anchor, "nil anchor stays relative")
+    expectEqual(p.components.map(\.description), ["foo", "bar"])
+  }
+
+  @Test
+  func reconstructBasicRoot() {
+    // The basic-root anchor: `/` on unix, `\` on Windows after slash
+    // conversion. Use `universal()` to express the platform-varying spelling.
+    let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("/"), comps("foo", "bar"))
+    expectEqual(p.description, universal("/foo/bar"),
+      "basic-root reconstruction")
+    expectEqual(p.anchor?.description, universal("/"),
+      "anchor is the basic root")
+    expectEqual(p.components.map(\.description), ["foo", "bar"])
+  }
+
+  @Test
+  func reconstructWindowsDriveAbsolute() {
+    withPlatform(.windows) {
+      let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor(#"C:\"#), comps("foo", "bar"))
+      // Anchor ends in a separator, so no gap separator is inserted.
+      expectEqual(p.description, #"C:\foo\bar"#, "C:\\ reconstruction")
+      expectTrue(p.anchor?.description == #"C:\"#, "anchor is C:\\")
+    }
+  }
+
+  @Test
+  func reconstructWindowsDriveRelative() {
+    withPlatform(.windows) {
+      let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("C:"), comps("foo", "bar"))
+      // Drive-relative `C:`: the colon is the boundary, so NO gap separator —
+      // `C:foo\bar`, not `C:\foo\bar` (which is a different anchor).
+      expectEqual(p.description, #"C:foo\bar"#, "C: (drive-relative) reconstruction")
+      expectTrue(p.anchor?.description == "C:", "anchor is C:")
+      expectFalse(p.isAbsolute, "C:foo\\bar is relative")
+    }
+  }
+
+  @Test
+  func reconstructDarwinNofollow() {
+    withPlatform(.darwin) {
+      let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("/.nofollow/"), comps("foo", "bar"))
+      expectEqual(p.description, "/.nofollow/foo/bar", "/.nofollow/ reconstruction")
+      expectTrue(p.anchor?.description == "/.nofollow/", "anchor is /.nofollow/")
+      expectEqual(p.components.map(\.description), ["foo", "bar"])
+    }
+  }
+
+  @Test
+  func reconstructTrailingSeparatorFlag() {
+    let withSep = _StdlibFilePath(
+      anchor: _StdlibFilePath.Anchor("/"), comps("foo"), hasTrailingSeparator: true)
+    expectEqual(withSep.description, universal("/foo/"),
+      "hasTrailingSeparator: true")
+    expectTrue(withSep.hasTrailingSeparator, "trailing separator present")
+
+    let noSep = _StdlibFilePath(
+      anchor: _StdlibFilePath.Anchor("/"), comps("foo"), hasTrailingSeparator: false)
+    expectEqual(noSep.description, universal("/foo"),
+      "hasTrailingSeparator: false")
+    expectFalse(noSep.hasTrailingSeparator, "no trailing separator")
+  }
+
+  @Test
+  func reconstructEmptyComponentsWithAnchor() {
+    let root = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("/"), [] as [_StdlibFilePath.Component])
+    expectEqual(root.description, universal("/"), "anchor-only basic root")
+    expectTrue(root.components.isEmpty, "no components")
+
+    withPlatform(.windows) {
+      let drive = _StdlibFilePath(anchor: _StdlibFilePath.Anchor(#"C:\"#), [] as [_StdlibFilePath.Component])
+      expectEqual(drive.description, #"C:\"#, "anchor-only C:\\")
+      expectTrue(drive.components.isEmpty, "no components")
+
+      // Trailing separator on an anchor that doesn't already end in one:
+      // \\server\share is a complete root, so the appended `\` is a trailing
+      // separator (proposal line 561).
+      let unc = _StdlibFilePath(
+        anchor: _StdlibFilePath.Anchor(#"\\server\share"#),
+        [] as [_StdlibFilePath.Component],
+        hasTrailingSeparator: true)
+      expectEqual(unc.description, #"\\server\share\"#, "UNC + trailing separator")
+      expectTrue(unc.hasTrailingSeparator, "UNC trailing separator present")
+    }
+  }
+
+  // MARK: - Darwin init(anchor:_:resourceFork:)
+
+  @Test
+  func reconstructDarwinResourceFork() {
+    withPlatform(.darwin) {
+      let p = _StdlibFilePath(
+        anchor: _StdlibFilePath.Anchor("/"), comps("foo", "bar"), resourceFork: true)
+      expectEqual(p.description, "/foo/bar/..namedfork/rsrc",
+        "resource-fork reconstruction")
+      expectTrue(p.isResourceFork, "isResourceFork is true")
+      // Mutual exclusivity with a trailing separator.
+      expectFalse(p.hasTrailingSeparator,
+        "resource fork excludes trailing separator")
+      // The suffix is not presented as components.
+      expectEqual(p.components.map(\.description), ["foo", "bar"],
+        "suffix is not a component")
+    }
+  }
+
+  // MARK: - Emergent semantics under reconstruction
+
+  // The reconstructed path normalizes as if the equivalent string literal were
+  // provided (proposal line 481). Building `/` + [".nofollow", "foo"] yields the
+  // bytes `/.nofollow/foo`, which re-decompose so the `.nofollow` is ABSORBED
+  // into the anchor — exactly as _StdlibFilePath("/.nofollow/foo") would.
+  @Test
+  func reconstructDarwinAnchorAbsorption() {
+    withPlatform(.darwin) {
+      let p = _StdlibFilePath(anchor: _StdlibFilePath.Anchor("/"), comps(".nofollow", "foo"))
+      // Proposal-derived expectation (NOT read from the implementation first):
+      expectEqual(p.description, "/.nofollow/foo", "absorbed printed form")
+      expectTrue(p.anchor?.description == "/.nofollow/",
+        ".nofollow absorbed into anchor")
+      expectEqual(p.components.map(\.description), ["foo"],
+        "only foo remains a component")
+      // Equivalent to constructing from the string literal.
+      expectEqual(p, _StdlibFilePath("/.nofollow/foo"),
+        "reconstruction == equivalent string literal")
+    }
+  }
+
+  // MARK: - hasTrailingSeparator setter + with/without
+
+  @Test
+  func trailingSeparatorSetter() {
+    var p = _StdlibFilePath("/foo")
+    expectFalse(p.hasTrailingSeparator, "starts without")
+
+    p.hasTrailingSeparator = true
+    expectEqual(p.description, universal("/foo/"), "set true adds separator")
+
+    p.hasTrailingSeparator = true  // no-op
+    expectEqual(p.description, universal("/foo/"), "set true again is a no-op")
+
+    p.hasTrailingSeparator = false
+    expectEqual(p.description, universal("/foo"), "set false removes separator")
+
+    p.hasTrailingSeparator = false  // no-op
+    expectEqual(p.description, universal("/foo"), "set false again is a no-op")
+  }
+
+  @Test
+  func withTrailingSeparatorMethods() {
+    expectEqual(_StdlibFilePath("/foo").withTrailingSeparator().description,
+      universal("/foo/"), "adds separator")
+    expectEqual(_StdlibFilePath("/foo/").withTrailingSeparator().description,
+      universal("/foo/"), "no-op when already present")
+    expectEqual(_StdlibFilePath("/foo/").withoutTrailingSeparator().description,
+      universal("/foo"), "removes separator")
+    expectEqual(_StdlibFilePath("/foo").withoutTrailingSeparator().description,
+      universal("/foo"), "no-op when absent")
+  }
+
+  @Test
+  func trailingSeparatorAnchorOnly() {
+    // The basic root's separator is structural (part of the anchor), so it is
+    // NOT a trailing separator and cannot be "added".
+    let root = _StdlibFilePath("/")
+    expectFalse(root.hasTrailingSeparator,
+      "basic root has no trailing separator")
+    expectEqual(root.withTrailingSeparator().description, universal("/"),
+      "withTrailingSeparator on basic root is a no-op")
+
+    withPlatform(.windows) {
+      // \\server\share is a complete root; adding a separator yields a real
+      // trailing separator (proposal lines 561, 573).
+      let unc = _StdlibFilePath(#"\\server\share"#)
+      expectFalse(unc.hasTrailingSeparator, "bare UNC has no trailing separator")
+      let withSep = unc.withTrailingSeparator()
+      expectEqual(withSep.description, #"\\server\share\"#, "UNC + separator")
+      expectTrue(withSep.hasTrailingSeparator, "now has trailing separator")
+    }
+  }
+
+  // MARK: - Darwin isResourceFork setter + with/without + suffix swap
+
+  @Test
+  func resourceForkSetter() {
+    withPlatform(.darwin) {
+      let base = _StdlibFilePath("/foo")
+      expectFalse(base.isResourceFork, "plain path is not a resource fork")
+
+      let forked = base.withResourceFork()
+      expectEqual(forked.description, "/foo/..namedfork/rsrc", "adds suffix")
+      expectTrue(forked.isResourceFork, "isResourceFork true")
+
+      let unforked = forked.withoutResourceFork()
+      expectEqual(unforked.description, "/foo", "removes suffix")
+      expectFalse(unforked.isResourceFork, "isResourceFork false")
+      // withoutResourceFork on a plain path is a no-op.
+      expectEqual(base.withoutResourceFork().description, "/foo", "no-op")
+    }
+  }
+
+  @Test
+  func suffixSwapTrailingToResourceFork() {
+    withPlatform(.darwin) {
+      // Setting isResourceFork on a path with a trailing separator REPLACES the
+      // separator with the resource-fork suffix (proposal lines 449-452).
+      var p = _StdlibFilePath("/foo/")
+      expectTrue(p.hasTrailingSeparator, "starts with trailing separator")
+      p.isResourceFork = true
+      expectEqual(p.description, "/foo/..namedfork/rsrc", "separator -> resource fork")
+      expectTrue(p.isResourceFork, "now a resource fork")
+      expectFalse(p.hasTrailingSeparator, "no longer a trailing separator")
+    }
+  }
+
+  @Test
+  func suffixSwapResourceForkToTrailing() {
+    withPlatform(.darwin) {
+      // Setting hasTrailingSeparator on a resource-fork path REPLACES the suffix
+      // with a trailing separator (proposal lines 413-415).
+      var p = _StdlibFilePath("/foo/..namedfork/rsrc")
+      expectTrue(p.isResourceFork, "starts as resource fork")
+      p.hasTrailingSeparator = true
+      expectEqual(p.description, "/foo/", "resource fork -> separator")
+      expectTrue(p.hasTrailingSeparator, "now a trailing separator")
+      expectFalse(p.isResourceFork, "no longer a resource fork")
+    }
+  }
+
+  // MARK: - anchor get/set
+
+  @Test
+  func anchorTransplantToVerbatim() {
+    withPlatform(.windows) {
+      // Proposal example (lines 46-50).
+      var p = _StdlibFilePath(#"C:\Users\dev\project"#)
+      expectTrue(p.anchor?.description == #"C:\"#, "starts as C:\\")
+      expectTrue(p.anchor?._isVerbatimComponent == false, "not verbatim initially")
+
+      p.anchor = _StdlibFilePath.Anchor(#"\\?\C:\"#)
+      expectEqual(p.description, #"\\?\C:\Users\dev\project"#, "transplanted to verbatim")
+      expectTrue(p.anchor?._isVerbatimComponent == true, "now verbatim")
+      expectTrue(p.anchor?._driveLetter == "C", "drive letter preserved")
+    }
+  }
+
+  @Test
+  func anchorStripDarwinToRoot() {
+    withPlatform(.darwin) {
+      // Proposal example (lines 52-55).
+      var p = _StdlibFilePath("/.nofollow/etc/passwd")
+      expectTrue(p.anchor?.description == "/.nofollow/", "starts as /.nofollow/")
+      p.anchor = _StdlibFilePath.Anchor("/")
+      expectEqual(p.description, "/etc/passwd", "stripped to /")
+      expectTrue(p.anchor?.description == "/", "anchor now /")
+    }
+  }
+
+  @Test
+  func anchorSetToNil() {
+    var p = _StdlibFilePath("/foo/bar")
+    p.anchor = nil
+    expectEqual(p.description, universal("foo/bar"),
+      "anchor removed -> relative")
+    expectNil(p.anchor, "anchor is nil")
+    expectFalse(p.isAbsolute, "now relative")
+  }
+
+  @Test
+  func anchorSetOntoRelative() {
+    var p = _StdlibFilePath("foo/bar")
+    expectNil(p.anchor, "starts relative")
+    p.anchor = _StdlibFilePath.Anchor("/")
+    expectEqual(p.description, universal("/foo/bar"), "anchor added")
+    // The basic root is fully qualified on unix but is the current-drive root
+    // (not absolute) on Windows. Pin only the unix half here; the Windows
+    // drive-relative case is covered below.
+    withPlatforms(.linux, .darwin) {
+      expectTrue(p.isAbsolute, "now absolute")
+    }
+    withPlatform(.windows) {
+      // Drive-relative anchor onto a relative path: no gap separator inserted.
+      var q = _StdlibFilePath(#"foo\bar"#)
+      expectNil(q.anchor, "starts relative")
+      q.anchor = _StdlibFilePath.Anchor("C:")
+      expectEqual(q.description, #"C:foo\bar"#, "C: prepended without a gap separator")
+      expectFalse(q.isAbsolute, "drive-relative is not absolute")
+    }
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/ResolveTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ResolveTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -92,7 +92,7 @@ struct ResolveTests {
     let s = String(decoding: resolved)
     expectFalse(s.hasPrefix("/var/"),
       "resolve() did not follow /var symlink: \(s)")
-}
+  }
 
   // MARK: - Resolving through a symlink yields the link target
 
@@ -115,7 +115,7 @@ struct ResolveTests {
       "link should resolve to the same path as the target: "
       + "got link → \(String(decoding: resolvedLink)) "
       + "and target → \(String(decoding: resolvedTarget))")
-}
+  }
 
   // MARK: - Nonexistent path throws
 
@@ -125,7 +125,7 @@ struct ResolveTests {
     let p = _StdlibFilePath(
       "/this/path/does/not/exist/anywhere/\(UUID().uuidString)")!
     _expectThrowsResolveError { _ = try p.resolve() }
-}
+  }
 
   // MARK: - Firmlink check (go/no-go for the no-FSOPT approach)
   //
@@ -142,8 +142,8 @@ struct ResolveTests {
     let resolved = try _StdlibFilePath(home)!.resolve()
     let s = String(decoding: resolved)
     expectFalse(s.hasPrefix("/System/Volumes/Data/"),
-      "resolve(\(home)) returned the non-firmlinked underlay: \(s) "
-      + "the no-FSOPT default does not produce firmlinked paths on "
-      + "this build, so the no-SPI approach is invalid")
-}
+      "resolve(\(home)) returned the non-firmlinked underlay: \(s). "
+      + "The no-FSOPT default does not produce firmlinked paths on this "
+      + "build, so the no-SPI approach is invalid")
+  }
 }

--- a/Tests/SystemTests/StdlibFilePathTests/ResolveTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ResolveTests.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,18 +15,14 @@ import Foundation
 @testable import System
 #endif
 
-// `_StdlibFilePath.resolve()` is a filesystem-touching API: tests need a real OS,
-// real syscalls, and real fixtures. The Darwin implementation uses
+// `_StdlibFilePath.resolve()` touches the filesystem, so these tests need a
+// real OS, real syscalls, and real fixtures. The Darwin implementation uses
 // `getattrlistat(ATTR_CMN_FULLPATH, FSOPT_ATTR_CMN_EXTENDED |
-// FSOPT_RETURN_REALDEV)` — *no* `realpath`, *no* `FSOPT_AUTOFIRMLINKPATH`
-// (the firmlink-aware private flag is unavailable from public SDKs and the
-// no-flag default already returns the firmlinked path for everything we
-// care about — pinned by `firmlinkedHomeRealPath` below). All tests run only
-// on the Darwin build via `withPlatform(.darwin)`; on other builds the
-// bodies are inert.
-//
-// Top-level suite (separate from `AllTests`) so we don't have to add a
-// nested struct to AllTests.swift. Mirrors the `SystemStringTests` pattern.
+// FSOPT_RETURN_REALDEV)`, with no `realpath` and no `FSOPT_AUTOFIRMLINKPATH`:
+// the firmlink-aware private flag is unavailable from public SDKs, and the
+// no-flag default already returns the firmlinked path for everything we care
+// about, which `firmlinkedHomeRealPath` below pins. Every test here is
+// Darwin-only and reports as skipped on other builds.
 
 @Suite
 struct ResolveTests {
@@ -48,11 +44,10 @@ struct ResolveTests {
   }
 
   /// Asserts `body` throws a `_FilePathResolveError`. Equivalent to
-  /// `#expect(throws: _FilePathResolveError.self)` but expressed without the
-  /// throwing-assertion seam (which the TestSupport layer doesn't yet vend
-  /// — see `withCodeUnitsThrowsTypedError` for the established exception
-  /// pattern). Keeps the type check rather than a bare did-it-throw bool, so
-  /// a future unexpected-error-type regression fails loudly.
+  /// `#expect(throws: _FilePathResolveError.self)`, which the TestSupport seam
+  /// does not vend (see `withCodeUnitsThrowsTypedError` in ValidationTests for
+  /// the same exception). Checks the error type rather than only that
+  /// something threw, so an unexpected error type fails loudly.
   private func _expectThrowsResolveError(
     _ body: () throws -> Void,
     sourceLocation: SourceLocation = #_sourceLocation
@@ -72,71 +67,65 @@ struct ResolveTests {
 
   // MARK: - Real existing file resolves to absolute, symlink-free path
 
-  @Test
+  @Test(.darwinOnly)
   func realFileResolvesToAbsoluteSymlinkFreePath() throws {
-    try withPlatform(.darwin) {
-      let dir = try _makeTempDir()
-      defer { _cleanup(dir) }
+    let dir = try _makeTempDir()
+    defer { _cleanup(dir) }
 
-      let fileURL = dir.appendingPathComponent("hello.txt")
-      let created = FileManager.default.createFile(
-        atPath: fileURL.path, contents: Data())
-      expectTrue(created, "could not create fixture \(fileURL.path)")
+    let fileURL = dir.appendingPathComponent("hello.txt")
+    let created = FileManager.default.createFile(
+      atPath: fileURL.path, contents: Data())
+    expectTrue(created, "could not create fixture \(fileURL.path)")
 
-      // _StdlibFilePath.init? on a Foundation URL path can only fail on NUL,
-      // which these paths cannot contain — hence the bare `!`.
-      let resolved = try _StdlibFilePath(fileURL.path)!.resolve()
-      expectTrue(resolved.isAbsolute,
-        "resolve() should return an absolute path, got "
-        + String(decoding: resolved))
+    // _StdlibFilePath.init? on a Foundation URL path can only fail on NUL,
+    // which these paths cannot contain, hence the bare `!`.
+    let resolved = try _StdlibFilePath(fileURL.path)!.resolve()
+    expectTrue(resolved.isAbsolute,
+      "resolve() should return an absolute path, got "
+      + String(decoding: resolved))
 
-      // Symlink-free check: macOS exposes `/var` as a symlink to
-      // `/private/var`, and `FileManager.default.temporaryDirectory` lives
-      // under `/var/folders/...`. A correct `resolve()` follows that
-      // symlink and returns a `/private/var/...` path; a `/var/...` prefix
-      // means the symlink was not followed.
-      let s = String(decoding: resolved)
-      expectFalse(s.hasPrefix("/var/"),
-        "resolve() did not follow /var symlink: \(s)")
-    }
-  }
+    // Symlink-free check: macOS exposes `/var` as a symlink to
+    // `/private/var`, and `FileManager.default.temporaryDirectory` lives
+    // under `/var/folders/...`. A correct `resolve()` follows that
+    // symlink and returns a `/private/var/...` path; a `/var/...` prefix
+    // means the symlink was not followed.
+    let s = String(decoding: resolved)
+    expectFalse(s.hasPrefix("/var/"),
+      "resolve() did not follow /var symlink: \(s)")
+}
 
   // MARK: - Resolving through a symlink yields the link target
 
-  @Test
+  @Test(.darwinOnly)
   func resolvingThroughSymlinkYieldsTarget() throws {
-    try withPlatform(.darwin) {
-      let dir = try _makeTempDir()
-      defer { _cleanup(dir) }
+    let dir = try _makeTempDir()
+    defer { _cleanup(dir) }
 
-      let target = dir.appendingPathComponent("target.txt")
-      let link = dir.appendingPathComponent("link.txt")
-      _ = FileManager.default.createFile(
-        atPath: target.path, contents: Data())
-      try FileManager.default.createSymbolicLink(
-        at: link, withDestinationURL: target)
+    let target = dir.appendingPathComponent("target.txt")
+    let link = dir.appendingPathComponent("link.txt")
+    _ = FileManager.default.createFile(
+      atPath: target.path, contents: Data())
+    try FileManager.default.createSymbolicLink(
+      at: link, withDestinationURL: target)
 
-      let resolvedLink = try _StdlibFilePath(link.path)!.resolve()
-      let resolvedTarget = try _StdlibFilePath(target.path)!.resolve()
+    let resolvedLink = try _StdlibFilePath(link.path)!.resolve()
+    let resolvedTarget = try _StdlibFilePath(target.path)!.resolve()
 
-      expectEqual(resolvedLink, resolvedTarget,
-        "link should resolve to the same path as the target — "
-        + "got link → \(String(decoding: resolvedLink)) "
-        + "and target → \(String(decoding: resolvedTarget))")
-    }
-  }
+    expectEqual(resolvedLink, resolvedTarget,
+      "link should resolve to the same path as the target: "
+      + "got link → \(String(decoding: resolvedLink)) "
+      + "and target → \(String(decoding: resolvedTarget))")
+}
 
   // MARK: - Nonexistent path throws
 
-  @Test
+  @Test(.darwinOnly)
   func nonexistentPathThrows() {
-    withPlatform(.darwin) {
-      // Unique suffix to ensure we don't accidentally hit a real file.
-      let p = _StdlibFilePath(
-        "/this/path/does/not/exist/anywhere/\(UUID().uuidString)")!
-      _expectThrowsResolveError { _ = try p.resolve() }
-    }
-  }
+    // Unique suffix to ensure we don't accidentally hit a real file.
+    let p = _StdlibFilePath(
+      "/this/path/does/not/exist/anywhere/\(UUID().uuidString)")!
+    _expectThrowsResolveError { _ = try p.resolve() }
+}
 
   // MARK: - Firmlink check (go/no-go for the no-FSOPT approach)
   //
@@ -147,16 +136,14 @@ struct ResolveTests {
   // that prefix, our no-FSOPT_AUTOFIRMLINKPATH approach would be invalid
   // and the implementation would need the private SPI flag.
 
-  @Test
+  @Test(.darwinOnly)
   func firmlinkedHomeRealPath() throws {
-    try withPlatform(.darwin) {
-      let home = FileManager.default.homeDirectoryForCurrentUser.path
-      let resolved = try _StdlibFilePath(home)!.resolve()
-      let s = String(decoding: resolved)
-      expectFalse(s.hasPrefix("/System/Volumes/Data/"),
-        "resolve(\(home)) returned the non-firmlinked underlay: \(s) "
-        + "— the no-FSOPT default does not produce firmlinked paths on "
-        + "this build, so the no-SPI approach is invalid")
-    }
-  }
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    let resolved = try _StdlibFilePath(home)!.resolve()
+    let s = String(decoding: resolved)
+    expectFalse(s.hasPrefix("/System/Volumes/Data/"),
+      "resolve(\(home)) returned the non-firmlinked underlay: \(s) "
+      + "the no-FSOPT default does not produce firmlinked paths on "
+      + "this build, so the no-SPI approach is invalid")
+}
 }

--- a/Tests/SystemTests/StdlibFilePathTests/ResolveTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ResolveTests.swift
@@ -1,0 +1,162 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+import Foundation
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// `_StdlibFilePath.resolve()` is a filesystem-touching API: tests need a real OS,
+// real syscalls, and real fixtures. The Darwin implementation uses
+// `getattrlistat(ATTR_CMN_FULLPATH, FSOPT_ATTR_CMN_EXTENDED |
+// FSOPT_RETURN_REALDEV)` — *no* `realpath`, *no* `FSOPT_AUTOFIRMLINKPATH`
+// (the firmlink-aware private flag is unavailable from public SDKs and the
+// no-flag default already returns the firmlinked path for everything we
+// care about — pinned by `firmlinkedHomeRealPath` below). All tests run only
+// on the Darwin build via `withPlatform(.darwin)`; on other builds the
+// bodies are inert.
+//
+// Top-level suite (separate from `AllTests`) so we don't have to add a
+// nested struct to AllTests.swift. Mirrors the `SystemStringTests` pattern.
+
+@Suite
+struct ResolveTests {
+
+  // MARK: - Helpers
+
+  /// Make a fresh, unique temp directory under the system temp dir.
+  /// Caller is responsible for cleanup via `defer` + `_cleanup`.
+  private func _makeTempDir() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("filepath-resolve-tests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private func _cleanup(_ url: URL) {
+    _ = try? FileManager.default.removeItem(at: url)
+  }
+
+  /// Asserts `body` throws a `_FilePathResolveError`. Equivalent to
+  /// `#expect(throws: _FilePathResolveError.self)` but expressed without the
+  /// throwing-assertion seam (which the TestSupport layer doesn't yet vend
+  /// — see `withCodeUnitsThrowsTypedError` for the established exception
+  /// pattern). Keeps the type check rather than a bare did-it-throw bool, so
+  /// a future unexpected-error-type regression fails loudly.
+  private func _expectThrowsResolveError(
+    _ body: () throws -> Void,
+    sourceLocation: SourceLocation = #_sourceLocation
+  ) {
+    do {
+      try body()
+      expectTrue(false, "expected resolve() to throw",
+        sourceLocation: sourceLocation)
+    } catch is _FilePathResolveError {
+      // Expected.
+    } catch {
+      expectTrue(false,
+        "expected _FilePathResolveError, got \(type(of: error)): \(error)",
+        sourceLocation: sourceLocation)
+    }
+  }
+
+  // MARK: - Real existing file resolves to absolute, symlink-free path
+
+  @Test
+  func realFileResolvesToAbsoluteSymlinkFreePath() throws {
+    try withPlatform(.darwin) {
+      let dir = try _makeTempDir()
+      defer { _cleanup(dir) }
+
+      let fileURL = dir.appendingPathComponent("hello.txt")
+      let created = FileManager.default.createFile(
+        atPath: fileURL.path, contents: Data())
+      expectTrue(created, "could not create fixture \(fileURL.path)")
+
+      // _StdlibFilePath.init? on a Foundation URL path can only fail on NUL,
+      // which these paths cannot contain — hence the bare `!`.
+      let resolved = try _StdlibFilePath(fileURL.path)!.resolve()
+      expectTrue(resolved.isAbsolute,
+        "resolve() should return an absolute path, got "
+        + String(decoding: resolved))
+
+      // Symlink-free check: macOS exposes `/var` as a symlink to
+      // `/private/var`, and `FileManager.default.temporaryDirectory` lives
+      // under `/var/folders/...`. A correct `resolve()` follows that
+      // symlink and returns a `/private/var/...` path; a `/var/...` prefix
+      // means the symlink was not followed.
+      let s = String(decoding: resolved)
+      expectFalse(s.hasPrefix("/var/"),
+        "resolve() did not follow /var symlink: \(s)")
+    }
+  }
+
+  // MARK: - Resolving through a symlink yields the link target
+
+  @Test
+  func resolvingThroughSymlinkYieldsTarget() throws {
+    try withPlatform(.darwin) {
+      let dir = try _makeTempDir()
+      defer { _cleanup(dir) }
+
+      let target = dir.appendingPathComponent("target.txt")
+      let link = dir.appendingPathComponent("link.txt")
+      _ = FileManager.default.createFile(
+        atPath: target.path, contents: Data())
+      try FileManager.default.createSymbolicLink(
+        at: link, withDestinationURL: target)
+
+      let resolvedLink = try _StdlibFilePath(link.path)!.resolve()
+      let resolvedTarget = try _StdlibFilePath(target.path)!.resolve()
+
+      expectEqual(resolvedLink, resolvedTarget,
+        "link should resolve to the same path as the target — "
+        + "got link → \(String(decoding: resolvedLink)) "
+        + "and target → \(String(decoding: resolvedTarget))")
+    }
+  }
+
+  // MARK: - Nonexistent path throws
+
+  @Test
+  func nonexistentPathThrows() {
+    withPlatform(.darwin) {
+      // Unique suffix to ensure we don't accidentally hit a real file.
+      let p = _StdlibFilePath(
+        "/this/path/does/not/exist/anywhere/\(UUID().uuidString)")!
+      _expectThrowsResolveError { _ = try p.resolve() }
+    }
+  }
+
+  // MARK: - Firmlink check (go/no-go for the no-FSOPT approach)
+  //
+  // On macOS Big Sur+, `/Users` lives on the data volume and is exposed via
+  // a firmlink. The kernel's *default* behavior for `ATTR_CMN_FULLPATH`
+  // returns the firmlinked path (e.g. `/Users/foo`). The non-firmlinked
+  // underlay is `/System/Volumes/Data/Users/foo`; if `resolve()` returned
+  // that prefix, our no-FSOPT_AUTOFIRMLINKPATH approach would be invalid
+  // and the implementation would need the private SPI flag.
+
+  @Test
+  func firmlinkedHomeRealPath() throws {
+    try withPlatform(.darwin) {
+      let home = FileManager.default.homeDirectoryForCurrentUser.path
+      let resolved = try _StdlibFilePath(home)!.resolve()
+      let s = String(decoding: resolved)
+      expectFalse(s.hasPrefix("/System/Volumes/Data/"),
+        "resolve(\(home)) returned the non-firmlinked underlay: \(s) "
+        + "— the no-FSOPT default does not produce firmlinked paths on "
+        + "this build, so the no-SPI approach is invalid")
+    }
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/StdlibSystemStringTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/StdlibSystemStringTests.swift
@@ -1,0 +1,369 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// _SystemString is the null-terminated byte buffer that backs _StdlibFilePath.
+// Its core invariant: storage is non-empty, the last byte is `._null`,
+// and there are no other null bytes anywhere else. The user-visible
+// length is `storage.count - 1` (the null doesn't count).
+//
+// These tests exercise the RangeReplaceableCollection surface
+// (replaceSubrange, append, insert, remove) and confirm the null
+// invariant is preserved across every flavor of mutation. Platform-
+// independent — never goes through the platform seam — hence a separate
+// top-level suite.
+
+@Suite
+struct SystemStringTests {
+
+  // MARK: - Helpers
+
+  /// Asserts the null invariant: storage ends with `._null` and
+  /// contains no other null bytes. Returns the user-visible bytes.
+  private func _checkAndExtract(
+    _ s: _SystemString,
+    _ sourceLocation: SourceLocation = #_sourceLocation
+  ) -> [_StdlibFilePath.CodeUnit] {
+    let storage = s.nullTerminatedStorage
+    expectFalse(storage.isEmpty, "storage must be non-empty",
+            sourceLocation: sourceLocation)
+    expectEqual(storage.last, ._null, "last byte must be null",
+            sourceLocation: sourceLocation)
+    expectFalse(storage.dropLast().contains(._null),
+            "no embedded nulls before the terminator",
+            sourceLocation: sourceLocation)
+    expectEqual(s.count, storage.count - 1,
+            "user-visible length excludes terminator",
+            sourceLocation: sourceLocation)
+    return Array(s)
+  }
+
+  private func _make(_ bytes: [Int]) -> _SystemString {
+    _SystemString(bytes.map { _StdlibFilePath.CodeUnit($0) })
+  }
+
+  // MARK: - Initialization
+
+  @Test
+  func defaultInitIsEmptyButTerminated() {
+    let s = _SystemString()
+    expectEqual(_checkAndExtract(s), [])
+    expectTrue(s.isEmpty)
+    expectEqual(s.count, 0)
+  }
+
+  @Test
+  func initFromEmptyCollection() {
+    let s = _SystemString([] as [_StdlibFilePath.CodeUnit])
+    expectEqual(_checkAndExtract(s), [])
+  }
+
+  @Test
+  func initFromBytesAppendsNull() {
+    let s = _make([0x41, 0x42, 0x43])
+    let bytes = _checkAndExtract(s)
+    expectEqual(bytes.map(Int.init), [0x41, 0x42, 0x43])
+    expectEqual(s.nullTerminatedStorage.count, 4)
+  }
+
+  @Test
+  func initFromBytesEndingInNullDoesntDouble() {
+    let s = _SystemString(nullTerminatedStorage:
+      [_StdlibFilePath.CodeUnit(0x41), _StdlibFilePath.CodeUnit(0x42), ._null])
+    let bytes = _checkAndExtract(s)
+    expectEqual(bytes.map(Int.init), [0x41, 0x42])
+    expectEqual(s.nullTerminatedStorage.count, 3)
+  }
+
+  // MARK: - Indexing boundaries
+
+  @Test
+  func endIndexIsBeforeNullByte() {
+    let s = _make([0x41, 0x42, 0x43])
+    expectEqual(s.endIndex, 3)
+    expectEqual(s.nullTerminatedStorage[s.endIndex], ._null)
+    // Iteration stops before the null
+    expectEqual(Array(s).count, 3)
+  }
+
+  @Test
+  func emptyStringEndIndexEqualsStartIndex() {
+    let s = _SystemString()
+    expectEqual(s.startIndex, s.endIndex)
+    expectEqual(s.nullTerminatedStorage[s.endIndex], ._null)
+  }
+
+  // MARK: - replaceSubrange
+
+  @Test
+  func replaceSubrangeMiddleSameSize() {
+    var s = _make([0x41, 0x42, 0x43, 0x44])
+    s.replaceSubrange(1..<3, with: [_StdlibFilePath.CodeUnit(0x58), _StdlibFilePath.CodeUnit(0x59)])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x58, 0x59, 0x44])
+  }
+
+  @Test
+  func replaceSubrangeMiddleGrows() {
+    var s = _make([0x41, 0x42, 0x43])
+    s.replaceSubrange(1..<2, with: [
+      _StdlibFilePath.CodeUnit(0x58), _StdlibFilePath.CodeUnit(0x59), _StdlibFilePath.CodeUnit(0x5A),
+    ])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x58, 0x59, 0x5A, 0x43])
+  }
+
+  @Test
+  func replaceSubrangeMiddleShrinks() {
+    var s = _make([0x41, 0x42, 0x43, 0x44, 0x45])
+    s.replaceSubrange(1..<4, with: [_StdlibFilePath.CodeUnit(0x58)])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x58, 0x45])
+  }
+
+  @Test
+  func replaceSubrangeAtFront() {
+    var s = _make([0x41, 0x42, 0x43])
+    s.replaceSubrange(0..<1, with: [_StdlibFilePath.CodeUnit(0x58), _StdlibFilePath.CodeUnit(0x59)])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x58, 0x59, 0x42, 0x43])
+  }
+
+  @Test
+  func replaceSubrangeAtEndIndex() {
+    // Replacing range at endIndex is a pure insertion; null stays.
+    var s = _make([0x41, 0x42])
+    s.replaceSubrange(2..<2, with: [_StdlibFilePath.CodeUnit(0x58)])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42, 0x58])
+  }
+
+  @Test
+  func replaceSubrangeFullToEnd() {
+    // Range running to endIndex must NOT consume the null byte.
+    var s = _make([0x41, 0x42, 0x43])
+    s.replaceSubrange(1..<3, with: [_StdlibFilePath.CodeUnit(0x58)])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x58])
+  }
+
+  @Test
+  func replaceSubrangeWholeStringWithEmpty() {
+    var s = _make([0x41, 0x42, 0x43])
+    s.replaceSubrange(0..<3, with: [] as [_StdlibFilePath.CodeUnit])
+    expectEqual(_checkAndExtract(s), [])
+  }
+
+  @Test
+  func replaceSubrangeWholeStringWithBytes() {
+    var s = _make([0x41, 0x42, 0x43])
+    s.replaceSubrange(0..<3, with: [
+      _StdlibFilePath.CodeUnit(0x58), _StdlibFilePath.CodeUnit(0x59),
+    ])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x58, 0x59])
+  }
+
+  @Test
+  func replaceSubrangeEmptyRangeWithEmptyIsNoOp() {
+    var s = _make([0x41, 0x42])
+    s.replaceSubrange(1..<1, with: [] as [_StdlibFilePath.CodeUnit])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42])
+  }
+
+  @Test
+  func replaceSubrangeOnEmptyString() {
+    var s = _SystemString()
+    s.replaceSubrange(0..<0, with: [
+      _StdlibFilePath.CodeUnit(0x41), _StdlibFilePath.CodeUnit(0x42),
+    ])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42])
+  }
+
+  // MARK: - append (default RRC impl)
+
+  @Test
+  func appendSingleByte() {
+    var s = _make([0x41])
+    s.append(_StdlibFilePath.CodeUnit(0x42))
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42])
+  }
+
+  @Test
+  func appendToEmpty() {
+    var s = _SystemString()
+    s.append(_StdlibFilePath.CodeUnit(0x41))
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41])
+  }
+
+  @Test
+  func appendContentsOfCollection() {
+    var s = _make([0x41])
+    s.append(contentsOf: [
+      _StdlibFilePath.CodeUnit(0x42), _StdlibFilePath.CodeUnit(0x43),
+    ])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42, 0x43])
+  }
+
+  @Test
+  func appendContentsOfEmpty() {
+    var s = _make([0x41])
+    s.append(contentsOf: [] as [_StdlibFilePath.CodeUnit])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41])
+  }
+
+  // MARK: - insert
+
+  @Test
+  func insertAtStart() {
+    var s = _make([0x42, 0x43])
+    s.insert(_StdlibFilePath.CodeUnit(0x41), at: 0)
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42, 0x43])
+  }
+
+  @Test
+  func insertAtMiddle() {
+    var s = _make([0x41, 0x43])
+    s.insert(_StdlibFilePath.CodeUnit(0x42), at: 1)
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42, 0x43])
+  }
+
+  @Test
+  func insertAtEndIndex() {
+    var s = _make([0x41, 0x42])
+    s.insert(_StdlibFilePath.CodeUnit(0x43), at: 2)
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42, 0x43])
+  }
+
+  @Test
+  func insertContentsOfAtMiddle() {
+    var s = _make([0x41, 0x44])
+    s.insert(contentsOf: [
+      _StdlibFilePath.CodeUnit(0x42), _StdlibFilePath.CodeUnit(0x43),
+    ], at: 1)
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42, 0x43, 0x44])
+  }
+
+  @Test
+  func insertContentsOfAtEnd() {
+    var s = _make([0x41, 0x42])
+    s.insert(contentsOf: [
+      _StdlibFilePath.CodeUnit(0x43), _StdlibFilePath.CodeUnit(0x44),
+    ], at: 2)
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42, 0x43, 0x44])
+  }
+
+  // MARK: - remove
+
+  @Test
+  func removeFirst() {
+    var s = _make([0x41, 0x42, 0x43])
+    let removed = s.removeFirst()
+    expectEqual(removed, _StdlibFilePath.CodeUnit(0x41))
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x42, 0x43])
+  }
+
+  @Test
+  func removeLast() {
+    var s = _make([0x41, 0x42, 0x43])
+    let removed = s.removeLast()
+    expectEqual(removed, _StdlibFilePath.CodeUnit(0x43))
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42])
+  }
+
+  @Test
+  func removeSubrangeMiddle() {
+    var s = _make([0x41, 0x42, 0x43, 0x44])
+    s.removeSubrange(1..<3)
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x44])
+  }
+
+  @Test
+  func removeSubrangeToEnd() {
+    var s = _make([0x41, 0x42, 0x43])
+    s.removeSubrange(1..<3)
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41])
+  }
+
+  @Test
+  func removeAll() {
+    var s = _make([0x41, 0x42, 0x43])
+    s.removeAll()
+    expectEqual(_checkAndExtract(s), [])
+  }
+
+  @Test
+  func removeAllOnEmpty() {
+    var s = _SystemString()
+    s.removeAll()
+    expectEqual(_checkAndExtract(s), [])
+  }
+
+  // MARK: - Subscript
+
+  @Test
+  func subscriptReadAtIndices() {
+    let s = _make([0x41, 0x42, 0x43])
+    expectEqual(s[0], _StdlibFilePath.CodeUnit(0x41))
+    expectEqual(s[1], _StdlibFilePath.CodeUnit(0x42))
+    expectEqual(s[2], _StdlibFilePath.CodeUnit(0x43))
+  }
+
+  @Test
+  func subscriptSetMiddle() {
+    var s = _make([0x41, 0x42, 0x43])
+    s[1] = _StdlibFilePath.CodeUnit(0x58)
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x58, 0x43])
+  }
+
+  // MARK: - Sequenced operations (the patterns Decomposition.swift uses)
+
+  @Test
+  func truncateThenAppendBytes() {
+    // Mirrors the components-setter pattern: removeSubrange to a
+    // boundary, then append the contribution. Null must stay at end.
+    var s = _make([0x41, 0x42, 0x43, 0x44, 0x45])
+    s.removeSubrange(2..<5)
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42])
+    s.append(_StdlibFilePath.CodeUnit(0x2F))  // separator-shaped byte
+    s.append(contentsOf: [
+      _StdlibFilePath.CodeUnit(0x58), _StdlibFilePath.CodeUnit(0x59),
+    ])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x42, 0x2F, 0x58, 0x59])
+  }
+
+  @Test
+  func replaceFrontThenInsert() {
+    // Mirrors the anchor-setter pattern: replace [0..<rootEnd] then
+    // maybe insert a separator just after. Null stays at end.
+    var s = _make([0x41, 0x42, 0x43, 0x44])
+    s.replaceSubrange(0..<2, with: [
+      _StdlibFilePath.CodeUnit(0x58), _StdlibFilePath.CodeUnit(0x59),
+      _StdlibFilePath.CodeUnit(0x5A),
+    ])
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x58, 0x59, 0x5A, 0x43, 0x44])
+    s.insert(_StdlibFilePath.CodeUnit(0x2F), at: 3)
+    expectEqual(_checkAndExtract(s).map(Int.init), [
+      0x58, 0x59, 0x5A, 0x2F, 0x43, 0x44,
+    ])
+  }
+
+  @Test
+  func splicePreservesNullAcrossManyOps() {
+    var s = _make([0x41, 0x42, 0x43, 0x44, 0x45])
+    s.replaceSubrange(1..<3, with: [_StdlibFilePath.CodeUnit(0x58)])
+    s.append(_StdlibFilePath.CodeUnit(0x59))
+    s.insert(_StdlibFilePath.CodeUnit(0x5A), at: 0)
+    s.removeFirst()
+    s.removeLast()
+    s.replaceSubrange(0..<s.count, with: [] as [_StdlibFilePath.CodeUnit])
+    s.append(contentsOf: [_StdlibFilePath.CodeUnit(0x60)])
+    // After all that, null still at end and only at end.
+    expectEqual(_checkAndExtract(s).map(Int.init), [0x60])
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/StdlibSystemStringTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/StdlibSystemStringTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -26,7 +26,7 @@ import Testing
 // separate top-level suite.
 
 @Suite
-struct SystemStringTests {
+struct StdlibSystemStringTests {
 
   // MARK: - Helpers
 

--- a/Tests/SystemTests/StdlibFilePathTests/StdlibSystemStringTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/StdlibSystemStringTests.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -21,9 +21,9 @@ import Testing
 //
 // These tests exercise the RangeReplaceableCollection surface
 // (replaceSubrange, append, insert, remove) and confirm the null
-// invariant is preserved across every flavor of mutation. Platform-
-// independent — never goes through the platform seam — hence a separate
-// top-level suite.
+// invariant is preserved across every flavor of mutation. These are
+// platform-independent and never go through the platform seam, hence a
+// separate top-level suite.
 
 @Suite
 struct SystemStringTests {
@@ -147,7 +147,7 @@ struct SystemStringTests {
 
   @Test
   func replaceSubrangeFullToEnd() {
-    // Range running to endIndex must NOT consume the null byte.
+    // Range running to endIndex must not consume the null byte.
     var s = _make([0x41, 0x42, 0x43])
     s.replaceSubrange(1..<3, with: [_StdlibFilePath.CodeUnit(0x58)])
     expectEqual(_checkAndExtract(s).map(Int.init), [0x41, 0x58])

--- a/Tests/SystemTests/StdlibFilePathTests/StringBridgingTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/StringBridgingTests.swift
@@ -1,0 +1,174 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// String bridging, including ill-formed Unicode. `String(decoding:)` and
+// `String(validating:)` on _StdlibFilePath / Anchor / Component were essentially
+// untested, and the U+FFFD path is the most likely Windows-side regression
+// at port time. Expectations from SE-0529 ("Paths and strings", 730-777,
+// and the `description` docs at 622-623 / 648-649 / 675-676):
+//   * `String(decoding:)` — UTF-8 (Linux/Darwin) or UTF-16 (Windows) decode,
+//     replacing ill-formed sequences with U+FFFD. Never fails.
+//   * `String(validating:)` — `nil` when the content is not well-formed.
+//   * `description` equals `String(decoding:)` for the same value.
+//
+// ENCODING: `_StdlibFilePath.CodeUnit` and the decode encoding are fixed at compile
+// time — `CChar`/UTF-8 off Windows, `UInt16`/UTF-16 on Windows. So on
+// non-Windows builds the ill-formed cases use lone UTF-8 bytes (0x80 / 0xFF).
+// The Windows-build target is an unpaired UTF-16 surrogate; we don't fake
+// it here because a lone surrogate is not representable in `[CChar]`.
+
+extension AllTests.StringBridgingTests {
+
+  // MARK: - codeUnits init path (mirrors ValidationTests)
+
+  private func filePath(fromCodeUnits units: [_StdlibFilePath.CodeUnit]) -> _StdlibFilePath? {
+    _StdlibFilePath(codeUnits: units.span)
+  }
+
+  private func component(
+    fromCodeUnits units: [_StdlibFilePath.CodeUnit]
+  ) -> _StdlibFilePath.Component? {
+    _StdlibFilePath.Component(codeUnits: units.span)
+  }
+
+  // MARK: - Well-formed round-trips
+
+  // For well-formed content, both `String(decoding:)` and `String(validating:)`
+  // recover the original text exactly.
+  @Test
+  func wellFormedRoundTripFilePath() {
+    // Inputs use `/`-form paths whose stored bytes (and decoded String)
+    // differ on Windows; restrict to unix.
+    withPlatforms(.linux, .darwin) {
+      for s in ["/foo/bar", "foo/bar", "/usr/local/bin", "/café/naïve", "a/b/c"] {
+        let p = _StdlibFilePath(s)!
+        expectEqual(String(decoding: p), s,
+          "decoding recovers \(s.debugDescription)")
+        // String(validating:) is String?; compare against the non-optional
+        // (Swift promotes the rhs). A nil here would also fail this assertion.
+        expectTrue(String(validating: p) == s,
+          "validating recovers \(s.debugDescription)")
+      }
+    }
+  }
+
+  @Test
+  func wellFormedRoundTripAnchor() {
+    withPlatforms(.linux, .darwin) {
+      let a = _StdlibFilePath.Anchor("/")
+      expectEqual(String(decoding: a), "/", "decoding anchor /")
+      expectTrue(String(validating: a) == "/", "validating anchor /")
+    }
+    withPlatform(.windows) {
+      let a = _StdlibFilePath.Anchor(#"C:\"#)
+      expectEqual(String(decoding: a), #"C:\"#, "decoding anchor C:\\")
+      expectTrue(String(validating: a) == #"C:\"#, "validating anchor C:\\")
+    }
+    withPlatform(.darwin) {
+      let a = _StdlibFilePath.Anchor("/.nofollow/")
+      expectEqual(String(decoding: a), "/.nofollow/", "decoding anchor /.nofollow/")
+      expectTrue(String(validating: a) == "/.nofollow/",
+        "validating anchor /.nofollow/")
+    }
+  }
+
+  @Test
+  func wellFormedRoundTripComponent() {
+    // Component names have no separator; round-trips are universal.
+    for name in ["foo", "file.txt", "café", ".."] {
+      let c = _StdlibFilePath.Component(name)!
+      expectEqual(String(decoding: c), name,
+        "decoding component \(name.debugDescription)")
+      expectTrue(String(validating: c) == name,
+        "validating component \(name.debugDescription)")
+    }
+  }
+
+  // MARK: - description == String(decoding:)
+
+  // The proposal specifies `description` as `String(decoding:)` of the same
+  // value (lossy, U+FFFD-correcting). Pin that identity on all three types —
+  // it holds whatever the platform-specific stored bytes look like.
+  @Test
+  func descriptionEqualsDecoding() {
+    let p = _StdlibFilePath("/foo/bar")
+    expectEqual(p.description, String(decoding: p), "_StdlibFilePath description")
+
+    let a = _StdlibFilePath.Anchor("/")
+    expectEqual(a.description, String(decoding: a), "Anchor description")
+
+    let c = _StdlibFilePath.Component("foo")
+    expectEqual(c.description, String(decoding: c), "Component description")
+  }
+
+#if !os(Windows)
+  // MARK: - Ill-formed Unicode (UTF-8 / CChar build only)
+  //
+  // Lone 0x80 is a UTF-8 continuation byte with no leader; 0xFF never appears
+  // in valid UTF-8. We append them to "foo" and drive construction through the
+  // public codeUnits init (the path ValidationTests uses).
+  //
+  // WINDOWS-BUILD TARGET (not exercised here): on a `UInt16`/UTF-16 build the
+  // analogous ill-formed input is an unpaired surrogate (e.g. a lone 0xD800).
+  // That is the most likely string-bridging regression at port time. We do NOT
+  // fake it under this build — a lone surrogate is not representable in
+  // `[CChar]` — so this section is `#if !os(Windows)`.
+
+  private func illFormedUTF8Bytes() -> [_StdlibFilePath.CodeUnit] {
+    let prefix = "foo".utf8.map { _StdlibFilePath.CodeUnit(bitPattern: $0) }
+    let bad: [_StdlibFilePath.CodeUnit] = [
+      _StdlibFilePath.CodeUnit(bitPattern: 0x80),
+      _StdlibFilePath.CodeUnit(bitPattern: 0xFF),
+    ]
+    return prefix + bad
+  }
+
+  @Test
+  func illFormedFilePath() {
+    let p = filePath(fromCodeUnits: illFormedUTF8Bytes())!
+    // validating: ill-formed => nil
+    expectNil(String(validating: p),
+      "String(validating:) is nil for ill-formed _StdlibFilePath")
+    // decoding: lossy => contains U+FFFD, never fails
+    expectTrue(String(decoding: p).unicodeScalars.contains("\u{FFFD}"),
+      "String(decoding:) yields U+FFFD for ill-formed _StdlibFilePath")
+    // description tracks decoding even when ill-formed
+    expectEqual(p.description, String(decoding: p),
+      "description == decoding (ill-formed)")
+  }
+
+  @Test
+  func illFormedComponent() {
+    let c = component(fromCodeUnits: illFormedUTF8Bytes())!
+
+    // decoding: lossy => U+FFFD. This matches the proposal and the impl.
+    expectTrue(String(decoding: c).unicodeScalars.contains("\u{FFFD}"),
+      "String(decoding:) yields U+FFFD for ill-formed Component")
+
+    // SE-0529 (lines 771-776): String?(validating: component) returns nil when
+    // the content is not well-formed Unicode. Fixed in StringBridging.swift to
+    // use the decode/re-encode/compare round-trip (matching the _StdlibFilePath
+    // overload) instead of the lossy U+FFFD description.
+    //
+    // The Anchor overload (lines 757-762) received the identical fix for
+    // symmetry but is not directly test-reachable: Anchor has no public
+    // codeUnits initializer to smuggle ill-formed bytes into the (otherwise
+    // structural/ASCII) anchor region.
+    expectNil(String(validating: c),
+      "String(validating:) should be nil for ill-formed Component")
+  }
+#endif
+}

--- a/Tests/SystemTests/StdlibFilePathTests/StringBridgingTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/StringBridgingTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -58,7 +58,7 @@ extension AllTests.StringBridgingTests {
       expectTrue(String(validating: p) == s,
         "validating recovers \(s.debugDescription)")
     }
-}
+  }
 
   @Test
   func wellFormedRoundTripAnchor() {
@@ -155,7 +155,8 @@ extension AllTests.StringBridgingTests {
     // Per SE-0529, `String?(validating: component)` returns nil when the
     // content is not well-formed Unicode, so FilePathStringBridging.swift
     // implements it as a decode/re-encode/compare round-trip (matching the
-    // `_StdlibFilePath` overload) rather than off the lossy U+FFFD description.
+    // `_StdlibFilePath` overload) instead of reading the lossy U+FFFD
+    // description.
     //
     // The Anchor overload works the same way but is not directly reachable
     // from a test: Anchor has no public codeUnits initializer, so there is no

--- a/Tests/SystemTests/StdlibFilePathTests/StringBridgingTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/StringBridgingTests.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,21 +14,18 @@ import Testing
 @testable import System
 #endif
 
-// String bridging, including ill-formed Unicode. `String(decoding:)` and
-// `String(validating:)` on _StdlibFilePath / Anchor / Component were essentially
-// untested, and the U+FFFD path is the most likely Windows-side regression
-// at port time. Expectations from SE-0529 ("Paths and strings", 730-777,
-// and the `description` docs at 622-623 / 648-649 / 675-676):
-//   * `String(decoding:)` — UTF-8 (Linux/Darwin) or UTF-16 (Windows) decode,
+// String bridging, including ill-formed Unicode. Expectations from SE-0529
+// ("Paths and strings", and the `description` documentation for each type):
+//   * `String(decoding:)`: UTF-8 (Linux/Darwin) or UTF-16 (Windows) decode,
 //     replacing ill-formed sequences with U+FFFD. Never fails.
-//   * `String(validating:)` — `nil` when the content is not well-formed.
+//   * `String(validating:)`: `nil` when the content is not well-formed.
 //   * `description` equals `String(decoding:)` for the same value.
 //
-// ENCODING: `_StdlibFilePath.CodeUnit` and the decode encoding are fixed at compile
-// time — `CChar`/UTF-8 off Windows, `UInt16`/UTF-16 on Windows. So on
-// non-Windows builds the ill-formed cases use lone UTF-8 bytes (0x80 / 0xFF).
-// The Windows-build target is an unpaired UTF-16 surrogate; we don't fake
-// it here because a lone surrogate is not representable in `[CChar]`.
+// `_StdlibFilePath.CodeUnit` and the decode encoding are fixed at compile time:
+// `CChar`/UTF-8 off Windows, `UInt16`/UTF-16 on Windows. So on a non-Windows
+// build the ill-formed cases use lone UTF-8 bytes (0x80 / 0xFF). The Windows
+// analogue is an unpaired UTF-16 surrogate, which this build cannot express in
+// `[CChar]`, so it is not faked here.
 
 extension AllTests.StringBridgingTests {
 
@@ -48,22 +45,20 @@ extension AllTests.StringBridgingTests {
 
   // For well-formed content, both `String(decoding:)` and `String(validating:)`
   // recover the original text exactly.
-  @Test
+  @Test(.unixOnly)
   func wellFormedRoundTripFilePath() {
     // Inputs use `/`-form paths whose stored bytes (and decoded String)
     // differ on Windows; restrict to unix.
-    withPlatforms(.linux, .darwin) {
-      for s in ["/foo/bar", "foo/bar", "/usr/local/bin", "/café/naïve", "a/b/c"] {
-        let p = _StdlibFilePath(s)!
-        expectEqual(String(decoding: p), s,
-          "decoding recovers \(s.debugDescription)")
-        // String(validating:) is String?; compare against the non-optional
-        // (Swift promotes the rhs). A nil here would also fail this assertion.
-        expectTrue(String(validating: p) == s,
-          "validating recovers \(s.debugDescription)")
-      }
+    for s in ["/foo/bar", "foo/bar", "/usr/local/bin", "/café/naïve", "a/b/c"] {
+      let p = _StdlibFilePath(s)!
+      expectEqual(String(decoding: p), s,
+        "decoding recovers \(s.debugDescription)")
+      // String(validating:) is String?; compare against the non-optional
+      // (Swift promotes the rhs). A nil here would also fail this assertion.
+      expectTrue(String(validating: p) == s,
+        "validating recovers \(s.debugDescription)")
     }
-  }
+}
 
   @Test
   func wellFormedRoundTripAnchor() {
@@ -100,7 +95,7 @@ extension AllTests.StringBridgingTests {
   // MARK: - description == String(decoding:)
 
   // The proposal specifies `description` as `String(decoding:)` of the same
-  // value (lossy, U+FFFD-correcting). Pin that identity on all three types —
+  // value (lossy, U+FFFD-correcting). Pin that identity on all three types;
   // it holds whatever the platform-specific stored bytes look like.
   @Test
   func descriptionEqualsDecoding() {
@@ -121,11 +116,10 @@ extension AllTests.StringBridgingTests {
   // in valid UTF-8. We append them to "foo" and drive construction through the
   // public codeUnits init (the path ValidationTests uses).
   //
-  // WINDOWS-BUILD TARGET (not exercised here): on a `UInt16`/UTF-16 build the
-  // analogous ill-formed input is an unpaired surrogate (e.g. a lone 0xD800).
-  // That is the most likely string-bridging regression at port time. We do NOT
-  // fake it under this build — a lone surrogate is not representable in
-  // `[CChar]` — so this section is `#if !os(Windows)`.
+  // Not exercised here: on a `UInt16`/UTF-16 build the analogous ill-formed
+  // input is an unpaired surrogate (a lone 0xD800, say). A lone surrogate is
+  // not representable in `[CChar]`, so rather than fake one, this section is
+  // `#if !os(Windows)`.
 
   private func illFormedUTF8Bytes() -> [_StdlibFilePath.CodeUnit] {
     let prefix = "foo".utf8.map { _StdlibFilePath.CodeUnit(bitPattern: $0) }
@@ -158,15 +152,15 @@ extension AllTests.StringBridgingTests {
     expectTrue(String(decoding: c).unicodeScalars.contains("\u{FFFD}"),
       "String(decoding:) yields U+FFFD for ill-formed Component")
 
-    // SE-0529 (lines 771-776): String?(validating: component) returns nil when
-    // the content is not well-formed Unicode. Fixed in StringBridging.swift to
-    // use the decode/re-encode/compare round-trip (matching the _StdlibFilePath
-    // overload) instead of the lossy U+FFFD description.
+    // Per SE-0529, `String?(validating: component)` returns nil when the
+    // content is not well-formed Unicode, so FilePathStringBridging.swift
+    // implements it as a decode/re-encode/compare round-trip (matching the
+    // `_StdlibFilePath` overload) rather than off the lossy U+FFFD description.
     //
-    // The Anchor overload (lines 757-762) received the identical fix for
-    // symmetry but is not directly test-reachable: Anchor has no public
-    // codeUnits initializer to smuggle ill-formed bytes into the (otherwise
-    // structural/ASCII) anchor region.
+    // The Anchor overload works the same way but is not directly reachable
+    // from a test: Anchor has no public codeUnits initializer, so there is no
+    // way to smuggle ill-formed bytes into its (otherwise structural, ASCII)
+    // region.
     expectNil(String(validating: c),
       "String(validating:) should be nil for ill-formed Component")
   }

--- a/Tests/SystemTests/StdlibFilePathTests/TestHelpers.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/TestHelpers.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SystemTests/StdlibFilePathTests/TestHelpers.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/TestHelpers.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SystemTests/StdlibFilePathTests/TestHelpers.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/TestHelpers.swift
@@ -1,0 +1,63 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+#if SYSTEM_PACKAGE
+import SystemPackage
+#else
+import System
+#endif
+
+struct Expected {
+  var anchor: String?
+  var components: [String]
+  var hasTrailingSeparator: Bool = false
+  var isResourceFork: Bool = false
+
+  var printed: String
+  var isAbsolute: Bool
+  var isRooted: Bool? = nil
+  var driveLetter: Unicode.Scalar? = nil
+  var kinds: [_StdlibFilePath.Component.Kind]? = nil
+}
+
+// Test-only helpers for integer-offset indexing into ComponentView.
+extension _StdlibFilePath.ComponentView {
+  func idx(_ offset: Int) -> Index {
+    index(startIndex, offsetBy: offset)
+  }
+
+  func range(_ r: Range<Int>) -> Range<Index> {
+    idx(r.lowerBound) ..< idx(r.upperBound)
+  }
+}
+
+struct PathTestCase {
+  var input: String
+  var linux: Expected
+  var darwin: Expected
+  var windows: Expected
+
+  init(
+    input: String, unix: Expected, windows: Expected
+  ) {
+    self.input = input
+    self.linux = unix
+    self.darwin = unix
+    self.windows = windows
+  }
+
+  init(
+    input: String, linux: Expected, darwin: Expected, windows: Expected
+  ) {
+    self.input = input
+    self.linux = linux
+    self.darwin = darwin
+    self.windows = windows
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/TestSupport.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/TestSupport.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SystemTests/StdlibFilePathTests/TestSupport.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/TestSupport.swift
@@ -1,0 +1,194 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+import Foundation
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+// TestSupport — the indirection seam between test bodies and (a) the test
+// framework, and (b) compile-time platform selection. At port time only this
+// file is rewritten: the `expect*` helpers forward to StdlibUnittest / XCTest
+// natives, and the platform helpers evaporate (the stdlib build is naturally
+// platform-fixed).
+//
+// Test bodies MUST go through the seam: no direct `#expect` /
+// `Testing.withKnownIssue`, no direct read of `_builtPlatform`. The one
+// in-tree exception is `withCodeUnitsThrowsTypedError` in ValidationTests —
+// the seam has no throwing-assertion helper because the analogues differ
+// sharply across destination frameworks.
+
+// MARK: - Assertion seam
+
+/// Empty messages → nil (otherwise swift-testing renders an empty comment).
+private func _msg(_ s: String) -> Comment? {
+  s.isEmpty ? nil : "\(s)"
+}
+
+func expectEqual<T: Equatable>(
+  _ lhs: T, _ rhs: T,
+  _ message: @autoclosure () -> String = "",
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  #expect(lhs == rhs, _msg(message()), sourceLocation: sourceLocation)
+}
+
+func expectNotEqual<T: Equatable>(
+  _ lhs: T, _ rhs: T,
+  _ message: @autoclosure () -> String = "",
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  #expect(lhs != rhs, _msg(message()), sourceLocation: sourceLocation)
+}
+
+func expectTrue(
+  _ condition: Bool,
+  _ message: @autoclosure () -> String = "",
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  #expect(condition, _msg(message()), sourceLocation: sourceLocation)
+}
+
+func expectFalse(
+  _ condition: Bool,
+  _ message: @autoclosure () -> String = "",
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  #expect(!condition, _msg(message()), sourceLocation: sourceLocation)
+}
+
+// `T` is unconstrained: nil-comparison on `Optional<T>` doesn't require
+// `Equatable`, and dropping the constraint keeps the signature expressible
+// in every destination framework.
+func expectNil<T>(
+  _ value: T?,
+  _ message: @autoclosure () -> String = "",
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  #expect(value == nil, _msg(message()), sourceLocation: sourceLocation)
+}
+
+func expectNotNil<T>(
+  _ value: T?,
+  _ message: @autoclosure () -> String = "",
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  #expect(value != nil, _msg(message()), sourceLocation: sourceLocation)
+}
+
+/// Records issues thrown inside `body` as *known* issues rather than failures.
+func expectKnownIssue(
+  _ message: String? = nil,
+  sourceLocation: SourceLocation = #_sourceLocation,
+  _ body: () throws -> Void
+) {
+  Testing.withKnownIssue(
+    message.map { "\($0)" }, sourceLocation: sourceLocation
+  ) {
+    try body()
+  }
+}
+
+// MARK: - Platform-runner seam
+
+/// Platform tag for gating tests. Internal so test files can name the
+/// platforms (`.linux` / `.darwin` / `.windows`); the library itself uses
+/// compile-time predicates and doesn't carry a type.
+enum _Platform: Sendable { case linux, darwin, windows }
+
+/// The single platform this target was built for, selected at compile time.
+let _builtPlatform: _Platform = {
+  #if os(Windows)
+  .windows
+  #elseif canImport(Darwin)
+  .darwin
+  #else
+  .linux
+  #endif
+}()
+
+/// Runs `body` only when `p` is the built platform. Other-platform calls are
+/// inert — the test still runs and passes, it just makes no assertions.
+func withPlatform(
+  _ p: _Platform,
+  _ body: () throws -> Void
+) rethrows {
+  guard p == _builtPlatform else { return }
+  try body()
+}
+
+/// Runs `body` when the built platform is one of `ps`. Canonical case:
+/// `withPlatforms(.linux, .darwin)` for "any unix". Tests valid on every
+/// platform should carry no gate at all.
+func withPlatforms(
+  _ ps: _Platform...,
+  body: () throws -> Void
+) rethrows {
+  guard ps.contains(_builtPlatform) else { return }
+  try body()
+}
+
+// MARK: - Universal path literals
+
+/// Translates a `/`-form path string into the build's separator spelling, so
+/// platform-INDEPENDENT tests can share expected strings:
+///
+///     expectEqual(path.description, universal("/usr/local/bin"))
+///
+/// Valid only for paths universal modulo the separator byte: relative paths
+/// and plain-root paths. Not for platform-specific anchors (`C:`, UNC, `\\?\…`,
+/// `/.vol/…`, `/.nofollow/…`, `/.resolve/…`) — those need a platform-specific
+/// test. Traps on backslashes in the input or non-plain-root anchors.
+func universal(_ canonicalSlashForm: String) -> String {
+  precondition(
+    !canonicalSlashForm.contains("\\"),
+    "universal(): literal contains a backslash; write it with '/' as the "
+    + "canonical separator, or use an exact string in a platform-specific "
+    + "test: \(canonicalSlashForm)")
+  let parsed = _StdlibFilePath(canonicalSlashForm)
+  if let anchor = parsed?.anchor {
+    let basicRoot: String = _isWindows ? "\\" : "/"
+    precondition(
+      anchor.description == basicRoot,
+      "universal(): literal has a platform-specific anchor "
+      + "(\(anchor.description)); use an exact string in a platform-specific "
+      + "test: \(canonicalSlashForm)")
+  }
+  return _isWindows
+    ? canonicalSlashForm.replacingOccurrences(of: "/", with: "\\")
+    : canonicalSlashForm
+}
+
+// MARK: - Windows-only API shims
+//
+// `driveLetter` and `isVerbatimComponent` are gated under `#if os(Windows)`
+// per the proposal. These shims expose them on every build (real value on
+// Windows, benign default elsewhere) so test bodies inside
+// `withPlatform(.windows)` blocks type-check on non-Windows builds.
+
+extension _StdlibFilePath.Anchor {
+  var _driveLetter: Unicode.Scalar? {
+    #if os(Windows)
+    return self.driveLetter
+    #else
+    return nil
+    #endif
+  }
+
+  var _isVerbatimComponent: Bool {
+    #if os(Windows)
+    return self.isVerbatimComponent
+    #else
+    return false
+    #endif
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/TestSupport.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/TestSupport.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,17 +15,16 @@ import Foundation
 @testable import System
 #endif
 
-// TestSupport — the indirection seam between test bodies and (a) the test
-// framework, and (b) compile-time platform selection. At port time only this
-// file is rewritten: the `expect*` helpers forward to StdlibUnittest / XCTest
-// natives, and the platform helpers evaporate (the stdlib build is naturally
-// platform-fixed).
+// TestSupport is the seam between the test bodies and (a) the test framework,
+// (b) the platform this target was built for. Test bodies go through it: they
+// call the `expect*` helpers rather than `#expect` directly, and they name a
+// platform with the traits and gates below rather than reading
+// `_builtPlatform`. Keeping the seam this narrow is what lets the suite change
+// test frameworks by rewriting one file.
 //
-// Test bodies MUST go through the seam: no direct `#expect` /
-// `Testing.withKnownIssue`, no direct read of `_builtPlatform`. The one
-// in-tree exception is `withCodeUnitsThrowsTypedError` in ValidationTests —
-// the seam has no throwing-assertion helper because the analogues differ
-// sharply across destination frameworks.
+// One assertion has no seam helper. `withCodeUnitsThrowsTypedError` in
+// ValidationTests calls `#expect(throws:)` directly, because throwing
+// assertions have no common spelling across frameworks.
 
 // MARK: - Assertion seam
 
@@ -66,9 +65,8 @@ func expectFalse(
   #expect(!condition, _msg(message()), sourceLocation: sourceLocation)
 }
 
-// `T` is unconstrained: nil-comparison on `Optional<T>` doesn't require
-// `Equatable`, and dropping the constraint keeps the signature expressible
-// in every destination framework.
+// `T` is unconstrained: comparing `Optional<T>` against nil does not
+// require `Equatable`.
 func expectNil<T>(
   _ value: T?,
   _ message: @autoclosure () -> String = "",
@@ -83,19 +81,6 @@ func expectNotNil<T>(
   sourceLocation: SourceLocation = #_sourceLocation
 ) {
   #expect(value != nil, _msg(message()), sourceLocation: sourceLocation)
-}
-
-/// Records issues thrown inside `body` as *known* issues rather than failures.
-func expectKnownIssue(
-  _ message: String? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
-  _ body: () throws -> Void
-) {
-  Testing.withKnownIssue(
-    message.map { "\($0)" }, sourceLocation: sourceLocation
-  ) {
-    try body()
-  }
 }
 
 // MARK: - Platform-runner seam
@@ -116,8 +101,32 @@ let _builtPlatform: _Platform = {
   #endif
 }()
 
-/// Runs `body` only when `p` is the built platform. Other-platform calls are
-/// inert — the test still runs and passes, it just makes no assertions.
+/// Test traits that skip a test whose subject does not exist on the built
+/// platform. A whole-platform test carries the trait, so an off-platform run
+/// reports it as skipped; a test that asserts on several platforms carries no
+/// trait and gates its per-platform sections with `withPlatform` below.
+///
+/// Prefer the trait. A gate that spans a whole test body makes the test pass
+/// while asserting nothing, which reads as coverage that isn't there.
+extension Trait where Self == ConditionTrait {
+  static var windowsOnly: Self {
+    .enabled(if: _builtPlatform == .windows, "Windows-only path syntax")
+  }
+  static var darwinOnly: Self {
+    .enabled(if: _builtPlatform == .darwin, "Darwin-only path syntax")
+  }
+  static var linuxOnly: Self {
+    .enabled(if: _builtPlatform == .linux, "Linux-only path syntax")
+  }
+  static var unixOnly: Self {
+    .enabled(if: _builtPlatform != .windows, "unix-only path syntax")
+  }
+}
+
+/// Runs `body` only when `p` is the built platform, for one section of a test
+/// that also asserts on other platforms. Off-platform calls are inert, so a
+/// gate wrapping an entire test body would make it pass vacuously: use the
+/// `.windowsOnly` / `.darwinOnly` / `.linuxOnly` traits for that instead.
 func withPlatform(
   _ p: _Platform,
   _ body: () throws -> Void
@@ -126,9 +135,9 @@ func withPlatform(
   try body()
 }
 
-/// Runs `body` when the built platform is one of `ps`. Canonical case:
-/// `withPlatforms(.linux, .darwin)` for "any unix". Tests valid on every
-/// platform should carry no gate at all.
+/// Runs `body` when the built platform is one of `ps`, for one section of a
+/// mixed-platform test. Canonical case: `withPlatforms(.linux, .darwin)` for
+/// "any unix". Tests valid on every platform should carry no gate at all.
 func withPlatforms(
   _ ps: _Platform...,
   body: () throws -> Void
@@ -140,13 +149,13 @@ func withPlatforms(
 // MARK: - Universal path literals
 
 /// Translates a `/`-form path string into the build's separator spelling, so
-/// platform-INDEPENDENT tests can share expected strings:
+/// platform-independent tests can share expected strings:
 ///
 ///     expectEqual(path.description, universal("/usr/local/bin"))
 ///
 /// Valid only for paths universal modulo the separator byte: relative paths
 /// and plain-root paths. Not for platform-specific anchors (`C:`, UNC, `\\?\…`,
-/// `/.vol/…`, `/.nofollow/…`, `/.resolve/…`) — those need a platform-specific
+/// `/.vol/…`, `/.nofollow/…`, `/.resolve/…`), which need a platform-specific
 /// test. Traps on backslashes in the input or non-plain-root anchors.
 func universal(_ canonicalSlashForm: String) -> String {
   precondition(
@@ -171,9 +180,9 @@ func universal(_ canonicalSlashForm: String) -> String {
 // MARK: - Windows-only API shims
 //
 // `driveLetter` and `isVerbatimComponent` are gated under `#if os(Windows)`
-// per the proposal. These shims expose them on every build (real value on
-// Windows, benign default elsewhere) so test bodies inside
-// `withPlatform(.windows)` blocks type-check on non-Windows builds.
+// per the proposal. These shims expose them on every build (the real value on
+// Windows, a benign default elsewhere) so that Windows-only test bodies still
+// type-check on a non-Windows build.
 
 extension _StdlibFilePath.Anchor {
   var _driveLetter: Unicode.Scalar? {

--- a/Tests/SystemTests/StdlibFilePathTests/ValidationTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ValidationTests.swift
@@ -1,0 +1,640 @@
+/*
+ This source file is part of the SE-0529 reference implementation
+
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+*/
+
+import Testing
+#if SYSTEM_PACKAGE
+@testable import SystemPackage
+#else
+@testable import System
+#endif
+
+extension AllTests.ValidationTests {
+
+  // MARK: - Helpers
+
+  func codeUnits(_ s: String) -> [_StdlibFilePath.CodeUnit] {
+    Array(s.utf8).map { CChar(bitPattern: $0) }
+  }
+
+  func filePathFromCodeUnits(
+    _ units: [_StdlibFilePath.CodeUnit]
+  ) -> _StdlibFilePath? {
+    _StdlibFilePath(codeUnits: units.span)
+  }
+
+  func componentFromCodeUnits(
+    _ units: [_StdlibFilePath.CodeUnit]
+  ) -> _StdlibFilePath.Component? {
+    _StdlibFilePath.Component(codeUnits: units.span)
+  }
+
+  // MARK: - _StdlibFilePath.init?(_: String) NUL rejection
+
+  @Test
+  func filePathInitRejectsNUL() {
+    // Platform-independent: NUL is rejected before normalization.
+    let good: String = "hello"
+    expectNotNil(_StdlibFilePath(good))
+
+    let empty: String = ""
+    expectNotNil(_StdlibFilePath(empty))
+
+    let abs: String = "/foo/bar"
+    expectNotNil(_StdlibFilePath(abs))
+
+    let nulMiddle: String = "hello\0world"
+    expectNil(_StdlibFilePath(nulMiddle))
+
+    let justNul: String = "\0"
+    expectNil(_StdlibFilePath(justNul))
+
+    let nulEnd: String = "foo\0"
+    expectNil(_StdlibFilePath(nulEnd))
+
+    let nulStart: String = "\0foo"
+    expectNil(_StdlibFilePath(nulStart))
+  }
+
+  @Test
+  func filePathStringLiteralWorks() {
+    let p: _StdlibFilePath = "/usr/local/bin"
+    expectEqual(p.description, universal("/usr/local/bin"))
+
+    let empty: _StdlibFilePath = ""
+    expectTrue(empty.isEmpty)
+  }
+
+  // MARK: - _StdlibFilePath.init?(codeUnits:) and round-trip via withCodeUnits
+
+  @Test
+  func filePathCodeUnitsRejectsNUL() {
+    // The `codeUnits(_:)` helper produces `[CChar]` (_StdlibFilePath.CodeUnit only on
+    // non-Windows builds), so this body is unix-only.
+    withPlatforms(.linux, .darwin) {
+      expectTrue(filePathFromCodeUnits(codeUnits("/foo"))?.description == "/foo")
+      expectNil(filePathFromCodeUnits(codeUnits("f\0o")))
+      expectNil(filePathFromCodeUnits(codeUnits("\0")))
+      expectNil(filePathFromCodeUnits(codeUnits("foo\0")))
+    }
+  }
+
+  @Test
+  func filePathCodeUnitsEmpty() {
+    let emptyPath = filePathFromCodeUnits([])
+    expectNotNil(emptyPath)
+    expectTrue(emptyPath?.isEmpty == true)
+  }
+
+  @Test
+  func filePathCodeUnitRoundTrip() {
+    for input in ["/foo/bar", "", ".", "foo/bar", "/usr/local/bin", "hello"] {
+      let s: String = input
+      let path = _StdlibFilePath(s)!
+      let extracted = path.withCodeUnits { ptr, count in
+        Array(UnsafeBufferPointer(start: ptr, count: count))
+      }
+      let roundTripped = filePathFromCodeUnits(extracted)
+      expectTrue(roundTripped == path,
+        "Code unit round-trip failed for \(input.debugDescription)")
+    }
+  }
+
+  @Test
+  func filePathCodeUnitRoundTripNonASCII() {
+    for input in ["/café/naïve", "/あ/🧟‍♀️", "Ångström"] {
+      let s: String = input
+      let path = _StdlibFilePath(s)!
+      let extracted = path.withCodeUnits { ptr, count in
+        Array(UnsafeBufferPointer(start: ptr, count: count))
+      }
+      let roundTripped = filePathFromCodeUnits(extracted)
+      expectTrue(roundTripped == path,
+        "Non-ASCII code unit round-trip failed for \(input.debugDescription)")
+    }
+  }
+
+  // MARK: - Component.init?(_: String)
+
+  @Test
+  func componentInitRejectsNUL() {
+    // Platform-independent.
+    let good: String = "hello"
+    expectNotNil(_StdlibFilePath.Component(good))
+
+    let nul: String = "hello\0world"
+    expectNil(_StdlibFilePath.Component(nul))
+
+    let justNul: String = "\0"
+    expectNil(_StdlibFilePath.Component(justNul))
+  }
+
+  @Test
+  func componentInitRejectsSeparator() {
+    withPlatforms(.linux, .darwin) {
+      let fwdSlash: String = "foo/bar"
+      expectNil(_StdlibFilePath.Component(fwdSlash))
+      let justSlash: String = "/"
+      expectNil(_StdlibFilePath.Component(justSlash))
+      let trailingSlash: String = "a/"
+      expectNil(_StdlibFilePath.Component(trailingSlash))
+
+      // Backslash is legal in filenames on unix.
+      let bsOnUnix: String = #"foo\bar"#
+      let bs = _StdlibFilePath.Component(bsOnUnix)
+      expectNotNil(bs)
+      expectTrue(bs?.description == #"foo\bar"#)
+    }
+
+    withPlatform(.windows) {
+      let backslash: String = #"foo\bar"#
+      expectNil(_StdlibFilePath.Component(backslash))
+      let justBack: String = #"\"#
+      expectNil(_StdlibFilePath.Component(justBack))
+      let fwdOnWin: String = "foo/bar"
+      expectNil(_StdlibFilePath.Component(fwdOnWin))
+    }
+  }
+
+  @Test
+  func componentInitRejectsEmpty() {
+    let empty: String = ""
+    expectNil(_StdlibFilePath.Component(empty))
+  }
+
+  @Test
+  func componentInitAcceptsValid() {
+    let hello: String = "hello"
+    let c = _StdlibFilePath.Component(hello)
+    expectNotNil(c)
+    expectTrue(c?.description == "hello")
+
+    let dotStr: String = "."
+    let dot = _StdlibFilePath.Component(dotStr)
+    expectNotNil(dot)
+    expectTrue(dot?.kind == .currentDirectory)
+
+    let dotdotStr: String = ".."
+    let dotdot = _StdlibFilePath.Component(dotdotStr)
+    expectNotNil(dotdot)
+    expectTrue(dotdot?.kind == .parentDirectory)
+  }
+
+  // MARK: - Component.init?(codeUnits:)
+
+  @Test
+  func componentCodeUnitsRejectsNUL() {
+    // Platform-independent.
+    expectNotNil(componentFromCodeUnits(codeUnits("foo")))
+    expectNil(componentFromCodeUnits(codeUnits("f\0o")))
+    expectNil(componentFromCodeUnits(codeUnits("\0")))
+  }
+
+  @Test
+  func componentCodeUnitsRejectsEmpty() {
+    expectNil(componentFromCodeUnits([]))
+  }
+
+  @Test
+  func componentCodeUnitsRejectsSeparator() {
+    // The `codeUnits(_:)` helper produces `[CChar]`, so this body is unix-only.
+    withPlatforms(.linux, .darwin) {
+      expectNil(componentFromCodeUnits(codeUnits("foo/bar")))
+      // Backslash is legal in filenames on unix.
+      expectNotNil(componentFromCodeUnits(codeUnits(#"foo\bar"#)))
+    }
+
+    withPlatform(.windows) {
+      expectNil(componentFromCodeUnits(codeUnits(#"foo\bar"#)))
+      expectNil(componentFromCodeUnits(codeUnits("foo/bar")))
+    }
+  }
+
+  @Test
+  func componentCodeUnitRoundTrip() {
+    for name in ["hello", ".", "..", "file.txt", "café", "🧟‍♀️"] {
+      let s: String = name
+      let comp = _StdlibFilePath.Component(s)!
+      let span = comp.codeUnits
+      var extracted = [_StdlibFilePath.CodeUnit]()
+      extracted.reserveCapacity(span.count)
+      for i in span.indices { extracted.append(span[i]) }
+      let roundTripped = componentFromCodeUnits(extracted)
+      expectTrue(roundTripped == comp,
+        "Component code unit round-trip failed for \(name.debugDescription)")
+    }
+  }
+
+  // MARK: - Span code-unit accessors
+
+  /// Copies a span of code units into an array (`Span` is not a `Sequence`).
+  private func _array(
+    _ span: Span<_StdlibFilePath.CodeUnit>
+  ) -> [_StdlibFilePath.CodeUnit] {
+    var out = [_StdlibFilePath.CodeUnit]()
+    out.reserveCapacity(span.count)
+    for i in span.indices { out.append(span[i]) }
+    return out
+  }
+
+  @Test
+  func spanCodeUnitsAccessors() {
+    func bytes(_ s: String) -> [_StdlibFilePath.CodeUnit] {
+      Array(s.utf8).map { CChar(bitPattern: $0) }
+    }
+    // The local `bytes(_:)` helper produces `[CChar]`, unix-only.
+    withPlatforms(.linux, .darwin) {
+      // Bind to `String` locals so the failable `init?(_:)` is selected
+      // (a bare string literal binds the non-failable
+      // `ExpressibleByStringLiteral` init, which is not optional).
+      let input: String = "/usr/local"
+      let path = _StdlibFilePath(input)!
+
+      // _StdlibFilePath.codeUnits excludes the null terminator;
+      // nullTerminatedCodeUnits includes it as the final element.
+      let cu = _array(path.codeUnits)
+      expectEqual(cu, bytes("/usr/local"))
+      expectFalse(cu.contains(0))
+
+      let ntcu = _array(path.nullTerminatedCodeUnits)
+      expectEqual(ntcu, bytes("/usr/local") + [0])
+      expectEqual(ntcu.count, cu.count + 1)
+      expectTrue(ntcu.last == 0)
+
+      // Bind each owner to a local before borrowing its span: a span
+      // borrowed from a force-unwrapped (`!`) temporary would outlive that
+      // temporary ("lifetime-dependent value escapes its scope").
+      let anchor = path.anchor!
+      expectEqual(_array(anchor.codeUnits), bytes("/"))
+
+      // ComponentView.codeUnits is the relative portion (anchor excluded).
+      let cv = path.components
+      expectEqual(_array(cv.codeUnits), bytes("usr/local"))
+
+      // Component.codeUnits is a single component's bytes.
+      let firstComp = cv.first!
+      let lastComp = cv.last!
+      expectEqual(_array(firstComp.codeUnits), bytes("usr"))
+      expectEqual(_array(lastComp.codeUnits), bytes("local"))
+
+      // ComponentView strips a trailing separator (suffix, not a component).
+      let trailingInput: String = "/usr/local/"
+      let trailing = _StdlibFilePath(trailingInput)!
+      expectTrue(trailing.hasTrailingSeparator)
+      let trailingCV = trailing.components
+      expectEqual(_array(trailingCV.codeUnits), bytes("usr/local"))
+
+      // Empty relative portion -> empty span.
+      let rootInput: String = "/"
+      let rootOnly = _StdlibFilePath(rootInput)!
+      let rootCV = rootOnly.components
+      expectEqual(_array(rootCV.codeUnits), [])
+      let rootAnchor = rootOnly.anchor!
+      expectEqual(_array(rootAnchor.codeUnits), bytes("/"))
+    }
+  }
+
+  // MARK: - Anchor.init?(_: String) NUL rejection
+
+  @Test
+  func anchorInitRejectsNULOnBasicRoot() {
+    // Basic-root NUL handling. Universal modulo separator: on Windows
+    // the slash-form input still parses (slash is converted), and NUL
+    // is rejected before normalization regardless.
+    let good: String = "/"
+    expectNotNil(_StdlibFilePath.Anchor(good))
+
+    let nul1: String = "/\0"
+    expectNil(_StdlibFilePath.Anchor(nul1))
+
+    let nul2: String = "\0/"
+    expectNil(_StdlibFilePath.Anchor(nul2))
+  }
+
+  @Test
+  func anchorInitRejectsNULDarwin() {
+    withPlatform(.darwin) {
+      let root: String = "/"
+      expectNotNil(_StdlibFilePath.Anchor(root))
+
+      let nofollow: String = "/.nofollow/"
+      expectNotNil(_StdlibFilePath.Anchor(nofollow))
+
+      let nul: String = "/.nofollow\0/"
+      expectNil(_StdlibFilePath.Anchor(nul))
+
+      let vol: String = "/.vol/1234/5678"
+      expectNotNil(_StdlibFilePath.Anchor(vol))
+
+      let volNul: String = "/.vol/1234\0/5678"
+      expectNil(_StdlibFilePath.Anchor(volNul))
+    }
+  }
+
+  // Per proposal line 111: a Darwin anchor may include resolve flags AND/OR
+  // a volume identifier. The combined form `[/.nofollow/ | /.resolve/N/]
+  // .vol/FSID/FILEID` is one anchor, and `Anchor.init?` accepts it iff the
+  // combined form is complete (no missing FSID/FILEID).
+  @Test
+  func anchorInitDarwinAcceptsCombinedForms() {
+    withPlatform(.darwin) {
+      // String literals dispatch to the trapping `init(stringLiteral:)`;
+      // route through let-bindings so the failable `init?(_:)` is selected.
+      let nofollowVol: String = "/.nofollow/.vol/1234/5678"
+      expectNotNil(_StdlibFilePath.Anchor(nofollowVol),
+        "/.nofollow/.vol/1234/5678 is a valid combined anchor")
+      let resolveVol: String = "/.resolve/3/.vol/1234/5678"
+      expectNotNil(_StdlibFilePath.Anchor(resolveVol),
+        "/.resolve/3/.vol/1234/5678 is a valid combined anchor")
+      // Combined with FILEID canonicalization (`2` -> `@`): still valid.
+      let nofollowVol2: String = "/.nofollow/.vol/1234/2"
+      expectNotNil(_StdlibFilePath.Anchor(nofollowVol2),
+        "/.nofollow/.vol/1234/2 canonicalizes and is accepted")
+      // Combined with both canonicalizations.
+      let resolveOneVol2: String = "/.resolve/1/.vol/1234/2"
+      expectNotNil(_StdlibFilePath.Anchor(resolveOneVol2),
+        "/.resolve/1/.vol/1234/2 canonicalizes and is accepted")
+    }
+  }
+
+  // Incomplete combined forms (missing FSID or FILEID) fall back to the
+  // leading flag as the anchor with the partial vol bytes as components.
+  // `Anchor.init?` then rejects them because components are non-empty.
+  @Test
+  func anchorInitDarwinRejectsIncompleteCombinedForms() {
+    withPlatform(.darwin) {
+      let nofollowVolEmpty: String = "/.nofollow/.vol/"
+      expectNil(_StdlibFilePath.Anchor(nofollowVolEmpty),
+        "/.nofollow/.vol/ has no FSID — falls back to /.nofollow/ + [.vol]")
+      let nofollowVolNoFileid: String = "/.nofollow/.vol/1234/"
+      expectNil(_StdlibFilePath.Anchor(nofollowVolNoFileid),
+        "/.nofollow/.vol/1234/ has no FILEID")
+      let resolveVolEmpty: String = "/.resolve/3/.vol/"
+      expectNil(_StdlibFilePath.Anchor(resolveVolEmpty),
+        "/.resolve/3/.vol/ has no FSID")
+      let resolveVolNoFileid: String = "/.resolve/3/.vol/1234/"
+      expectNil(_StdlibFilePath.Anchor(resolveVolNoFileid),
+        "/.resolve/3/.vol/1234/ has no FILEID")
+    }
+  }
+
+  @Test
+  func anchorInitRejectsNULWindows() {
+    withPlatform(.windows) {
+      let drive: String = #"C:\"#
+      expectNotNil(_StdlibFilePath.Anchor(drive))
+
+      let driveNul: String = "C:\\\0"
+      expectNil(_StdlibFilePath.Anchor(driveNul))
+
+      let unc: String = #"\\server\share"#
+      expectNotNil(_StdlibFilePath.Anchor(unc))
+
+      let uncNul: String = "\\\\\0server\\share"
+      expectNil(_StdlibFilePath.Anchor(uncNul))
+    }
+  }
+
+  @Test
+  func anchorInitRejectsInvalid() {
+    // Universal modulo separator: empty input has no anchor; "foo" is
+    // a relative component-only path (no anchor); "/foo" parses to an
+    // anchored path with components, which `Anchor.init?` rejects
+    // (anchor only, no components allowed).
+    let empty: String = ""
+    expectNil(_StdlibFilePath.Anchor(empty))
+
+    let noAnchor: String = "foo"
+    expectNil(_StdlibFilePath.Anchor(noAnchor))
+
+    let hasComponents: String = "/foo"
+    expectNil(_StdlibFilePath.Anchor(hasComponents))
+  }
+
+  // MARK: - Anchor.init? strictness vs _StdlibFilePath.init? totality (Windows)
+  //
+  // `_StdlibFilePath.Anchor.init?` is STRICT: a named anchor form must carry its
+  // name. It rejects incomplete UNC (no server / no share), empty device
+  // (`\\.\`), and empty verbatim (`\\?\`). `_StdlibFilePath.init?` by contrast is
+  // total and coalesces these same inputs into a degraded anchor. These two
+  // tests pin both halves and the resulting divergence.
+
+  @Test
+  func anchorInitStrictRejectsIncompleteWindowsForms() {
+    withPlatform(.windows) {
+      // Named forms missing their name -> nil.
+      let incomplete: [String] = [
+        #"\\"#,         // incomplete UNC: no server, no share
+        #"\\server"#,   // incomplete UNC: server but no share
+        #"\\\server"#,  // 3+ backslashes -> `\` root + `server` component
+        #"\\."#,        // empty device: no device name
+        #"\\.\"#,       // empty device: no device name
+        #"\\?"#,        // empty verbatim: no component
+        #"\\?\"#,       // empty verbatim: no component
+      ]
+      for input in incomplete {
+        expectNil(_StdlibFilePath.Anchor(input),
+          "Anchor.init? should reject \(input.debugDescription)")
+      }
+
+      // Populated named forms still construct and round-trip to themselves.
+      let named: [(input: String, printed: String)] = [
+        (#"\\server\share"#, #"\\server\share"#),
+        (#"\\.\pipe"#,       #"\\.\pipe"#),
+        (#"\\?\C:\"#,        #"\\?\C:\"#),
+        (#"\\?\pictures"#,   #"\\?\pictures"#),
+      ]
+      for (input, printed) in named {
+        let anchor = _StdlibFilePath.Anchor(input)
+        expectNotNil(anchor,
+          "Anchor.init? should accept \(input.debugDescription)")
+        expectEqual(anchor?.description, printed,
+          "Anchor \(input.debugDescription) printed form")
+      }
+    }
+  }
+
+  @Test
+  func filePathStillCoalescesAnchorRejectedForms() {
+    withPlatform(.windows) {
+      // The inputs `Anchor.init?` rejects remain TOTAL under `_StdlibFilePath.init?`,
+      // which coalesces each into its degraded shape. This is the deliberate
+      // divergence: _StdlibFilePath stays total, Anchor is strict.
+
+      // Headline case: `\\\server\share` coalesces to a current-drive root
+      // with `server` and `share` as ordinary components, yet the strict
+      // Anchor initializer rejects the same string.
+      let triple: String = #"\\\server\share"#
+      expectNil(_StdlibFilePath.Anchor(triple),
+        #"Anchor.init? rejects \\\server\share"#)
+      let p = _StdlibFilePath(triple)
+      expectNotNil(p, #"_StdlibFilePath.init? accepts \\\server\share"#)
+      expectEqual(p?.anchor?.description, #"\"#,
+        #"\\\server\share coalesces to anchor \"#)
+      expectEqual(p?.components.map(\.description) ?? [], ["server", "share"],
+        #"\\\server\share components"#)
+
+      // Every rejected anchor input still constructs a _StdlibFilePath whose anchor
+      // is the coalesced/degraded form, with no relative components — while
+      // `Anchor.init?` rejects that very input.
+      let coalesced: [(input: String, anchor: String)] = [
+        (#"\\"#,       #"\\\"#),       // -> degraded 3-backslash root
+        (#"\\server"#, #"\\server\"#), // -> server with empty share
+        (#"\\."#,      #"\\.\"#),      // -> empty device
+        (#"\\.\"#,     #"\\.\"#),      // -> empty device
+        (#"\\?"#,      #"\\?\"#),      // -> empty verbatim
+        (#"\\?\"#,     #"\\?\"#),      // -> empty verbatim
+      ]
+      for (input, anchor) in coalesced {
+        let fp = _StdlibFilePath(input)
+        expectNotNil(fp,
+          "_StdlibFilePath.init? should accept \(input.debugDescription)")
+        expectEqual(fp?.anchor?.description, anchor,
+          "_StdlibFilePath \(input.debugDescription) coalesced anchor")
+        expectTrue(fp?.components.isEmpty ?? false,
+          "_StdlibFilePath \(input.debugDescription) should have no components")
+        expectNil(_StdlibFilePath.Anchor(input),
+          "Anchor.init? should reject \(input.debugDescription)")
+      }
+    }
+  }
+
+  // MARK: - Verbatim-UNC trailing separator is not synthesized (Windows)
+
+  @Test
+  func verbatimUNCTrailingSeparatorNotSynthesized() {
+    withPlatform(.windows) {
+      // A verbatim-UNC root with NO trailing separator must not have one
+      // synthesized: `\\?\UNC\s\h` stores verbatim with hasTrailingSeparator
+      // false, while `\\?\UNC\s\h\` has a genuine trailing separator. The
+      // trailing separator is significant, so the two are not equal.
+      let noSep: String = #"\\?\UNC\s\h"#
+      let withSep: String = #"\\?\UNC\s\h\"#
+
+      let a = _StdlibFilePath(noSep)!
+      expectEqual(a.anchor?.description, #"\\?\UNC\s\h"#)
+      expectTrue(a.components.isEmpty)
+      expectFalse(a.hasTrailingSeparator,
+        #"\\?\UNC\s\h should have no trailing separator"#)
+      expectEqual(a.description, #"\\?\UNC\s\h"#,
+        #"\\?\UNC\s\h must be stored without an added backslash"#)
+
+      let b = _StdlibFilePath(withSep)!
+      expectEqual(b.anchor?.description, #"\\?\UNC\s\h"#)
+      expectTrue(b.components.isEmpty)
+      expectTrue(b.hasTrailingSeparator,
+        #"\\?\UNC\s\h\ should have a trailing separator"#)
+
+      expectNotEqual(a, b,
+        #"\\?\UNC\s\h must not equal \\?\UNC\s\h\"#)
+
+      // A populated verbatim-UNC path is unaffected by the fix.
+      let fooInput: String = #"\\?\UNC\server\share\foo"#
+      let c = _StdlibFilePath(fooInput)!
+      expectEqual(c.anchor?.description, #"\\?\UNC\server\share"#)
+      expectEqual(c.components.map(\.description), ["foo"])
+    }
+  }
+
+  // MARK: - isAbsolute (isRelative removed)
+
+  @Test
+  func isAbsoluteExists() {
+    // On Windows `\foo` (the converted form of `/foo`) is the current-drive
+    // root — rooted but not fully qualified, so isAbsolute is false. The
+    // unix-side expectation is "absolute"; restrict to those.
+    withPlatforms(.linux, .darwin) {
+      let abs: _StdlibFilePath = "/foo"
+      expectTrue(abs.isAbsolute)
+
+      let rel: _StdlibFilePath = "foo"
+      expectFalse(rel.isAbsolute)
+    }
+  }
+
+  // MARK: - withCodeUnits
+
+  @Test
+  func withCodeUnitsProvidesPointerAndCount() {
+    // Asserts CChar-typed values; unix-only.
+    withPlatforms(.linux, .darwin) {
+      let path: _StdlibFilePath = "/foo/bar"
+      path.withCodeUnits { ptr, count in
+        expectEqual(count, 8)
+        expectEqual(ptr[0], CChar(UInt8(ascii: "/")))
+        expectEqual(ptr[1], CChar(UInt8(ascii: "f")))
+        expectEqual(ptr[4], CChar(UInt8(ascii: "/")))
+        // The count excludes the null terminator, which sits at [count].
+        expectEqual(ptr[count], 0)
+      }
+    }
+  }
+
+  @Test
+  func withCodeUnitsEmpty() {
+    let path: _StdlibFilePath = ""
+    path.withCodeUnits { ptr, count in
+      expectEqual(count, 0)
+      expectEqual(ptr[0], 0)
+    }
+  }
+
+  @Test
+  func withCodeUnitsNonASCII() {
+    // Asserts CChar-typed values and a UTF-8 byte (0xA9); unix-only.
+    withPlatforms(.linux, .darwin) {
+      let path: _StdlibFilePath = "/café"
+      path.withCodeUnits { ptr, count in
+        // "/café" is 6 UTF-8 bytes: / c a f 0xC3 0xA9
+        expectEqual(count, 6)
+        expectEqual(ptr[0], CChar(UInt8(ascii: "/")))
+        expectEqual(ptr[5], CChar(bitPattern: 0xA9))
+        expectEqual(ptr[count], 0)
+      }
+    }
+  }
+
+  @Test
+  func withCodeUnitsReturnsValue() {
+    let path: _StdlibFilePath = "/foo"
+    let len = path.withCodeUnits { (ptr, _) -> Int in
+      var i = 0
+      while ptr[i] != 0 { i += 1 }
+      return i
+    }
+    expectEqual(len, 4)
+  }
+
+  @Test
+  func withCodeUnitsThrowsTypedError() {
+    struct TestError: Error {}
+    let path: _StdlibFilePath = "/foo"
+    // SEAM EXCEPTION: no throwing-assertion helper in the seam (analogues
+    // differ sharply across StdlibUnittest / XCTest).
+    #expect(throws: TestError.self) {
+      try path.withCodeUnits {
+        (_: UnsafePointer<_StdlibFilePath.CodeUnit>, _: Int) throws(TestError) -> Int in
+        throw TestError()
+      }
+    }
+  }
+
+  // MARK: - String literal inits
+
+  @Test
+  func componentStringLiteralValid() {
+    let c: _StdlibFilePath.Component = "hello"
+    expectEqual(c.description, "hello")
+  }
+
+  @Test
+  func anchorStringLiteralValid() {
+    let a: _StdlibFilePath.Anchor = "/"
+    expectEqual(a.description, universal("/"))
+  }
+}

--- a/Tests/SystemTests/StdlibFilePathTests/ValidationTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ValidationTests.swift
@@ -1,7 +1,7 @@
 /*
- This source file is part of the SE-0529 reference implementation
+ This source file is part of the Swift System open source project
 
- Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -72,17 +72,15 @@ extension AllTests.ValidationTests {
 
   // MARK: - _StdlibFilePath.init?(codeUnits:) and round-trip via withCodeUnits
 
-  @Test
+  @Test(.unixOnly)
   func filePathCodeUnitsRejectsNUL() {
     // The `codeUnits(_:)` helper produces `[CChar]` (_StdlibFilePath.CodeUnit only on
     // non-Windows builds), so this body is unix-only.
-    withPlatforms(.linux, .darwin) {
-      expectTrue(filePathFromCodeUnits(codeUnits("/foo"))?.description == "/foo")
-      expectNil(filePathFromCodeUnits(codeUnits("f\0o")))
-      expectNil(filePathFromCodeUnits(codeUnits("\0")))
-      expectNil(filePathFromCodeUnits(codeUnits("foo\0")))
-    }
-  }
+    expectTrue(filePathFromCodeUnits(codeUnits("/foo"))?.description == "/foo")
+    expectNil(filePathFromCodeUnits(codeUnits("f\0o")))
+    expectNil(filePathFromCodeUnits(codeUnits("\0")))
+    expectNil(filePathFromCodeUnits(codeUnits("foo\0")))
+}
 
   @Test
   func filePathCodeUnitsEmpty() {
@@ -316,89 +314,80 @@ extension AllTests.ValidationTests {
     expectNil(_StdlibFilePath.Anchor(nul2))
   }
 
-  @Test
+  @Test(.darwinOnly)
   func anchorInitRejectsNULDarwin() {
-    withPlatform(.darwin) {
-      let root: String = "/"
-      expectNotNil(_StdlibFilePath.Anchor(root))
+    let root: String = "/"
+    expectNotNil(_StdlibFilePath.Anchor(root))
 
-      let nofollow: String = "/.nofollow/"
-      expectNotNil(_StdlibFilePath.Anchor(nofollow))
+    let nofollow: String = "/.nofollow/"
+    expectNotNil(_StdlibFilePath.Anchor(nofollow))
 
-      let nul: String = "/.nofollow\0/"
-      expectNil(_StdlibFilePath.Anchor(nul))
+    let nul: String = "/.nofollow\0/"
+    expectNil(_StdlibFilePath.Anchor(nul))
 
-      let vol: String = "/.vol/1234/5678"
-      expectNotNil(_StdlibFilePath.Anchor(vol))
+    let vol: String = "/.vol/1234/5678"
+    expectNotNil(_StdlibFilePath.Anchor(vol))
 
-      let volNul: String = "/.vol/1234\0/5678"
-      expectNil(_StdlibFilePath.Anchor(volNul))
-    }
-  }
+    let volNul: String = "/.vol/1234\0/5678"
+    expectNil(_StdlibFilePath.Anchor(volNul))
+}
 
-  // Per proposal line 111: a Darwin anchor may include resolve flags AND/OR
-  // a volume identifier. The combined form `[/.nofollow/ | /.resolve/N/]
+  // A Darwin anchor may include resolve flags and/or a volume identifier. The combined form `[/.nofollow/ | /.resolve/N/]
   // .vol/FSID/FILEID` is one anchor, and `Anchor.init?` accepts it iff the
   // combined form is complete (no missing FSID/FILEID).
-  @Test
+  @Test(.darwinOnly)
   func anchorInitDarwinAcceptsCombinedForms() {
-    withPlatform(.darwin) {
-      // String literals dispatch to the trapping `init(stringLiteral:)`;
-      // route through let-bindings so the failable `init?(_:)` is selected.
-      let nofollowVol: String = "/.nofollow/.vol/1234/5678"
-      expectNotNil(_StdlibFilePath.Anchor(nofollowVol),
-        "/.nofollow/.vol/1234/5678 is a valid combined anchor")
-      let resolveVol: String = "/.resolve/3/.vol/1234/5678"
-      expectNotNil(_StdlibFilePath.Anchor(resolveVol),
-        "/.resolve/3/.vol/1234/5678 is a valid combined anchor")
-      // Combined with FILEID canonicalization (`2` -> `@`): still valid.
-      let nofollowVol2: String = "/.nofollow/.vol/1234/2"
-      expectNotNil(_StdlibFilePath.Anchor(nofollowVol2),
-        "/.nofollow/.vol/1234/2 canonicalizes and is accepted")
-      // Combined with both canonicalizations.
-      let resolveOneVol2: String = "/.resolve/1/.vol/1234/2"
-      expectNotNil(_StdlibFilePath.Anchor(resolveOneVol2),
-        "/.resolve/1/.vol/1234/2 canonicalizes and is accepted")
-    }
-  }
+    // String literals dispatch to the trapping `init(stringLiteral:)`;
+    // route through let-bindings so the failable `init?(_:)` is selected.
+    let nofollowVol: String = "/.nofollow/.vol/1234/5678"
+    expectNotNil(_StdlibFilePath.Anchor(nofollowVol),
+      "/.nofollow/.vol/1234/5678 is a valid combined anchor")
+    let resolveVol: String = "/.resolve/3/.vol/1234/5678"
+    expectNotNil(_StdlibFilePath.Anchor(resolveVol),
+      "/.resolve/3/.vol/1234/5678 is a valid combined anchor")
+    // Combined with FILEID canonicalization (`2` -> `@`): still valid.
+    let nofollowVol2: String = "/.nofollow/.vol/1234/2"
+    expectNotNil(_StdlibFilePath.Anchor(nofollowVol2),
+      "/.nofollow/.vol/1234/2 canonicalizes and is accepted")
+    // Combined with both canonicalizations.
+    let resolveOneVol2: String = "/.resolve/1/.vol/1234/2"
+    expectNotNil(_StdlibFilePath.Anchor(resolveOneVol2),
+      "/.resolve/1/.vol/1234/2 canonicalizes and is accepted")
+}
 
   // Incomplete combined forms (missing FSID or FILEID) fall back to the
   // leading flag as the anchor with the partial vol bytes as components.
   // `Anchor.init?` then rejects them because components are non-empty.
-  @Test
+  @Test(.darwinOnly)
   func anchorInitDarwinRejectsIncompleteCombinedForms() {
-    withPlatform(.darwin) {
-      let nofollowVolEmpty: String = "/.nofollow/.vol/"
-      expectNil(_StdlibFilePath.Anchor(nofollowVolEmpty),
-        "/.nofollow/.vol/ has no FSID — falls back to /.nofollow/ + [.vol]")
-      let nofollowVolNoFileid: String = "/.nofollow/.vol/1234/"
-      expectNil(_StdlibFilePath.Anchor(nofollowVolNoFileid),
-        "/.nofollow/.vol/1234/ has no FILEID")
-      let resolveVolEmpty: String = "/.resolve/3/.vol/"
-      expectNil(_StdlibFilePath.Anchor(resolveVolEmpty),
-        "/.resolve/3/.vol/ has no FSID")
-      let resolveVolNoFileid: String = "/.resolve/3/.vol/1234/"
-      expectNil(_StdlibFilePath.Anchor(resolveVolNoFileid),
-        "/.resolve/3/.vol/1234/ has no FILEID")
-    }
-  }
+    let nofollowVolEmpty: String = "/.nofollow/.vol/"
+    expectNil(_StdlibFilePath.Anchor(nofollowVolEmpty),
+      "/.nofollow/.vol/ has no FSID, falls back to /.nofollow/ + [.vol]")
+    let nofollowVolNoFileid: String = "/.nofollow/.vol/1234/"
+    expectNil(_StdlibFilePath.Anchor(nofollowVolNoFileid),
+      "/.nofollow/.vol/1234/ has no FILEID")
+    let resolveVolEmpty: String = "/.resolve/3/.vol/"
+    expectNil(_StdlibFilePath.Anchor(resolveVolEmpty),
+      "/.resolve/3/.vol/ has no FSID")
+    let resolveVolNoFileid: String = "/.resolve/3/.vol/1234/"
+    expectNil(_StdlibFilePath.Anchor(resolveVolNoFileid),
+      "/.resolve/3/.vol/1234/ has no FILEID")
+}
 
-  @Test
+  @Test(.windowsOnly)
   func anchorInitRejectsNULWindows() {
-    withPlatform(.windows) {
-      let drive: String = #"C:\"#
-      expectNotNil(_StdlibFilePath.Anchor(drive))
+    let drive: String = #"C:\"#
+    expectNotNil(_StdlibFilePath.Anchor(drive))
 
-      let driveNul: String = "C:\\\0"
-      expectNil(_StdlibFilePath.Anchor(driveNul))
+    let driveNul: String = "C:\\\0"
+    expectNil(_StdlibFilePath.Anchor(driveNul))
 
-      let unc: String = #"\\server\share"#
-      expectNotNil(_StdlibFilePath.Anchor(unc))
+    let unc: String = #"\\server\share"#
+    expectNotNil(_StdlibFilePath.Anchor(unc))
 
-      let uncNul: String = "\\\\\0server\\share"
-      expectNil(_StdlibFilePath.Anchor(uncNul))
-    }
-  }
+    let uncNul: String = "\\\\\0server\\share"
+    expectNil(_StdlibFilePath.Anchor(uncNul))
+}
 
   @Test
   func anchorInitRejectsInvalid() {
@@ -418,162 +407,152 @@ extension AllTests.ValidationTests {
 
   // MARK: - Anchor.init? strictness vs _StdlibFilePath.init? totality (Windows)
   //
-  // `_StdlibFilePath.Anchor.init?` is STRICT: a named anchor form must carry its
-  // name. It rejects incomplete UNC (no server / no share), empty device
-  // (`\\.\`), and empty verbatim (`\\?\`). `_StdlibFilePath.init?` by contrast is
-  // total and coalesces these same inputs into a degraded anchor. These two
+  // `_StdlibFilePath.Anchor.init?` is strict: a named anchor form must carry
+  // its name. It rejects incomplete UNC (no server or no share), empty device
+  // (`\\.\`), and empty verbatim (`\\?\`). `_StdlibFilePath.init?` by contrast
+  // is total and coalesces these same inputs into a degraded anchor. These two
   // tests pin both halves and the resulting divergence.
 
-  @Test
+  @Test(.windowsOnly)
   func anchorInitStrictRejectsIncompleteWindowsForms() {
-    withPlatform(.windows) {
-      // Named forms missing their name -> nil.
-      let incomplete: [String] = [
-        #"\\"#,         // incomplete UNC: no server, no share
-        #"\\server"#,   // incomplete UNC: server but no share
-        #"\\\server"#,  // 3+ backslashes -> `\` root + `server` component
-        #"\\."#,        // empty device: no device name
-        #"\\.\"#,       // empty device: no device name
-        #"\\?"#,        // empty verbatim: no component
-        #"\\?\"#,       // empty verbatim: no component
-      ]
-      for input in incomplete {
-        expectNil(_StdlibFilePath.Anchor(input),
-          "Anchor.init? should reject \(input.debugDescription)")
-      }
-
-      // Populated named forms still construct and round-trip to themselves.
-      let named: [(input: String, printed: String)] = [
-        (#"\\server\share"#, #"\\server\share"#),
-        (#"\\.\pipe"#,       #"\\.\pipe"#),
-        (#"\\?\C:\"#,        #"\\?\C:\"#),
-        (#"\\?\pictures"#,   #"\\?\pictures"#),
-      ]
-      for (input, printed) in named {
-        let anchor = _StdlibFilePath.Anchor(input)
-        expectNotNil(anchor,
-          "Anchor.init? should accept \(input.debugDescription)")
-        expectEqual(anchor?.description, printed,
-          "Anchor \(input.debugDescription) printed form")
-      }
+    // Named forms missing their name -> nil.
+    let incomplete: [String] = [
+      #"\\"#,         // incomplete UNC: no server, no share
+      #"\\server"#,   // incomplete UNC: server but no share
+      #"\\\server"#,  // 3+ backslashes -> `\` root + `server` component
+      #"\\."#,        // empty device: no device name
+      #"\\.\"#,       // empty device: no device name
+      #"\\?"#,        // empty verbatim: no component
+      #"\\?\"#,       // empty verbatim: no component
+    ]
+    for input in incomplete {
+      expectNil(_StdlibFilePath.Anchor(input),
+        "Anchor.init? should reject \(input.debugDescription)")
     }
-  }
 
-  @Test
+    // Populated named forms still construct and round-trip to themselves.
+    let named: [(input: String, printed: String)] = [
+      (#"\\server\share"#, #"\\server\share"#),
+      (#"\\.\pipe"#,       #"\\.\pipe"#),
+      (#"\\?\C:\"#,        #"\\?\C:\"#),
+      (#"\\?\pictures"#,   #"\\?\pictures"#),
+    ]
+    for (input, printed) in named {
+      let anchor = _StdlibFilePath.Anchor(input)
+      expectNotNil(anchor,
+        "Anchor.init? should accept \(input.debugDescription)")
+      expectEqual(anchor?.description, printed,
+        "Anchor \(input.debugDescription) printed form")
+    }
+}
+
+  @Test(.windowsOnly)
   func filePathStillCoalescesAnchorRejectedForms() {
-    withPlatform(.windows) {
-      // The inputs `Anchor.init?` rejects remain TOTAL under `_StdlibFilePath.init?`,
-      // which coalesces each into its degraded shape. This is the deliberate
-      // divergence: _StdlibFilePath stays total, Anchor is strict.
+    // The inputs `Anchor.init?` rejects remain total under `_StdlibFilePath.init?`,
+    // which coalesces each into its degraded shape. This is the deliberate
+    // divergence: _StdlibFilePath stays total, Anchor is strict.
 
-      // Headline case: `\\\server\share` coalesces to a current-drive root
-      // with `server` and `share` as ordinary components, yet the strict
-      // Anchor initializer rejects the same string.
-      let triple: String = #"\\\server\share"#
-      expectNil(_StdlibFilePath.Anchor(triple),
-        #"Anchor.init? rejects \\\server\share"#)
-      let p = _StdlibFilePath(triple)
-      expectNotNil(p, #"_StdlibFilePath.init? accepts \\\server\share"#)
-      expectEqual(p?.anchor?.description, #"\"#,
-        #"\\\server\share coalesces to anchor \"#)
-      expectEqual(p?.components.map(\.description) ?? [], ["server", "share"],
-        #"\\\server\share components"#)
+    // Headline case: `\\\server\share` coalesces to a current-drive root
+    // with `server` and `share` as ordinary components, yet the strict
+    // Anchor initializer rejects the same string.
+    let triple: String = #"\\\server\share"#
+    expectNil(_StdlibFilePath.Anchor(triple),
+      #"Anchor.init? rejects \\\server\share"#)
+    let p = _StdlibFilePath(triple)
+    expectNotNil(p, #"_StdlibFilePath.init? accepts \\\server\share"#)
+    expectEqual(p?.anchor?.description, #"\"#,
+      #"\\\server\share coalesces to anchor \"#)
+    expectEqual(p?.components.map(\.description) ?? [], ["server", "share"],
+      #"\\\server\share components"#)
 
-      // Every rejected anchor input still constructs a _StdlibFilePath whose anchor
-      // is the coalesced/degraded form, with no relative components — while
-      // `Anchor.init?` rejects that very input.
-      let coalesced: [(input: String, anchor: String)] = [
-        (#"\\"#,       #"\\\"#),       // -> degraded 3-backslash root
-        (#"\\server"#, #"\\server\"#), // -> server with empty share
-        (#"\\."#,      #"\\.\"#),      // -> empty device
-        (#"\\.\"#,     #"\\.\"#),      // -> empty device
-        (#"\\?"#,      #"\\?\"#),      // -> empty verbatim
-        (#"\\?\"#,     #"\\?\"#),      // -> empty verbatim
-      ]
-      for (input, anchor) in coalesced {
-        let fp = _StdlibFilePath(input)
-        expectNotNil(fp,
-          "_StdlibFilePath.init? should accept \(input.debugDescription)")
-        expectEqual(fp?.anchor?.description, anchor,
-          "_StdlibFilePath \(input.debugDescription) coalesced anchor")
-        expectTrue(fp?.components.isEmpty ?? false,
-          "_StdlibFilePath \(input.debugDescription) should have no components")
-        expectNil(_StdlibFilePath.Anchor(input),
-          "Anchor.init? should reject \(input.debugDescription)")
-      }
+    // Every rejected anchor input still constructs a _StdlibFilePath whose anchor
+    // is the coalesced/degraded form, with no relative components, while
+    // `Anchor.init?` rejects that very input.
+    let coalesced: [(input: String, anchor: String)] = [
+      (#"\\"#,       #"\\\"#),       // -> degraded 3-backslash root
+      (#"\\server"#, #"\\server\"#), // -> server with empty share
+      (#"\\."#,      #"\\.\"#),      // -> empty device
+      (#"\\.\"#,     #"\\.\"#),      // -> empty device
+      (#"\\?"#,      #"\\?\"#),      // -> empty verbatim
+      (#"\\?\"#,     #"\\?\"#),      // -> empty verbatim
+    ]
+    for (input, anchor) in coalesced {
+      let fp = _StdlibFilePath(input)
+      expectNotNil(fp,
+        "_StdlibFilePath.init? should accept \(input.debugDescription)")
+      expectEqual(fp?.anchor?.description, anchor,
+        "_StdlibFilePath \(input.debugDescription) coalesced anchor")
+      expectTrue(fp?.components.isEmpty ?? false,
+        "_StdlibFilePath \(input.debugDescription) should have no components")
+      expectNil(_StdlibFilePath.Anchor(input),
+        "Anchor.init? should reject \(input.debugDescription)")
     }
-  }
+}
 
   // MARK: - Verbatim-UNC trailing separator is not synthesized (Windows)
 
-  @Test
+  @Test(.windowsOnly)
   func verbatimUNCTrailingSeparatorNotSynthesized() {
-    withPlatform(.windows) {
-      // A verbatim-UNC root with NO trailing separator must not have one
-      // synthesized: `\\?\UNC\s\h` stores verbatim with hasTrailingSeparator
-      // false, while `\\?\UNC\s\h\` has a genuine trailing separator. The
-      // trailing separator is significant, so the two are not equal.
-      let noSep: String = #"\\?\UNC\s\h"#
-      let withSep: String = #"\\?\UNC\s\h\"#
+    // A verbatim-UNC root with no trailing separator must not have one
+    // synthesized: `\\?\UNC\s\h` stores verbatim with hasTrailingSeparator
+    // false, while `\\?\UNC\s\h\` has a genuine trailing separator. The
+    // trailing separator is significant, so the two are not equal.
+    let noSep: String = #"\\?\UNC\s\h"#
+    let withSep: String = #"\\?\UNC\s\h\"#
 
-      let a = _StdlibFilePath(noSep)!
-      expectEqual(a.anchor?.description, #"\\?\UNC\s\h"#)
-      expectTrue(a.components.isEmpty)
-      expectFalse(a.hasTrailingSeparator,
-        #"\\?\UNC\s\h should have no trailing separator"#)
-      expectEqual(a.description, #"\\?\UNC\s\h"#,
-        #"\\?\UNC\s\h must be stored without an added backslash"#)
+    let a = _StdlibFilePath(noSep)!
+    expectEqual(a.anchor?.description, #"\\?\UNC\s\h"#)
+    expectTrue(a.components.isEmpty)
+    expectFalse(a.hasTrailingSeparator,
+      #"\\?\UNC\s\h should have no trailing separator"#)
+    expectEqual(a.description, #"\\?\UNC\s\h"#,
+      #"\\?\UNC\s\h must be stored without an added backslash"#)
 
-      let b = _StdlibFilePath(withSep)!
-      expectEqual(b.anchor?.description, #"\\?\UNC\s\h"#)
-      expectTrue(b.components.isEmpty)
-      expectTrue(b.hasTrailingSeparator,
-        #"\\?\UNC\s\h\ should have a trailing separator"#)
+    let b = _StdlibFilePath(withSep)!
+    expectEqual(b.anchor?.description, #"\\?\UNC\s\h"#)
+    expectTrue(b.components.isEmpty)
+    expectTrue(b.hasTrailingSeparator,
+      #"\\?\UNC\s\h\ should have a trailing separator"#)
 
-      expectNotEqual(a, b,
-        #"\\?\UNC\s\h must not equal \\?\UNC\s\h\"#)
+    expectNotEqual(a, b,
+      #"\\?\UNC\s\h must not equal \\?\UNC\s\h\"#)
 
-      // A populated verbatim-UNC path is unaffected by the fix.
-      let fooInput: String = #"\\?\UNC\server\share\foo"#
-      let c = _StdlibFilePath(fooInput)!
-      expectEqual(c.anchor?.description, #"\\?\UNC\server\share"#)
-      expectEqual(c.components.map(\.description), ["foo"])
-    }
-  }
+    // A populated verbatim-UNC path is unaffected by the fix.
+    let fooInput: String = #"\\?\UNC\server\share\foo"#
+    let c = _StdlibFilePath(fooInput)!
+    expectEqual(c.anchor?.description, #"\\?\UNC\server\share"#)
+    expectEqual(c.components.map(\.description), ["foo"])
+}
 
   // MARK: - isAbsolute (isRelative removed)
 
-  @Test
+  @Test(.unixOnly)
   func isAbsoluteExists() {
     // On Windows `\foo` (the converted form of `/foo`) is the current-drive
-    // root — rooted but not fully qualified, so isAbsolute is false. The
+    // root: rooted but not fully qualified, so isAbsolute is false. The
     // unix-side expectation is "absolute"; restrict to those.
-    withPlatforms(.linux, .darwin) {
-      let abs: _StdlibFilePath = "/foo"
-      expectTrue(abs.isAbsolute)
+    let abs: _StdlibFilePath = "/foo"
+    expectTrue(abs.isAbsolute)
 
-      let rel: _StdlibFilePath = "foo"
-      expectFalse(rel.isAbsolute)
-    }
-  }
+    let rel: _StdlibFilePath = "foo"
+    expectFalse(rel.isAbsolute)
+}
 
   // MARK: - withCodeUnits
 
-  @Test
+  @Test(.unixOnly)
   func withCodeUnitsProvidesPointerAndCount() {
     // Asserts CChar-typed values; unix-only.
-    withPlatforms(.linux, .darwin) {
-      let path: _StdlibFilePath = "/foo/bar"
-      path.withCodeUnits { ptr, count in
-        expectEqual(count, 8)
-        expectEqual(ptr[0], CChar(UInt8(ascii: "/")))
-        expectEqual(ptr[1], CChar(UInt8(ascii: "f")))
-        expectEqual(ptr[4], CChar(UInt8(ascii: "/")))
-        // The count excludes the null terminator, which sits at [count].
-        expectEqual(ptr[count], 0)
-      }
+    let path: _StdlibFilePath = "/foo/bar"
+    path.withCodeUnits { ptr, count in
+      expectEqual(count, 8)
+      expectEqual(ptr[0], CChar(UInt8(ascii: "/")))
+      expectEqual(ptr[1], CChar(UInt8(ascii: "f")))
+      expectEqual(ptr[4], CChar(UInt8(ascii: "/")))
+      // The count excludes the null terminator, which sits at [count].
+      expectEqual(ptr[count], 0)
     }
-  }
+}
 
   @Test
   func withCodeUnitsEmpty() {
@@ -584,20 +563,18 @@ extension AllTests.ValidationTests {
     }
   }
 
-  @Test
+  @Test(.unixOnly)
   func withCodeUnitsNonASCII() {
     // Asserts CChar-typed values and a UTF-8 byte (0xA9); unix-only.
-    withPlatforms(.linux, .darwin) {
-      let path: _StdlibFilePath = "/café"
-      path.withCodeUnits { ptr, count in
-        // "/café" is 6 UTF-8 bytes: / c a f 0xC3 0xA9
-        expectEqual(count, 6)
-        expectEqual(ptr[0], CChar(UInt8(ascii: "/")))
-        expectEqual(ptr[5], CChar(bitPattern: 0xA9))
-        expectEqual(ptr[count], 0)
-      }
+    let path: _StdlibFilePath = "/café"
+    path.withCodeUnits { ptr, count in
+      // "/café" is 6 UTF-8 bytes: / c a f 0xC3 0xA9
+      expectEqual(count, 6)
+      expectEqual(ptr[0], CChar(UInt8(ascii: "/")))
+      expectEqual(ptr[5], CChar(bitPattern: 0xA9))
+      expectEqual(ptr[count], 0)
     }
-  }
+}
 
   @Test
   func withCodeUnitsReturnsValue() {
@@ -614,8 +591,8 @@ extension AllTests.ValidationTests {
   func withCodeUnitsThrowsTypedError() {
     struct TestError: Error {}
     let path: _StdlibFilePath = "/foo"
-    // SEAM EXCEPTION: no throwing-assertion helper in the seam (analogues
-    // differ sharply across StdlibUnittest / XCTest).
+    // The seam vends no throwing-assertion helper, because throwing
+    // assertions have no common spelling across test frameworks.
     #expect(throws: TestError.self) {
       try path.withCodeUnits {
         (_: UnsafePointer<_StdlibFilePath.CodeUnit>, _: Int) throws(TestError) -> Int in

--- a/Tests/SystemTests/StdlibFilePathTests/ValidationTests.swift
+++ b/Tests/SystemTests/StdlibFilePathTests/ValidationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift System open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift System project authors
+ Copyright (c) 2020 - 2026 Apple Inc. and the Swift System project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -80,7 +80,7 @@ extension AllTests.ValidationTests {
     expectNil(filePathFromCodeUnits(codeUnits("f\0o")))
     expectNil(filePathFromCodeUnits(codeUnits("\0")))
     expectNil(filePathFromCodeUnits(codeUnits("foo\0")))
-}
+  }
 
   @Test
   func filePathCodeUnitsEmpty() {
@@ -330,11 +330,12 @@ extension AllTests.ValidationTests {
 
     let volNul: String = "/.vol/1234\0/5678"
     expectNil(_StdlibFilePath.Anchor(volNul))
-}
+  }
 
-  // A Darwin anchor may include resolve flags and/or a volume identifier. The combined form `[/.nofollow/ | /.resolve/N/]
-  // .vol/FSID/FILEID` is one anchor, and `Anchor.init?` accepts it iff the
-  // combined form is complete (no missing FSID/FILEID).
+  // A Darwin anchor may include resolve flags and/or a volume identifier. The
+  // combined form `[/.nofollow/ | /.resolve/N/].vol/FSID/FILEID` is one
+  // anchor, and `Anchor.init?` accepts it iff the combined form is complete
+  // (no missing FSID/FILEID).
   @Test(.darwinOnly)
   func anchorInitDarwinAcceptsCombinedForms() {
     // String literals dispatch to the trapping `init(stringLiteral:)`;
@@ -353,7 +354,7 @@ extension AllTests.ValidationTests {
     let resolveOneVol2: String = "/.resolve/1/.vol/1234/2"
     expectNotNil(_StdlibFilePath.Anchor(resolveOneVol2),
       "/.resolve/1/.vol/1234/2 canonicalizes and is accepted")
-}
+  }
 
   // Incomplete combined forms (missing FSID or FILEID) fall back to the
   // leading flag as the anchor with the partial vol bytes as components.
@@ -372,7 +373,7 @@ extension AllTests.ValidationTests {
     let resolveVolNoFileid: String = "/.resolve/3/.vol/1234/"
     expectNil(_StdlibFilePath.Anchor(resolveVolNoFileid),
       "/.resolve/3/.vol/1234/ has no FILEID")
-}
+  }
 
   @Test(.windowsOnly)
   func anchorInitRejectsNULWindows() {
@@ -387,7 +388,7 @@ extension AllTests.ValidationTests {
 
     let uncNul: String = "\\\\\0server\\share"
     expectNil(_StdlibFilePath.Anchor(uncNul))
-}
+  }
 
   @Test
   func anchorInitRejectsInvalid() {
@@ -444,12 +445,13 @@ extension AllTests.ValidationTests {
       expectEqual(anchor?.description, printed,
         "Anchor \(input.debugDescription) printed form")
     }
-}
+  }
 
   @Test(.windowsOnly)
   func filePathStillCoalescesAnchorRejectedForms() {
-    // The inputs `Anchor.init?` rejects remain total under `_StdlibFilePath.init?`,
-    // which coalesces each into its degraded shape. This is the deliberate
+    // The inputs `Anchor.init?` rejects remain total under
+    // `_StdlibFilePath.init?`, which coalesces each into its degraded shape.
+    // This is the deliberate
     // divergence: _StdlibFilePath stays total, Anchor is strict.
 
     // Headline case: `\\\server\share` coalesces to a current-drive root
@@ -465,8 +467,9 @@ extension AllTests.ValidationTests {
     expectEqual(p?.components.map(\.description) ?? [], ["server", "share"],
       #"\\\server\share components"#)
 
-    // Every rejected anchor input still constructs a _StdlibFilePath whose anchor
-    // is the coalesced/degraded form, with no relative components, while
+    // Every rejected anchor input still constructs a _StdlibFilePath whose
+    // anchor is the coalesced/degraded form, with no relative components,
+    // while
     // `Anchor.init?` rejects that very input.
     let coalesced: [(input: String, anchor: String)] = [
       (#"\\"#,       #"\\\"#),       // -> degraded 3-backslash root
@@ -487,7 +490,7 @@ extension AllTests.ValidationTests {
       expectNil(_StdlibFilePath.Anchor(input),
         "Anchor.init? should reject \(input.debugDescription)")
     }
-}
+  }
 
   // MARK: - Verbatim-UNC trailing separator is not synthesized (Windows)
 
@@ -522,7 +525,7 @@ extension AllTests.ValidationTests {
     let c = _StdlibFilePath(fooInput)!
     expectEqual(c.anchor?.description, #"\\?\UNC\server\share"#)
     expectEqual(c.components.map(\.description), ["foo"])
-}
+  }
 
   // MARK: - isAbsolute (isRelative removed)
 
@@ -536,7 +539,7 @@ extension AllTests.ValidationTests {
 
     let rel: _StdlibFilePath = "foo"
     expectFalse(rel.isAbsolute)
-}
+  }
 
   // MARK: - withCodeUnits
 
@@ -552,7 +555,7 @@ extension AllTests.ValidationTests {
       // The count excludes the null terminator, which sits at [count].
       expectEqual(ptr[count], 0)
     }
-}
+  }
 
   @Test
   func withCodeUnitsEmpty() {
@@ -574,7 +577,7 @@ extension AllTests.ValidationTests {
       expectEqual(ptr[5], CChar(bitPattern: 0xA9))
       expectEqual(ptr[count], 0)
     }
-}
+  }
 
   @Test
   func withCodeUnitsReturnsValue() {

--- a/Tests/SystemTests/SystemStringTests.swift
+++ b/Tests/SystemTests/SystemStringTests.swift
@@ -144,12 +144,12 @@ struct StringTest: TestCase {
         string.unicodeScalars, compStr.string.unicodeScalars, "Component from string")
       expectEqual(string, String(decoding: compStr), "Component from string")
       expectEqual(string, String(validating: compStr), "Component from string")
-      expectEqual(sysStr, compStr._slice.base, "Component from string")
+      expectEqual(sysStr, compStr._sliceBase, "Component from string")
 
       let compRaw = FilePath.Component(sysRaw)!
       expectEqual(string, String(decoding: compRaw), "raw Component")
       expectEqual(isValid, nil != String(validating: compRaw), "raw Component")
-      expectEqual(sysRaw, compRaw._slice.base, "raw Component")
+      expectEqual(sysRaw, compRaw._sliceBase, "raw Component")
       expectEqual(isValid, compStr == compRaw, "raw Component")
 
       // TODO: Below works after we add last component optimization
@@ -171,7 +171,7 @@ struct StringTest: TestCase {
         expectEqual(sysRaw, FilePath(platformString: $0)._storage)
         if isComponent {
           expectEqual(
-            sysRaw, FilePath.Component(platformString: $0)!._slice.base)
+            sysRaw, FilePath.Component(platformString: $0)!._sliceBase)
         }
       }
     }

--- a/Tests/SystemTests/TestingInfrastructure.swift
+++ b/Tests/SystemTests/TestingInfrastructure.swift
@@ -251,3 +251,15 @@ internal struct MockTestCase: TestCase {
 internal func withWindowsPaths(enabled: Bool, _ body: () -> ()) {
   _withWindowsPaths(enabled: enabled, body)
 }
+
+/// Whether the active `FilePath` backing is the SE-0529 implementation.
+///
+/// The one test-side name for the era switch. This suite is swift-system's own,
+/// so most of it encodes historical behavior; where SE-0529 legitimately
+/// changed an answer, the assertion selects on this rather than pinning one
+/// era. Keeping the reach for the module internal in this file alone means the
+/// other test files need no `@testable` import to be era-aware.
+@available(System 0.0.2, *)
+internal var usingStdlibFilePath: Bool {
+  _FilePathBackingSelection.useStdlib
+}


### PR DESCRIPTION
For testing purposes, dynamically switch between "old" and "new" file path based on SPI or environment variable. This includes all the semantic changes such as significant-trailing-slash, proper Darwin `Root` parsing, canonicalization of interior `.`s, etc.

---


FilePath becomes a wrapper over two backings behind one unchanged public API:

- Backings: _SwiftSystemFilePath (classic, default) and _StdlibFilePath (SE-0529)
- Switch at runtime: _setFilePathSemanticMode(.legacy / .stdlibNew), or the _SWIFT_SYSTEM_NEW_FILEPATH env var
- Per-backing dispatch for Root, ComponentView, and Component, so each era's own validator answers; all era logic lives in the wrapper
- Codable _v2 archive-compat preserved
- SE-0529 core gated at SwiftStdlib 9999, mapped to macOS 26 (26 floor)
- Adds the SE-0529 standalone suite (StdlibFilePathTests)

Legacy mode passes swift-system's suite unchanged; SE-0529 mode produces the known semantic delta. Darwin-only.
